### PR TITLE
Add SessionMemory and include conversation history in orchestrator/agents/chat

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -26,9 +26,26 @@ class BaseAgent(ABC):
         """Собрать финальный prompt из message и context."""
         message = str(state.get("message", ""))
         context = str(state.get("context", ""))
+        prompt = message
         if context:
-            return f"Контекст:\n{context}\n\nЗапрос:\n{message}"
-        return message
+            prompt = f"Контекст:\n{context}\n\nЗапрос:\n{message}"
+
+        conversation_history = state.get("conversation_history", [])
+        if not conversation_history:
+            return prompt
+
+        lines: list[str] = []
+        for item in conversation_history:
+            if not isinstance(item, dict):
+                continue
+            role = str(item.get("role", "unknown"))
+            content = str(item.get("content", ""))
+            timestamp = str(item.get("timestamp", ""))
+            lines.append(f"- [{timestamp}] {role}: {content}")
+
+        if not lines:
+            return prompt
+        return f"{prompt}\n\nИстория диалога:\n" + "\n".join(lines)
 
     def _update_state(self, state: dict[str, Any], reply: str) -> dict[str, Any]:
         """Добавить результат агента в историю."""

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1,11 +1,14 @@
 """Chat endpoint — основной интерфейс общения с ИИ."""
 
+import uuid
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 from core.orchestrator import Orchestrator
 
 router = APIRouter()
+orchestrator = Orchestrator()
 
 
 class ChatRequest(BaseModel):
@@ -28,10 +31,10 @@ class ChatResponse(BaseModel):
 @router.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
     """Обработать сообщение пользователя через оркестратор."""
-    orchestrator = Orchestrator()
+    session_id = request.session_id or str(uuid.uuid4())
     result = await orchestrator.process(
         message=request.message,
-        session_id=request.session_id,
+        session_id=session_id,
         role=request.role,
     )
     return result

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -23,6 +23,7 @@ from agents.legal_expert import LegalExpertAgent
 from agents.researcher import ResearcherAgent
 from agents.verifier import VerifierAgent
 from core.llm_router import LLMRouter
+from core.session_memory import SessionMemory
 
 
 class PipelineState(TypedDict):
@@ -35,6 +36,7 @@ class PipelineState(TypedDict):
     audit_log: list[dict]
     critic_iterations: int
     final_output: str | None
+    conversation_history: list[dict[str, str]]
 
 
 class Orchestrator:
@@ -50,6 +52,7 @@ class Orchestrator:
         )
         self.config = self._load_config()
         self.llm_router = LLMRouter()
+        self.session_memory = SessionMemory()
         self.agents: dict[str, dict] = {
             agent["id"]: agent for agent in self.config["agents"]
         }
@@ -186,6 +189,7 @@ class Orchestrator:
             "message": message,
             "session_id": session_id,
             "role": role,
+            "conversation_history": self.session_memory.get(session_id, last_n=10),
             "history": [],
             "audit_log": [],
             "critic_iterations": 0,
