### PR TITLE
Implement agent run/state workflow and add smoke tests

### DIFF
--- a/agents/analyst.py
+++ b/agents/analyst.py
@@ -1,50 +1,27 @@
 """Агент Analyst — анализ документации, выявление противоречий и рисков."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class AnalystAgent(BaseAgent):
-    """📊 Analyst — конфликт-анализ и оценка рисков.
+    """📊 Analyst — выявляет противоречия и формирует отчёт о рисках."""
 
-    Активируется при анализе документов и тендеров.
-    Выявляет противоречия, несоответствия нормативам, риски.
-    """
-
-    agent_id = "analyst"
-    name = "Analyst"
     system_prompt = (
-        "Ты — агент-аналитик строительной ИИ-платформы. "
-        "Твоя задача — выявлять противоречия, конфликты и риски в документации. "
-        "Анализируй на соответствие нормативам (СП, СНиП, ГОСТ). "
-        "Формируй структурированный отчёт: риски, несоответствия, рекомендации. "
-        "Используй шкалу критичности: ВЫСОКИЙ / СРЕДНИЙ / НИЗКИЙ."
+        "Ты — Analyst агент. Выявляй противоречия и несоответствия в тексте. "
+        "Возвращай отчёт: (а) найденные конфликты, (б) риски, (в) уровень риска "
+        "(высокий/средний/низкий), (г) рекомендации."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="02", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Провести анализ документации."""
-        prompt = f"Проанализируй документацию и выяви риски/противоречия:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
-
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
-
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={"provider": response.provider.value, "model": response.model},
-        )
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        state["risk_report"] = response.text
+        return self._update_state(state, response.text)

--- a/agents/author.py
+++ b/agents/author.py
@@ -1,50 +1,26 @@
 """Агент Author — генерация текстов документов."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class AuthorAgent(BaseAgent):
-    """✍️ Author — генерация ТК, ППР, писем, отчётов.
+    """✍️ Author — генерирует черновик документа делового стиля."""
 
-    Активируется при генерации документов.
-    Черновик передаётся агенту Critic для рецензирования.
-    """
-
-    agent_id = "author"
-    name = "Author"
     system_prompt = (
-        "Ты — агент-автор строительной ИИ-платформы. "
-        "Генерируешь тексты технологических карт (ТК), проектов производства работ (ППР), "
-        "деловых писем и отчётов. Деловой стиль, формальные требования. "
-        "Структурируй текст по разделам согласно СП 48.13330. "
-        "Используй данные от агента Researcher."
+        "Ты — Author агент. Сгенерируй черновик документа в деловом стиле, "
+        "с чёткой структурой разделов, формальными формулировками и без разговорной лексики."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="03", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Сгенерировать текст документа."""
-        prompt = f"Сгенерируй текст документа:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
-
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
-
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={"provider": response.provider.value, "model": response.model},
-        )
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        state["draft"] = response.text
+        return self._update_state(state, response.text)

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,63 +1,41 @@
 """Базовый класс агента."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from typing import Any
 
 from core.llm_router import LLMRouter
 
 
-@dataclass
-class AgentResult:
-    """Результат работы агента."""
-
-    agent_id: str
-    output: str
-    metadata: dict[str, Any] = field(default_factory=dict)
-    confidence: float | None = None
-    issues: list[str] = field(default_factory=list)
-
-
 class BaseAgent(ABC):
-    """Базовый класс для всех агентов Construction AI.
-
-    Каждый агент:
-    - Имеет уникальный ID и системный промпт
-    - Получает контекст задачи и предыдущие результаты
-    - Возвращает AgentResult
-    """
+    """Базовый класс для всех агентов Construction AI."""
 
     agent_id: str
-    name: str
     system_prompt: str
 
-    def __init__(self, llm_router: LLMRouter):
-        self.llm = llm_router
+    def __init__(self, agent_id: str, llm_router: LLMRouter) -> None:
+        self.agent_id = agent_id
+        self.llm_router = llm_router
 
     @abstractmethod
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Выполнить задачу агента.
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Запустить агента и вернуть обновлённый state."""
 
