### PR TITLE
Добавить `/api/generate/letter` с моделями и опцией отключения Legal Expert

### DIFF
--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -1,6 +1,8 @@
 """Generate endpoints — генерация документов."""
 
+import re
 import uuid
+from enum import Enum
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, field_validator
@@ -51,23 +53,36 @@ class TKResponse(BaseModel):
     sha256: str | None
 
 
-class LetterGenerateRequest(BaseModel):
-    """Параметры генерации делового письма."""
+class LetterType(str, Enum):
+    """Тип делового письма."""
 
-    letter_type: str
-    situation: str
-    recipient: str | None = None
-    references: list[str] | None = None
+    REQUEST = "запрос"
+    CLAIM = "претензия"
+    NOTIFICATION = "уведомление"
+    RESPONSE = "ответ"
 
 
-class GenerateResponse(BaseModel):
-    """Результат генерации."""
+class LetterRequest(BaseModel):
+    """Запрос на генерацию делового письма."""
 
-    document_id: str
-    status: str
-    preview: str | None = None
-    download_url: str | None = None
-    agents_log: list[dict] = []
+    letter_type: LetterType
+    addressee: str
+    subject: str
+    body_points: list[str] = Field(min_length=1, max_length=10)
+    contract_number: str | None = None
+    include_npa: bool = True
+    role: str = "foreman"
+    session_id: str | None = None
+
+
+class LetterResponse(BaseModel):
+    """Ответ на генерацию делового письма."""
+
+    session_id: str
+    document: dict
+    agents_used: list[str]
+    legal_references: list[str]
+    confidence: float | None
 
 
 @router.post("/generate/tk", response_model=TKResponse)
@@ -106,13 +121,67 @@ async def generate_tk(request: TKRequest):
     )
 
 
