### PR TITLE
Add TK generation endpoint with validation and forced orchestrator intent

### DIFF
--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -1,63 +1,114 @@
 """Generate endpoints — генерация документов."""
 
-from fastapi import APIRouter
-from pydantic import BaseModel
+import uuid
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from core.orchestrator import Orchestrator
 
 router = APIRouter()
+orchestrator = Orchestrator()
+
+ALLOWED_UNITS = ["м³", "м²", "пог.м.", "шт.", "т", "кг"]
 
 
-# ── Схемы запросов ─────────────────────────────
+class TKRequest(BaseModel):
+    """Запрос на генерацию технологической карты."""
+
+    work_type: str = Field(min_length=5)
+    object_name: str
+    volume: float
+    unit: str
+    norms: list[str] = []
+    role: str = "pto_engineer"
+    session_id: str | None = None
+
+    @field_validator("volume")
+    @classmethod
+    def validate_volume(cls, value: float) -> float:
+        """Объём работ должен быть больше нуля."""
+        if value <= 0:
+            raise ValueError("volume must be > 0")
+        return value
+
+    @field_validator("unit")
+    @classmethod
+    def validate_unit(cls, value: str) -> str:
+        """Единица измерения должна быть из разрешённого списка."""
+        if value not in ALLOWED_UNITS:
+            raise ValueError(f"unit must be one of: {', '.join(ALLOWED_UNITS)}")
+        return value
 
 
-class TKGenerateRequest(BaseModel):
-    """Параметры генерации технологической карты."""
+class TKResponse(BaseModel):
+    """Ответ на генерацию технологической карты."""
 
-    work_type: str  # монолит / кладка / кровля / и т.д.
-    volume: str | None = None  # объём работ
-    deadline: str | None = None  # срок выполнения
-    brigade_size: int | None = None  # размер бригады
-    conditions: str | None = None  # особые условия
-    rd_file_path: str | None = None  # путь к загруженной РД
+    session_id: str
+    document: dict
+    agents_used: list[str]
+    confidence: float | None
+    sha256: str | None
 
 
 class LetterGenerateRequest(BaseModel):
     """Параметры генерации делового письма."""
 
-    letter_type: str  # запрос | ответ | претензия | уведомление
-    situation: str  # описание ситуации
-    recipient: str | None = None  # получатель
-    references: list[str] | None = None  # ссылки на документы
+    letter_type: str
+    situation: str
+    recipient: str | None = None
+    references: list[str] | None = None
 
 
 class GenerateResponse(BaseModel):
     """Результат генерации."""
 
     document_id: str
-    status: str  # draft | review | approved
+    status: str
     preview: str | None = None
     download_url: str | None = None
     agents_log: list[dict] = []
 
 
-# ── Endpoints ──────────────────────────────────
+@router.post("/generate/tk", response_model=TKResponse)
+async def generate_tk(request: TKRequest):
+    """Генерация технологической карты (ТК) через orchestrator."""
+    session_id = request.session_id or str(uuid.uuid4())
+    norms_text = ", ".join(request.norms) if request.norms else "не указаны"
+    message = (
+        "Сформируй технологическую карту на русском языке.\n"
+        f"Вид работ: {request.work_type}.\n"
+        f"Наименование объекта: {request.object_name}.\n"
+        f"Объём работ: {request.volume} {request.unit}.\n"
+        f"Нормативы: {norms_text}.\n"
+        "Подготовь структурированный документ для последующего DOCX-форматирования."
+    )
 