-        Args:
-            task: Текст задачи / запроса.
-            context: Дополнительный контекст (файлы, параметры).
-            previous_results: Результаты предыдущих агентов в pipeline.
+    def _build_prompt(self, state: dict[str, Any]) -> str:
+        """Собрать финальный prompt из message и context."""
+        message = str(state.get("message", ""))
+        context = str(state.get("context", ""))
+        if context:
+            return f"Контекст:\n{context}\n\nЗапрос:\n{message}"
+        return message
 
-        Returns:
-            AgentResult с выходными данными.
-        """
-        ...
+    def _update_state(self, state: dict[str, Any], reply: str) -> dict[str, Any]:
+        """Добавить результат агента в историю."""
+        history = state.setdefault("history", [])
+        if not isinstance(history, list):
+            raise TypeError("state['history'] must be a list")
 
-    def _build_context_prompt(self, previous_results: list[AgentResult] | None) -> str:
-        """Сформировать контекст из результатов предыдущих агентов."""
-        if not previous_results:
-            return ""
-        parts = []
-        for r in previous_results:
-            parts.append(f"[{r.agent_id}]: {r.output[:2000]}")
-        return "\n\n--- Результаты предыдущих агентов ---\n" + "\n".join(parts)
+        history.append({"agent": self.agent_id, "output": reply})
+        state["history"] = history
+        return state

--- a/agents/calculator.py
+++ b/agents/calculator.py
@@ -1,63 +1,87 @@
 """Агент Calculator — детерминированные расчёты."""
 
+from __future__ import annotations
+
+import ast
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
+
+_ALLOWED_BIN_OPS: tuple[type[ast.operator], ...] = (
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Pow,
+    ast.Mod,
+)
+_ALLOWED_UNARY_OPS: tuple[type[ast.unaryop], ...] = (ast.UAdd, ast.USub)
 
 
 class CalculatorAgent(BaseAgent):
-    """🧮 Calculator — расчёты объёмов, трудозатрат, смет.
+    """🧮 Calculator — детерминированные вычисления без eval."""
 
-    Детерминированные вычисления для:
-    - КС-2/КС-3 (акты выполненных работ)
-    - Трудозатраты и материалы для ТК
-    - Сметные показатели
-
-    В отличие от других агентов, Calculator комбинирует LLM
-    (для понимания задачи) с точными математическими расчётами.
-    """
-
-    agent_id = "calculator"
-    name = "Calculator"
     system_prompt = (
-        "Ты — агент-калькулятор строительной ИИ-платформы. "
-        "Выполняешь детерминированные расчёты объёмов работ, трудозатрат, "
-        "сметных показателей для КС-2/КС-3 и технологических карт. "
-        "Все расчёты должны быть точными и воспроизводимыми. "
-        "Формат ответа:\n"
-        "ИСХОДНЫЕ ДАННЫЕ: ...\n"
-        "РАСЧЁТ: ...\n"
-        "РЕЗУЛЬТАТ: ...\n"
-        "Используй табличный формат для итогов."
+        "Ты — Calculator агент. Объясни расчёты на основе уже вычисленных "
+        "детерминированных результатов и представь вывод в табличной форме."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="08", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Выполнить расчёты."""
-        prompt = f"Выполни расчёт:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
+    def _safe_eval(self, expression: str, values: dict[str, float]) -> float:
+        node = ast.parse(expression, mode="eval")
 
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
+        def _eval(expr: ast.AST) -> float:
+            if isinstance(expr, ast.Expression):
+                return _eval(expr.body)
+            if isinstance(expr, ast.Constant) and isinstance(expr.value, (int, float)):
+                return float(expr.value)
+            if isinstance(expr, ast.Name):
+                if expr.id not in values:
+                    raise ValueError(f"Unknown variable: {expr.id}")
+                return float(values[expr.id])
+            if isinstance(expr, ast.BinOp) and isinstance(expr.op, _ALLOWED_BIN_OPS):
+                left = _eval(expr.left)
+                right = _eval(expr.right)
+                if isinstance(expr.op, ast.Add):
+                    return left + right
+                if isinstance(expr.op, ast.Sub):
+                    return left - right
+                if isinstance(expr.op, ast.Mult):
+                    return left * right
+                if isinstance(expr.op, ast.Div):
+                    return left / right
+                if isinstance(expr.op, ast.Pow):
+                    return left**right
+                if isinstance(expr.op, ast.Mod):
+                    return left % right
+            if isinstance(expr, ast.UnaryOp) and isinstance(expr.op, _ALLOWED_UNARY_OPS):
+                value = _eval(expr.operand)
+                return value if isinstance(expr.op, ast.UAdd) else -value
+            raise ValueError(f"Unsupported expression: {expression}")
 
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={
-                "calculation_type": "deterministic",
-                "provider": response.provider.value,
-                "model": response.model,
-            },
-        )
+        return _eval(node)
+
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        calc_params = state.get("calculation_params", {})
+        if not isinstance(calc_params, dict):
+            raise TypeError("state['calculation_params'] must be a dict")
+
+        formulas = calc_params.get("formulas", {})
+        values = calc_params.get("values", {})
+        if not isinstance(formulas, dict) or not isinstance(values, dict):
+            raise TypeError("calculation_params must contain dicts 'formulas' and 'values'")
+
+        numeric_values = {k: float(v) for k, v in values.items()}
+        results: dict[str, float] = {}
+        for key, expr in formulas.items():
+            if not isinstance(expr, str):
+                raise TypeError("Each formula must be a string")
+            results[key] = self._safe_eval(expr, numeric_values | results)
+
+        state["calculation_results"] = results
+        prompt = f"Исходные данные: {numeric_values}. Результаты: {results}."
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        return self._update_state(state, response.text)