-@router.post("/generate/letter", response_model=GenerateResponse)
-async def generate_letter(request: LetterGenerateRequest):
-    """Генерация делового письма."""
-    return GenerateResponse(
-        document_id="letter-draft-001",
-        status="draft",
-        preview="[Генерация писем в разработке]",
+LEGAL_REFERENCE_PATTERN = re.compile(
+    r"(ст\.\s*\d+(?:\.\d+)?\s*[А-ЯA-Zа-яa-zЁё\s]{0,25}РФ|ФЗ-\d+)",
+    flags=re.IGNORECASE,
+)
+
+
+def _extract_legal_references(history: list[dict]) -> list[str]:
+    """Извлечь ссылки на НПА из history записей Legal Expert."""
+    references: list[str] = []
+    for item in history:
+        if not isinstance(item, dict):
+            continue
+        agent_name = str(item.get("agent_name", "")).lower().replace(" ", "")
+        if agent_name != "legalexpert":
+            continue
+
+        output = str(item.get("output", ""))
+        matches = LEGAL_REFERENCE_PATTERN.findall(output)
+        for match in matches:
+            normalized = " ".join(match.strip().split())
+            if normalized and normalized not in references:
+                references.append(normalized)
+    return references
+
+
+@router.post("/generate/letter", response_model=LetterResponse)
+async def generate_letter_v2(request: LetterRequest):
+    """Генерация делового письма через orchestrator."""
+    session_id = request.session_id or str(uuid.uuid4())
+    body_points_text = "; ".join(request.body_points)
+    contract_number = request.contract_number or "не указан"
+    message = (
+        f"Тип: {request.letter_type.value}. "
+        f"Получатель: {request.addressee}. "
+        f"Тема: {request.subject}. "
+        f"Тезисы: {body_points_text}. "
+        f"Договор: {contract_number}."
+    )
+
+    try:
+        result = await orchestrator.process(
+            message=message,
+            session_id=session_id,
+            role=request.role,
+            intent="generate_letter",
+            include_legal_expert=request.include_npa,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
+
+    state = result.get("state", {}) if isinstance(result, dict) else {}
+    history = state.get("history", []) if isinstance(state, dict) else []
+    document = state.get("docx_payload") or {"content": result.get("reply")}
+    legal_references = _extract_legal_references(history)
+
+    return LetterResponse(
+        session_id=result["session_id"],
+        document=document,
+        agents_used=result.get("agents_used", []),
+        legal_references=legal_references,
+        confidence=result.get("confidence"),
     )
 
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -173,9 +173,16 @@ class Orchestrator:
         message: str,
         session_id: str,
         role: str,
+        include_legal_expert: bool = True,
     ) -> dict[str, Any]:
         """Запустить workflow по intent через LangGraph."""
         pipeline = self.get_workflow(intent)
+        if (
+            intent == "generate_letter"
+            and not include_legal_expert
+            and isinstance(pipeline, list)
+        ):
+            pipeline = [agent for agent in pipeline if agent != "legal_expert"]
         if not pipeline:
             return {
                 "reply": None,
@@ -211,6 +218,7 @@ class Orchestrator:
         session_id: str | None = None,
         role: str = "pto_engineer",
         intent: str | None = None,
+        include_legal_expert: bool = True,
     ) -> dict[str, Any]:
         """Обработать запрос пользователя.
 
@@ -234,7 +242,13 @@ class Orchestrator:
         intent = intent or await self._detect_intent(message)
 
         if intent != "chat":
-            result = await self._run_pipeline(intent, message, session_id, role)
+            result = await self._run_pipeline(
+                intent,
+                message,
+                session_id,
+                role,
+                include_legal_expert=include_legal_expert,
+            )
             if result.get("reply"):
                 self.session_memory.add(
                     session_id, role="assistant", content=str(result["reply"])

--- a/tests/test_generate_letter.py
+++ b/tests/test_generate_letter.py
@@ -1,0 +1,107 @@
+"""Тесты /api/generate/letter."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import generate
+
+
+def test_generate_letter_with_npa_pipeline():
+    """POST /api/generate/letter с include_npa=True использует Legal Expert."""
+    client = TestClient(app)
+    mocked_process = AsyncMock(
+        return_value={
+            "session_id": "session-legal",
+            "agents_used": [
+                "researcher",
+                "author",
+                "legal_expert",
+                "critic",
+                "verifier",
+                "formatter",
+            ],
+            "confidence": 0.93,
+            "reply": "Итоговый текст письма",
+            "state": {
+                "docx_payload": {"title": "Письмо", "sections": []},
+                "history": [
+                    {
+                        "agent_name": "LegalExpert",
+                        "output": "Основания: ст. 309 ГК РФ; ФЗ-44.",
+                    }
+                ],
+            },
+        }
+    )
+
+    generate.orchestrator.process = mocked_process
+
+    response = client.post(
+        "/api/generate/letter",
+        json={
+            "letter_type": "запрос",
+            "addressee": "ООО Ромашка",
+            "subject": "Предоставление графика работ",
+            "body_points": ["Просим прислать график", "Срок до 15.05.2026"],
+            "contract_number": "Д-123",
+            "include_npa": True,
+            "role": "foreman",
+            "session_id": "session-legal",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == "session-legal"
+    assert "legal_expert" in data["agents_used"]
+    assert data["legal_references"] == ["ст. 309 ГК РФ", "ФЗ-44"]
+
+    mocked_process.assert_awaited_once()
+    call_kwargs = mocked_process.await_args.kwargs
+    assert call_kwargs["intent"] == "generate_letter"
+    assert call_kwargs["include_legal_expert"] is True
+    assert "Тип: запрос." in call_kwargs["message"]
+
+
+def test_generate_letter_without_npa_pipeline():
+    """POST /api/generate/letter с include_npa=False отключает Legal Expert."""
+    client = TestClient(app)
+    mocked_process = AsyncMock(
+        return_value={
+            "session_id": "session-no-legal",
+            "agents_used": ["researcher", "author", "critic", "verifier", "formatter"],
+            "confidence": 0.9,
+            "reply": "Итоговый текст письма",
+            "state": {
+                "docx_payload": {"title": "Письмо без НПА", "sections": []},
+                "history": [],
+            },
+        }
+    )
+
+    generate.orchestrator.process = mocked_process
+
+    response = client.post(
+        "/api/generate/letter",
+        json={
+            "letter_type": "ответ",
+            "addressee": "АО Заказчик",
+            "subject": "Ответ по замечаниям",
+            "body_points": ["Замечания устранены"],
+            "include_npa": False,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == "session-no-legal"
+    assert "legal_expert" not in data["agents_used"]
+    assert data["legal_references"] == []
+
+    mocked_process.assert_awaited_once()
+    call_kwargs = mocked_process.await_args.kwargs
+    assert call_kwargs["intent"] == "generate_letter"
+    assert call_kwargs["include_legal_expert"] is False
+    assert "Договор: не указан." in call_kwargs["message"]


### PR DESCRIPTION
### Motivation
- Реализовать полноценную генерацию деловых писем с типизированными входными/выходными моделями и контролем участия юридического эксперта в pipeline.
- Обеспечить единый формат сообщения на русском и извлечение ссылок на НПА из истории работы агента `Legal Expert`.

### Description
- Добавлены Pydantic-модели `LetterType`, `LetterRequest` и `LetterResponse` в `api/routes/generate.py` и использованы для валидации запроса/ответа через endpoint `POST /api/generate/letter`.
- Реализован шаблон сообщения на русском в формате `"Тип: {letter_type}. Получатель: {addressee}. Тема: {subject}. Тезисы: {body_points}. Договор: {contract_number}."` и принудительный `intent="generate_letter"` при вызове `orchestrator.process`.
- Добавлена функция `_extract_legal_references` с регулярным выражением `ст. X ... РФ` и `ФЗ-XXX` для извлечения `legal_references` из записей `state["history"]` только от агента `Legal Expert`.
- Расширен `Orchestrator` в `core/orchestrator.py` — добавлен аргумент `include_legal_expert` к `process`/`_run_pipeline` и логика исключения агента `legal_expert` из pipeline при `include_legal_expert=False`.
- Добавлен тест `tests/test_generate_letter.py`, покрывающий оба сценария: с `include_npa=True` (с `legal_expert`) и с `include_npa=False` (без `legal_expert`).

### Testing
- Запущена команда `pytest -q tests/test_generate_tk.py tests/test_generate_letter.py tests/test_orchestrator.py` и все тесты прошли успешно, результат: `6 passed, 1 warning` (предупреждение конфигурации pytest, не связанное с изменениями).
- Новый файл `tests/test_generate_letter.py` проверяет, что при `include_npa=True` в вызове `orchestrator.process` передаётся `include_legal_expert=True` и что из истории извлекаются юридические ссылки, а при `include_npa=False` агент `legal_expert` исключается из pipeline и `legal_references` пусты.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca80007ec832f9f94355d1836086d)