+    try:
+        result = await orchestrator.process(
+            message=message,
+            session_id=session_id,
+            role=request.role,
+            intent="generate_tk",
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
 
-@router.post("/generate/tk", response_model=GenerateResponse)
-async def generate_tk(request: TKGenerateRequest):
-    """Генерация технологической карты (ТК)."""
-    # TODO: Фаза 1 — вызов tk-generator через subprocess
-    # TODO: Фаза 2 — полноценная генерация через оркестратор
-    return GenerateResponse(
-        document_id="tk-draft-001",
-        status="draft",
-        preview="[Генерация ТК в разработке]",
+    state = result.get("state", {}) if isinstance(result, dict) else {}
+    document = state.get("docx_payload") or {"content": result.get("reply")}
+
+    return TKResponse(
+        session_id=result["session_id"],
+        document=document,
+        agents_used=result.get("agents_used", []),
+        confidence=result.get("confidence"),
+        sha256=result.get("sha256"),
     )
 
 
 @router.post("/generate/letter", response_model=GenerateResponse)
 async def generate_letter(request: LetterGenerateRequest):
     """Генерация делового письма."""
-    # TODO: Фаза 2 — генератор писем через оркестратор
     return GenerateResponse(
         document_id="letter-draft-001",
         status="draft",

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -210,6 +210,7 @@ class Orchestrator:
         message: str,
         session_id: str | None = None,
         role: str = "pto_engineer",
+        intent: str | None = None,
     ) -> dict[str, Any]:
         """Обработать запрос пользователя.
 
@@ -222,6 +223,7 @@ class Orchestrator:
             message: Сообщение пользователя.
             session_id: ID сессии (для контекста).
             role: Роль пользователя.
+            intent: Принудительный intent (если задан, без LLM-детекции).
 
         Returns:
             Словарь с ответом и метаданными.
@@ -229,7 +231,7 @@ class Orchestrator:
         session_id = session_id or str(uuid.uuid4())
         self.session_memory.add(session_id, role="user", content=message)
 
-        intent = await self._detect_intent(message)
+        intent = intent or await self._detect_intent(message)
 
         if intent != "chat":
             result = await self._run_pipeline(intent, message, session_id, role)

--- a/tests/test_generate_tk.py
+++ b/tests/test_generate_tk.py
@@ -1,0 +1,64 @@
+"""Тесты /api/generate/tk."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import generate
+
+
+def test_generate_tk_happy_path():
+    """POST /api/generate/tk возвращает TKResponse при успешной обработке."""
+    client = TestClient(app)
+    mocked_process = AsyncMock(
+        return_value={
+            "session_id": "session-1",
+            "agents_used": ["researcher", "author", "critic", "verifier", "formatter"],
+            "confidence": 0.96,
+            "sha256": "abc123",
+            "state": {"docx_payload": {"title": "ТК", "sections": []}},
+        }
+    )
+
+    generate.orchestrator.process = mocked_process
+
+    response = client.post(
+        "/api/generate/tk",
+        json={
+            "work_type": "бетонирование монолитных конструкций",
+            "object_name": "ЖК Север",
+            "volume": 120.5,
+            "unit": "м³",
+            "norms": ["СП 70.13330", "ГОСТ 7473"],
+            "role": "pto_engineer",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == "session-1"
+    assert data["agents_used"][-1] == "formatter"
+    assert data["document"]["title"] == "ТК"
+    mocked_process.assert_awaited_once()
+    call_kwargs = mocked_process.await_args.kwargs
+    assert call_kwargs["intent"] == "generate_tk"
+    assert call_kwargs["role"] == "pto_engineer"
+    assert "бетонирование монолитных конструкций" in call_kwargs["message"]
+
+
+def test_generate_tk_validation_error():
+    """POST /api/generate/tk должен вернуть 422 при невалидных данных."""
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/generate/tk",
+        json={
+            "work_type": "бетон",
+            "object_name": "ЖК Север",
+            "volume": 0,
+            "unit": "литр",
+        },
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
### Motivation
- Provide a real `/api/generate/tk` implementation that builds a structured Russian prompt from request fields and runs the generate_tk pipeline instead of a placeholder response. 
- Ensure incoming requests are validated for minimal quality and safe units before invoking the orchestrator. 
- Allow callers to force a workflow intent to bypass LLM-based intent detection for deterministic pipeline execution.

### Description
- Added `TKRequest` and `TKResponse` Pydantic models in `api/routes/generate.py` with fields specified and validations: `work_type` min length 5, `volume > 0`, and `unit` restricted to `['м³','м²','пог.м.','шт.','т','кг']` using `field_validator` and `Field`. 
- Implemented `POST /api/generate/tk` which composes a Russian template message from the request, calls `orchestrator.process(..., intent="generate_tk")`, extracts `docx_payload` from the returned `state` and returns `TKResponse`. 
- Added HTTP error handling to return `422` on request validation (handled by FastAPI/Pydantic) and `500` for orchestrator/LLM runtime errors via `HTTPException`. 
- Extended `Orchestrator.process` signature to accept an optional `intent` parameter and use it when provided (`intent = intent or await self._detect_intent(message)`). 
- Added unit tests `tests/test_generate_tk.py` using `TestClient` and a mocked `Orchestrator.process` to validate the happy path and a validation-failure case.

### Testing
- Ran `pytest -q tests/test_generate_tk.py tests/test_orchestrator.py`, and both tests suites passed (4 tests total passed). 
- Attempted `pytest -q tests/test_generate_tk.py tests/test_orchestrator.py tests/test_health.py`, which produced 2 failures for async health tests because the local environment lacked an async pytest plugin (e.g. `pytest-asyncio`), not related to the new endpoint logic. 
- The new tests verify that `orchestrator.process` is awaited with `intent='generate_tk'`, that a successful flow returns the `docx_payload` title, and that invalid input returns HTTP `422`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca72b2270832fa554447af7e5c7d8)