--- a/agents/critic.py
+++ b/agents/critic.py
@@ -1,65 +1,40 @@
 """Агент Critic — рецензирование черновиков."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class CriticAgent(BaseAgent):
-    """🔎 Critic — рецензирование и проверка черновиков.
+    """🔎 Critic — проверяет черновик и возвращает замечания или APPROVED."""
 
-    Активируется после Author. Проверяет:
-    - Полноту содержания
-    - Соответствие нормативам
-    - Логику изложения
-    - Корректность ссылок
-
-    Возвращает список замечаний → Author (до 5 итераций).
-    """
-
-    agent_id = "critic"
-    name = "Critic"
     system_prompt = (
-        "Ты — агент-рецензент строительной ИИ-платформы. "
-        "Проверяешь черновики документов на полноту, соответствие нормативам, "
-        "логику изложения и корректность ссылок. "
-        "Формируй список замечаний с указанием критичности. "
-        "Если документ готов — ответь 'APPROVED'. "
-        "Если есть замечания — перечисли их для доработки Author."
+        "Ты — Critic агент. Проверь черновик: полнота, логика, стиль, ссылки на нормы. "
+        "Если всё корректно, верни только 'APPROVED'. Иначе верни список замечаний по пунктам."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="04", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Провести рецензирование черновика."""
-        prompt = f"Проведи рецензию следующего документа:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        history = state.get("history", [])
+        if not isinstance(history, list):
+            raise TypeError("state['history'] must be a list")
 
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
+        author_output = ""
+        for item in reversed(history):
+            if isinstance(item, dict) and item.get("agent") == "03":
+                author_output = str(item.get("output", ""))
+                break
 
-        # Определяем наличие замечаний
-        is_approved = "APPROVED" in response.text.upper()
-        issues = [] if is_approved else [response.text]
+        if not author_output:
+            raise ValueError("Author output not found in state['history']")
 
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={
-                "approved": is_approved,
-                "provider": response.provider.value,
-                "model": response.model,
-            },
-            issues=issues,
-        )
+        prompt = f"Черновик автора для проверки:\n\n{author_output}"
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        review = response.text.strip()
+        state["critic_verdict"] = review
+        return self._update_state(state, "APPROVED" if review.upper() == "APPROVED" else review)

--- a/agents/formatter.py
+++ b/agents/formatter.py
@@ -1,59 +1,32 @@
 """Агент Formatter — ГОСТ-форматирование DOCX."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class FormatterAgent(BaseAgent):
-    """📐 Formatter — оформление по ГОСТ Р 21.1101.
+    """📐 Formatter — готовит структурированный dict для будущего DOCX."""
 
