### PR TITLE
Add intent routing and pipeline stub execution in Orchestrator

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -37,6 +37,65 @@ class Orchestrator:
         with open(self.config_path) as f:
             return json.load(f)
 
+    async def _detect_intent(self, message: str) -> str:
+        """Определить intent пользовательского запроса через LLMRouter."""
+        system_prompt = (
+            "Определи intent запроса. "
+            "Верни ровно одно слово из списка: "
+            "generate_tk, generate_letter, analyze_tender, generate_ks, chat."
+        )
+        response = await self.llm_router.query(
+            prompt=message,
+            system_prompt=system_prompt,
+        )
+
+        intent = response.text.strip().lower()
+        allowed_intents = {
+            "generate_tk",
+            "generate_letter",
+            "analyze_tender",
+            "generate_ks",
+            "chat",
+        }
+        return intent if intent in allowed_intents else "chat"
+
+    async def _run_pipeline(
+        self,
+        intent: str,
+        message: str,
+        session_id: str,
+        role: str,
+    ) -> dict[str, Any]:
+        """Stub для запуска pipeline по intent."""
+        _ = (message, role)
+        pipeline_map = {
+            "generate_tk": ["researcher", "author", "critic", "verifier", "formatter"],
+            "generate_letter": [
+                "researcher",
+                "author",
+                "legal_expert",
+                "critic",
+                "verifier",
+                "formatter",
+            ],
+            "analyze_tender": ["researcher", "analyst", "legal_expert", "verifier"],
+            "generate_ks": [
+                "researcher",
+                "calculator",
+                "author",
+                "critic",
+                "verifier",
+                "formatter",
+            ],
+        }
+        agents_used = pipeline_map.get(intent, [])
+        return {
+            "reply": f"Pipeline {intent} запущен (stub)",
+            "session_id": session_id,
+            "agents_used": agents_used,
+            "confidence": None,
+        }
+
     async def process(
         self,
         message: str,
@@ -59,6 +118,11 @@ class Orchestrator:
             Словарь с ответом и метаданными.
         """
         session_id = session_id or str(uuid.uuid4())
+
+        intent = await self._detect_intent(message)
+
+        if intent != "chat":
+            return await self._run_pipeline(intent, message, session_id, role)
 
         # TODO: Фаза 1 — базовый чат через LLM Router
         # Пока без полноценного pipeline, просто прямой запрос к LLM

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,31 @@
+"""Тесты intent-детекции оркестратора."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from core.orchestrator import Orchestrator
+
+
+def test_detect_intent_generate_tk():
+    """Фраза про ТК должна маршрутизироваться в generate_tk."""
+    orchestrator = Orchestrator()
+    orchestrator.llm_router.query = AsyncMock(
+        return_value=SimpleNamespace(text="generate_tk")
+    )
+
+    intent = asyncio.run(orchestrator._detect_intent("сделай ТК на бетонирование"))
+
+    assert intent == "generate_tk"
+
+
+def test_detect_intent_generate_letter():
+    """Фраза про письмо подрядчику должна маршрутизироваться в generate_letter."""
+    orchestrator = Orchestrator()
+    orchestrator.llm_router.query = AsyncMock(
+        return_value=SimpleNamespace(text="generate_letter")
+    )
+
+    intent = asyncio.run(orchestrator._detect_intent("напиши письмо подрядчику"))
+
+    assert intent == "generate_letter"


### PR DESCRIPTION
### Motivation
- Добавить определение типа запроса (intent) чтобы оркестратор мог выбирать нужный pipeline перед реализацией агентов. 
- Обеспечить безопасный fallback на чат и сохранить текущее поведение для `chat`-intent.

### Description
- Реализован async метод `Orchestrator._detect_intent(message: str)` который вызывает `LLMRouter.query(...)` с коротким `system_prompt` и возвращает ровно одно ключевое слово из: `generate_tk`, `generate_letter`, `analyze_tender`, `generate_ks`, `chat`, с безопасным fallback в `chat`.
- Добавлен async stub `Orchestrator._run_pipeline(...)`, который мапит intent на список агентов по pipeline и возвращает структуру `{"reply": "Pipeline {intent} запущен (stub)", "session_id": ..., "agents_used": [...], "confidence": None}`.
- Обновлён `Orchestrator.process(...)`: теперь он вызывает `await _detect_intent(...)` и для non-`chat` intent диспетчеризует выполнение в `await _run_pipeline(...)`, оставив прежний прямой вызов `LLMRouter` для `chat`.
- Добавлены юнит-тесты в `tests/test_orchestrator.py` с мокированием `LLMRouter.query` через `unittest.mock.AsyncMock` для сценариев `"сделай ТК на бетонирование" -> generate_tk` и `"напиши письмо подрядчику" -> generate_letter`.

### Testing
- Запущено: `pytest -q tests/test_orchestrator.py tests/test_orchestrator_config.py` and all tests passed (`5 passed`).
- Новые тесты `tests/test_orchestrator.py` проверяют `Orchestrator._detect_intent` с замоканным `LLMRouter.query` и успешно прошли. 
- В выводе тестов зафиксировано предупреждение окружения: неизвестная опция pytest `asyncio_mode`, но это предупреждение не повлияло на прохождение тестов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca28a622c832fbff4bc30e67d334a)