@@ -223,11 +227,17 @@ class Orchestrator:
             Словарь с ответом и метаданными.
         """
         session_id = session_id or str(uuid.uuid4())
+        self.session_memory.add(session_id, role="user", content=message)
 
         intent = await self._detect_intent(message)
 
         if intent != "chat":
-            return await self._run_pipeline(intent, message, session_id, role)
+            result = await self._run_pipeline(intent, message, session_id, role)
+            if result.get("reply"):
+                self.session_memory.add(
+                    session_id, role="assistant", content=str(result["reply"])
+                )
+            return result
 
         # TODO: Фаза 1 — базовый чат через LLM Router
         # Пока без полноценного pipeline, просто прямой запрос к LLM
@@ -238,6 +248,7 @@ class Orchestrator:
                 prompt=message,
                 system_prompt=system_prompt,
             )
+            self.session_memory.add(session_id, role="assistant", content=response.text)
             return {
                 "reply": response.text,
                 "session_id": session_id,
@@ -245,6 +256,11 @@ class Orchestrator:
                 "confidence": None,
             }
         except Exception as e:
+            self.session_memory.add(
+                session_id,
+                role="assistant",
+                content=f"Ошибка обработки: {e}",
+            )
             return {
                 "reply": f"Ошибка обработки: {e}",
                 "session_id": session_id,

--- a/core/session_memory.py
+++ b/core/session_memory.py
@@ -1,0 +1,37 @@
+"""In-memory хранилище истории сообщений сессии."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+
+
+class SessionMemory:
+    """Простое in-memory хранилище истории по session_id."""
+
+    def __init__(self, max_messages: int = 50) -> None:
+        self.max_messages = max_messages
+        self._store: dict[str, list[dict[str, str]]] = defaultdict(list)
+
+    def add(self, session_id: str, role: str, content: str) -> None:
+        """Добавить сообщение в историю сессии."""
+        message = {
+            "role": role,
+            "content": content,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        history = self._store[session_id]
+        history.append(message)
+        if len(history) > self.max_messages:
+            del history[0 : len(history) - self.max_messages]
+
+    def get(self, session_id: str, last_n: int = 10) -> list[dict[str, str]]:
+        """Вернуть последние N сообщений сессии."""
+        history = self._store.get(session_id, [])
+        if last_n <= 0:
+            return []
+        return history[-last_n:]
+
+    def clear(self, session_id: str) -> None:
+        """Очистить историю конкретной сессии."""
+        self._store.pop(session_id, None)

--- a/tests/test_session_memory.py
+++ b/tests/test_session_memory.py
@@ -1,0 +1,41 @@
+"""Тесты SessionMemory."""
+
+from core.session_memory import SessionMemory
+
+
+def test_session_memory_fifo_limit() -> None:
+    """При переполнении хранилища старые сообщения удаляются по FIFO."""
+    memory = SessionMemory(max_messages=50)
+    session_id = "s-fifo"
+
+    for idx in range(55):
+        memory.add(session_id, role="user", content=f"msg-{idx}")
+
+    history = memory.get(session_id, last_n=100)
+    assert len(history) == 50
+    assert history[0]["content"] == "msg-5"
+    assert history[-1]["content"] == "msg-54"
+
+
+def test_session_memory_get_last_n() -> None:
+    """get(last_n) должен возвращать только последние N сообщений."""
+    memory = SessionMemory()
+    session_id = "s-last-n"
+
+    for idx in range(6):
+        memory.add(session_id, role="assistant", content=f"reply-{idx}")
+
+    history = memory.get(session_id, last_n=3)
+    assert [item["content"] for item in history] == ["reply-3", "reply-4", "reply-5"]
+
+
+def test_session_memory_clear() -> None:
+    """clear должен удалять историю сессии."""
+    memory = SessionMemory()
+    session_id = "s-clear"
+
+    memory.add(session_id, role="agent", content="internal-note")
+    assert len(memory.get(session_id)) == 1
+
+    memory.clear(session_id)
+    assert memory.get(session_id) == []


### PR DESCRIPTION
### Motivation
- Provide an in-memory session history store to preserve recent messages per session (with future plan to replace with SQLite/Redis) so agents can use conversational context.
- Ensure user messages and assistant replies are recorded and that pipelines receive recent history to improve multi-step workflows.
- Make `session_id` optional at the API layer and ensure a stable `session_id` is generated/returned for client-side continuity.

### Description
- Added `core/session_memory.py` implementing `SessionMemory` with `add(session_id, role, content)`, `get(session_id, last_n=10)`, `clear(session_id)`, ISO8601 `timestamp`, and FIFO cap of 50 messages.
- Integrated `SessionMemory` into `Orchestrator` by initializing `self.session_memory`, recording the user message before processing, recording assistant replies after pipeline/chat handling, and injecting `conversation_history` (last 10 messages) into pipeline `state`.
- Updated `BaseAgent._build_prompt()` to append formatted `conversation_history` (timestamped lines) after the main message/context.
- Updated `POST /api/chat` (`api/routes/chat.py`) to accept an optional `session_id`, generate a UUID when missing, return/use that `session_id`, and reuse a module-level `Orchestrator` so in-memory history persists in-process.
- Added tests `tests/test_session_memory.py` covering FIFO behavior, `get(last_n)`, and `clear()`.

### Testing
- Ran `pytest -q tests/test_session_memory.py tests/test_orchestrator.py tests/test_pipeline_integration.py`, all tests passed (6 passed, 1 warning).
- Running the full test suite including health async tests with `pytest -q tests/test_session_memory.py tests/test_orchestrator.py tests/test_pipeline_integration.py tests/test_health.py` failed due to missing `pytest-asyncio` plugin in the environment (health async tests could not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca61ab888832fba03dffaa387fd22)