-    Финальное оформление DOCX:
-    - Заголовки и нумерация по ГОСТ
-    - Таблицы по стандарту
-    - Jinja2-шаблоны через docxtpl
-    """
-
-    agent_id = "formatter"
-    name = "Formatter"
     system_prompt = (
-        "Ты — агент-форматировщик строительной ИИ-платформы. "
-        "Отвечаешь за финальное оформление документов по ГОСТ Р 21.1101. "
-        "Преобразуй текст в структурированный формат для DOCX-шаблона: "
-        "заголовки, таблицы, нумерация, подписи. "
-        "Выход — JSON с данными для Jinja2-шаблона docxtpl."
+        "Ты — Formatter агент. Сформируй структуру документа для DOCX: "
+        "title, headings, sections (с подзаголовками и абзацами), tables (если есть)."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="07", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Подготовить данные для DOCX-шаблона."""
-        prompt = (
-            "Подготовь структурированные данные для DOCX-шаблона "
-            f"(формат JSON для docxtpl):\n\n{task}"
-        )
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
-
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
-
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={
-                "format": "docx_template_data",
-                "provider": response.provider.value,
-                "model": response.model,
-            },
-        )
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        docx_payload = {
+            "title": state.get("title", "Документ"),
+            "headings": state.get("headings", []),
+            "sections": state.get("sections", []),
+            "llm_layout": response.text,
+        }
+        state["docx_payload"] = docx_payload
+        return self._update_state(state, response.text)

--- a/agents/legal_expert.py
+++ b/agents/legal_expert.py
@@ -1,50 +1,26 @@
 """Агент Legal Expert — проверка ссылок на НПА."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class LegalExpertAgent(BaseAgent):
-    """⚖️ Legal Expert — юридическая проверка.
+    """⚖️ Legal Expert — добавляет ссылки на ФЗ/ГК РФ/ТК РФ."""
 
-    Проверяет ссылки на НПА: ФЗ, ГК РФ, ТК РФ, договорные условия.
-    Формулировки претензий. Активируется при генерации писем и анализе тендеров.
-    """
-
-    agent_id = "legal_expert"
-    name = "Legal Expert"
     system_prompt = (
-        "Ты — юридический агент строительной ИИ-платформы. "
-        "Проверяешь и добавляешь ссылки на нормативно-правовые акты: "
-        "ФЗ, ГК РФ, ТК РФ, Градостроительный кодекс, договорные условия. "
-        "Проверяешь корректность формулировок претензий и уведомлений. "
-        "Указывай конкретные статьи и пункты."
+        "Ты — Legal Expert агент. Проверь юридические формулировки и добавь релевантные "
+        "ссылки на ФЗ, ГК РФ, ТК РФ (статья/часть/пункт). Верни правки списком."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="06", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Провести юридическую проверку."""
-        prompt = f"Проведи юридическую проверку документа:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
-
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
-
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={"provider": response.provider.value, "model": response.model},
-        )
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        state["legal_review"] = response.text
+        return self._update_state(state, response.text)

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -1,56 +1,27 @@
 """Агент Researcher — поиск информации по нормативам и базе знаний."""
 
+from __future__ import annotations
+
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class ResearcherAgent(BaseAgent):
-    """🔍 Researcher — поиск по нормативам, учебникам, RAG.
+    """🔍 Researcher — поиск по нормативам и возврат структурированных фактов."""
 
-    Активируется при любом запросе. Ищет информацию в:
-    - Нормативных документах (СП, СНиП, ГОСТ)
-    - Строительных учебниках и справочниках
-    - Базе знаний (RAG / ChromaDB)
-    - РД и ПСД (загруженные документы)
-    """
-
-    agent_id = "researcher"
-    name = "Researcher"
     system_prompt = (
-        "Ты — агент-исследователь строительной ИИ-платформы. "
-        "Твоя задача — найти релевантную информацию по нормативным документам "
-        "(СП, СНиП, ГОСТ, МДС, ФНП), строительным учебникам и технической литературе. "
-        "Всегда указывай конкретные номера документов и пункты. "
-        "Если информация не найдена — честно сообщи об этом."
+        "Ты — Researcher агент. Ищи факты по СП/СНиП/ГОСТ и стройнормам. "
+        "Возвращай структурированно: 1) факт, 2) источник (номер документа, пункт), "
+        "3) применимость. Если данных нет — явно укажи это."
     )
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
-        # TODO: подключить ChromaDB для RAG-поиска
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="01", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Найти информацию по запросу."""
-        # TODO: Фаза 2 — RAG-поиск по ChromaDB
-        # Пока — прямой запрос к LLM
-        prompt = f"Найди информацию по строительным нормативам:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
-
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
-
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={"provider": response.provider.value, "model": response.model},
-        )
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        state["research_facts"] = response.text
+        return self._update_state(state, response.text)

--- a/agents/tests/test_agents.py
+++ b/agents/tests/test_agents.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agents.analyst import AnalystAgent
+from agents.author import AuthorAgent
+from agents.calculator import CalculatorAgent
+from agents.critic import CriticAgent
+from agents.formatter import FormatterAgent
+from agents.legal_expert import LegalExpertAgent
+from agents.researcher import ResearcherAgent
+from agents.verifier import VerifierAgent
+
+
+@pytest.fixture
+def llm_router_mock() -> SimpleNamespace:
+    return SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text="ok")))
+
+
+def test_researcher_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = ResearcherAgent(llm_router_mock)
+    state = asyncio.run(agent.run({"message": "Найди СП", "context": "ПТО", "history": []}))
+    assert state["history"][-1]["agent"] == "01"
+
+
+def test_analyst_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = AnalystAgent(llm_router_mock)
+    state = asyncio.run(agent.run({"message": "Проверь риски", "history": []}))
+    assert state["history"][-1]["agent"] == "02"
+
+
+def test_author_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = AuthorAgent(llm_router_mock)
+    state = asyncio.run(agent.run({"message": "Сделай письмо", "history": []}))
+    assert state["history"][-1]["agent"] == "03"
+
+
+def test_critic_smoke(llm_router_mock: SimpleNamespace) -> None:
+    llm_router_mock.query = AsyncMock(return_value=SimpleNamespace(text="APPROVED"))
+    agent = CriticAgent(llm_router_mock)
+    state = asyncio.run(
+        agent.run(
+            {
+                "message": "Проверь",
+                "history": [{"agent": "03", "output": "Черновик"}],
+            }
+        )
+    )
+    assert state["history"][-1]["output"] == "APPROVED"
+
+
+def test_verifier_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = VerifierAgent(llm_router_mock)
+    state = asyncio.run(
+        agent.run(
+            {
+                "message": "Верифицируй",
+                "history": [],
+                "confidence": 0.96,
+                "conflict_rate": 0.04,
+                "final_text": "Финальный текст",
+                "audit_log": [],
+            }
+        )
+    )
+    assert state["audit_log"][-1]["approved"] is True
+    assert len(state["audit_log"][-1]["sha256"]) == 64
+
+
+def test_legal_expert_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = LegalExpertAgent(llm_router_mock)
+    state = asyncio.run(agent.run({"message": "Добавь НПА", "history": []}))
+    assert state["history"][-1]["agent"] == "06"
+
+
+def test_formatter_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = FormatterAgent(llm_router_mock)
+    state = asyncio.run(agent.run({"message": "Оформи", "history": [], "title": "Тест"}))
+    assert state["docx_payload"]["title"] == "Тест"
+
+
+def test_calculator_smoke(llm_router_mock: SimpleNamespace) -> None:
+    agent = CalculatorAgent(llm_router_mock)
+    state = asyncio.run(
+        agent.run(
+            {
+                "message": "Рассчитай",
+                "history": [],
+                "calculation_params": {
+                    "values": {"length": 10, "width": 5},
+                    "formulas": {"area": "length * width"},
+                },
+            }
+        )
+    )
+    assert state["calculation_results"]["area"] == 50.0

--- a/agents/verifier.py
+++ b/agents/verifier.py
@@ -1,69 +1,51 @@
 """Агент Verifier — финальная KPI-проверка."""
 
+from __future__ import annotations
+
 import hashlib
 from typing import Any
 
-from agents.base import AgentResult, BaseAgent
+from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
 
 class VerifierAgent(BaseAgent):
-    """✅ Verifier — финальная проверка и верификация.
+    """✅ Verifier — проверка KPI и аудит."""
 
-    KPI:
-    - confidence ≥ 0.95
-    - conflict_rate ≤ 0.05
-    - SHA256-хэш версии документа
-
-    Результат: Approved / Reject → audit log.
-    """
-
-    agent_id = "verifier"
-    name = "Verifier"
     system_prompt = (
-        "Ты — агент-верификатор строительной ИИ-платформы. "
-        "Проводишь финальную проверку документа перед выгрузкой. "
-        "Оцени confidence (0.0–1.0) и conflict_rate (0.0–1.0). "
-        "Ответь в формате:\n"
-        "CONFIDENCE: <число>\n"
-        "CONFLICT_RATE: <число>\n"
-        "VERDICT: APPROVED или REJECTED\n"
-        "REASON: <пояснение>"
+        "Ты — Verifier агент. Проведи финальную верификацию и кратко обоснуй результат "
+        "по метрикам confidence и conflict_rate."
     )
-
     MIN_CONFIDENCE = 0.95
     MAX_CONFLICT_RATE = 0.05
 
-    def __init__(self, llm_router: LLMRouter):
-        super().__init__(llm_router)
+    def __init__(self, llm_router: LLMRouter) -> None:
+        super().__init__(agent_id="05", llm_router=llm_router)
 
-    async def execute(
-        self,
-        task: str,
-        context: dict[str, Any] | None = None,
-        previous_results: list[AgentResult] | None = None,
-    ) -> AgentResult:
-        """Провести финальную верификацию документа."""
-        prompt = f"Проведи финальную верификацию документа:\n\n{task}"
-        ctx = self._build_context_prompt(previous_results)
-        if ctx:
-            prompt += ctx
+    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+        confidence = float(state.get("confidence", 0.0))
+        conflict_rate = float(state.get("conflict_rate", 1.0))
 
-        response = await self.llm.query(
-            prompt=prompt,
-            system_prompt=self.system_prompt,
-        )
+        prompt = self._build_prompt(state)
+        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
 
-        # Генерируем SHA256-хэш версии
-        doc_content = previous_results[-1].output if previous_results else task
-        version_hash = hashlib.sha256(doc_content.encode()).hexdigest()
+        final_text = str(state.get("final_text") or state.get("draft") or "")
+        version_hash = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
 
-        return AgentResult(
-            agent_id=self.agent_id,
-            output=response.text,
-            metadata={
-                "version_hash": version_hash,
-                "provider": response.provider.value,
-                "model": response.model,
-            },
-        )
+        approved = confidence >= self.MIN_CONFIDENCE and conflict_rate <= self.MAX_CONFLICT_RATE
+        audit_entry = {
+            "agent": self.agent_id,
+            "confidence": confidence,
+            "conflict_rate": conflict_rate,
+            "approved": approved,
+            "sha256": version_hash,
+        }
+
+        audit_log = state.setdefault("audit_log", [])
+        if not isinstance(audit_log, list):
+            raise TypeError("state['audit_log'] must be a list")
+        audit_log.append(audit_entry)
+        state["audit_log"] = audit_log
+        state["verification"] = {"approved": approved, "sha256": version_hash, "details": response.text}
+
+        return self._update_state(state, response.text)


### PR DESCRIPTION
### Motivation
- Introduce a state-driven contract for agents so orchestration pipelines can pass a mutable `state` dict between agents.
- Provide concrete implementations for all eight specialized agents so they perform their domain-specific transformations and update `state` accordingly. 

### Description
- Reworked `BaseAgent` to expose `agent_id: str`, `llm_router: LLMRouter`, an abstract `async def run(self, state: dict) -> dict`, `_build_prompt(state)` that composes `state["message"]` and `state.get("context", "")`, and `_update_state(state, reply)` which appends `{"agent": self.agent_id, "output": reply}` to `state["history"]`.
- Implemented all agents with IDs `01`..`08` that use `LLMRouter.query(...)`: `Researcher` (structured normative facts), `Analyst` (conflicts and risk report), `Author` (business-style draft), `Critic` (reviews latest Author output from `history` and returns remarks or `APPROVED`), `Verifier` (checks `confidence`/`conflict_rate`, computes SHA256 of final text and appends to `audit_log`), `LegalExpert` (adds legal references), `Formatter` (builds `docx_payload` dict), and `Calculator` (deterministic safe AST evaluator for formulas without `eval`).
- Added smoke tests `agents/tests/test_agents.py` which mock `LLMRouter.query` with `AsyncMock` and assert each agent updates `state` as expected.

### Testing
- Ran `pytest -q agents/tests/test_agents.py` in a default environment which failed during collection due to Python path resolution of the `agents` package (import error). 
- Re-ran with module path set and executed `PYTHONPATH=. pytest -q agents/tests/test_agents.py`, which completed with `8 passed` and one pytest configuration warning about `asyncio_mode` but all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3962a84832fae398df5f17bc081)