### PR TITLE
Generate DOCX from Verifier output: add DocxGenerator, update FormatterAgent and API download

### DIFF
--- a/agents/formatter.py
+++ b/agents/formatter.py
@@ -2,31 +2,92 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from agents.base import BaseAgent
+from core.docx_generator import DocxGenerator
 from core.llm_router import LLMRouter
 
 
 class FormatterAgent(BaseAgent):
-    """📐 Formatter — готовит структурированный dict для будущего DOCX."""
+    """📐 Formatter — готовит финальный DOCX на основе вывода Verifier."""
 
-    system_prompt = (
-        "Ты — Formatter агент. Сформируй структуру документа для DOCX: "
-        "title, headings, sections (с подзаголовками и абзацами), tables (если есть)."
-    )
+    system_prompt = "Ты — Formatter агент."
 
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="07", llm_router=llm_router)
+        self.docx_generator = DocxGenerator()
+
+    def _extract_verifier_output(self, state: dict[str, Any]) -> str:
+        history = state.get("history", [])
+        if not isinstance(history, list):
+            return ""
+
+        for item in reversed(history):
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("agent_name", "")).lower() == "verifier":
+                return str(item.get("output", ""))
+        return ""
+
+    def _extract_by_label(self, text: str, labels: list[str]) -> str:
+        escaped = "|".join(re.escape(label) for label in labels)
+        pattern = re.compile(
+            rf"(?:^|\\n)\s*(?:{escaped})\s*[:\-]?\s*(.+?)(?=\\n\s*[А-ЯA-Z0-9].{{0,40}}[:\-]|\Z)",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        match = pattern.search(text)
+        if not match:
+            return ""
+        return " ".join(match.group(1).strip().split())
+
+    def _parse_context(self, verifier_output: str, state: dict[str, Any]) -> dict[str, Any]:
+        normative_raw = self._extract_by_label(
+            verifier_output,
+            ["Нормативные документы", "Нормативные акты", "НПА", "normative_docs"],
+        )
+        normative_docs = [
+            line.strip("•-— ")
+            for line in re.split(r"[\n,;]", normative_raw)
+            if line.strip("•-— ")
+        ]
+
+        sha256 = str(state.get("verification", {}).get("sha256", "")).strip()
+        if not sha256:
+            audit_log = state.get("audit_log", [])
+            if isinstance(audit_log, list) and audit_log:
+                sha256 = str(audit_log[-1].get("sha256", "")).strip()
+
+        return {
+            "work_type": self._extract_by_label(verifier_output, ["Вид работ", "work_type"])
+            or str(state.get("title", "Технологическая карта")),
+            "scope": self._extract_by_label(verifier_output, ["Область применения", "scope"])
+            or "Не указано",
+            "technology": self._extract_by_label(
+                verifier_output,
+                ["Организация и технология производства работ", "Технология", "technology"],
+            )
+            or "Не указано",
+            "quality_requirements": self._extract_by_label(
+                verifier_output,
+                ["Требования к качеству работ", "Качество", "quality_requirements"],
+            )
+            or "Не указано",
+            "normative_docs": normative_docs or ["Не указано"],
+            "sha256": sha256 or "n/a",
+        }
 
     async def run(self, state: dict[str, Any]) -> dict[str, Any]:
-        prompt = self._build_prompt(state)
-        response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
-        docx_payload = {
-            "title": state.get("title", "Документ"),
-            "headings": state.get("headings", []),
-            "sections": state.get("sections", []),
-            "llm_layout": response.text,
+        verifier_output = self._extract_verifier_output(state)
+        context = self._parse_context(verifier_output, state)
+        docx_bytes = self.docx_generator.generate("tk_template", context)
+
+        state["docx_bytes"] = docx_bytes
+        state["final_output"] = {
+            "template": "tk_template",
+            "context": context,
+            "docx_size": len(docx_bytes),
         }
-        state["docx_payload"] = docx_payload
-        return self._update_state(state, response.text)
+
+        return self._update_state(state, "DOCX generated")

--- a/agents/tests/test_agents.py
+++ b/agents/tests/test_agents.py
@@ -79,8 +79,28 @@ def test_legal_expert_smoke(llm_router_mock: SimpleNamespace) -> None:
 
 def test_formatter_smoke(llm_router_mock: SimpleNamespace) -> None:
     agent = FormatterAgent(llm_router_mock)
-    state = asyncio.run(agent.run({"message": "Оформи", "history": [], "title": "Тест"}))
-    assert state["docx_payload"]["title"] == "Тест"
+    state = asyncio.run(
+        agent.run(
+            {
+                "message": "Оформи",
+                "history": [
+                    {
+                        "agent_name": "Verifier",
+                        "output": """
+                        Вид работ: Монолитные работы
+                        Область применения: Устройство фундаментной плиты.
+                        Организация и технология производства работ: Поэтапное бетонирование.
+                        Требования к качеству работ: Контроль прочности.
+                        Нормативные документы: СП 70.13330, ГОСТ 7473
+                        """,
+                    }
+                ],
+                "verification": {"sha256": "abc123"},
+            }
+        )
+    )
+    assert isinstance(state["docx_bytes"], bytes)
+    assert state["final_output"]["template"] == "tk_template"
 
 
 def test_calculator_smoke(llm_router_mock: SimpleNamespace) -> None:

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -1,10 +1,13 @@
 """Generate endpoints — генерация документов."""
 
 import re
+import tempfile
 import uuid
 from enum import Enum
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, field_validator
 
 from core.orchestrator import Orchestrator
@@ -13,6 +16,8 @@ router = APIRouter()
 orchestrator = Orchestrator()
 
 ALLOWED_UNITS = ["м³", "м²", "пог.м.", "шт.", "т", "кг"]
+
+DOCX_CACHE: dict[str, bytes] = {}
 
 
 class TKRequest(BaseModel):
@@ -110,7 +115,15 @@ async def generate_tk(request: TKRequest):
         raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
 
     state = result.get("state", {}) if isinstance(result, dict) else {}
-    document = state.get("docx_payload") or {"content": result.get("reply")}
+    docx_bytes = state.get("docx_bytes")
+    if isinstance(docx_bytes, bytes):
+        DOCX_CACHE[session_id] = docx_bytes
+
+    document = (
+        state.get("final_output")
+        or state.get("docx_payload")
+        or {"content": result.get("reply")}
+    )
 
     return TKResponse(
         session_id=result["session_id"],
@@ -189,3 +202,24 @@ async def generate_letter_v2(request: LetterRequest):
 async def generate_ks():
     """Генерация КС-2/КС-3 (Фаза 4)."""
     return {"status": "not_implemented", "message": "КС-2/КС-3 запланирован на Фазу 4"}
+
+
+@router.get("/generate/tk/{session_id}/download")
+async def download_tk_docx(session_id: str):
+    """Скачать ранее сгенерированный DOCX по session_id."""
+    docx_bytes = DOCX_CACHE.get(session_id)
+    if not docx_bytes:
+        raise HTTPException(status_code=404, detail="DOCX not found for this session")
+
+    tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".docx")
+    tmp_path = Path(tmp_file.name)
+    with tmp_file:
+        tmp_file.write(docx_bytes)
+
+    return FileResponse(
+        path=tmp_path,
+        media_type=(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+        filename=f"tk_{session_id}.docx",
+    )

--- a/core/docx_generator.py
+++ b/core/docx_generator.py
@@ -1,0 +1,76 @@
+"""Утилита генерации DOCX из Jinja2-шаблонов."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from docx import Document
+from docxtpl import DocxTemplate
+
+
+class DocxGenerator:
+    """Генератор DOCX на базе docxtpl."""
+
+    def __init__(self, templates_dir: str | Path | None = None) -> None:
+        base_dir = Path(__file__).resolve().parent.parent
+        self.templates_dir = Path(templates_dir) if templates_dir else base_dir / "templates"
+
+    def _create_default_tk_template(self, template_path: Path) -> None:
+        """Создать минимальный tk_template.docx, если бинарный шаблон отсутствует."""
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+
+        doc = Document()
+        doc.add_heading("ТЕХНОЛОГИЧЕСКАЯ КАРТА на {{work_type}}", level=1)
+
+        doc.add_heading("1. Область применения", level=2)
+        doc.add_paragraph("{{scope}}")
+
+        doc.add_heading("2. Организация и технология производства работ", level=2)
+        doc.add_paragraph("{{technology}}")
+
+        doc.add_heading("3. Требования к качеству работ", level=2)
+        doc.add_paragraph("{{quality_requirements}}")
+
+        doc.add_heading("4. Нормативные документы", level=2)
+        doc.add_paragraph(
+            "{% for doc_name in normative_docs %}"
+            "• {{doc_name}}"
+            "{% if not loop.last %}\n{% endif %}"
+            "{% endfor %}"
+        )
+
+        footer = doc.sections[0].footer
+        footer.paragraphs[0].text = "ГОСТ Р 21.1101 · SHA256: {{sha256}}"
+        doc.save(template_path)
+
+    def _ensure_template(self, template_name: str) -> Path:
+        template_path = self.templates_dir / f"{template_name}.docx"
+        if template_path.exists():
+            return template_path
+
+        if template_name == "tk_template":
+            self._create_default_tk_template(template_path)
+            return template_path
+
+        raise FileNotFoundError(f"Template not found: {template_path}")
+
+    def generate(self, template_name: str, context: dict) -> bytes:
+        """Сгенерировать DOCX по шаблону и вернуть bytes."""
+        template_path = self._ensure_template(template_name)
+
+        tpl = DocxTemplate(str(template_path))
+        tpl.render(context)
+
+        buffer = BytesIO()
+        tpl.save(buffer)
+        return buffer.getvalue()
+
+    def list_templates(self) -> list[str]:
+        """Список доступных DOCX-шаблонов (без расширения)."""
+        self.templates_dir.mkdir(parents=True, exist_ok=True)
+        templates = {
+            path.stem for path in self.templates_dir.glob("*.docx") if path.is_file()
+        }
+        templates.add("tk_template")
+        return sorted(templates)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,6 @@
+# Templates
+
+В репозитории не храним бинарные `.docx` файлы.
+
+`tk_template.docx` создаётся автоматически в рантайме классом `DocxGenerator`
+при первом вызове `generate("tk_template", context)`.

--- a/tests/test_docx_generator.py
+++ b/tests/test_docx_generator.py
@@ -1,0 +1,25 @@
+"""Тесты генератора DOCX."""
+
+from core.docx_generator import DocxGenerator
+
+
+def test_docx_generator_creates_non_empty_document(tmp_path) -> None:
+    """DocxGenerator должен возвращать непустые bytes DOCX."""
+    generator = DocxGenerator(templates_dir=tmp_path)
+
+    payload = generator.generate(
+        "tk_template",
+        {
+            "work_type": "монолитные работы",
+            "scope": "Применяется при устройстве фундаментной плиты.",
+            "technology": "Работы выполняются поэтапно с контролем бетона.",
+            "quality_requirements": "Контроль прочности и геометрии конструкций.",
+            "normative_docs": ["СП 70.13330", "ГОСТ 7473"],
+            "sha256": "abc123",
+        },
+    )
+
+    assert isinstance(payload, bytes)
+    assert len(payload) > 0
+    assert (tmp_path / "tk_template.docx").exists()
+    assert "tk_template" in generator.list_templates()


### PR DESCRIPTION
### Motivation
- Convert Formatter agent from producing an intermediate dict to generating a final DOCX based on Verifier output and a reusable DOCX templating utility.
- Provide an API flow to persist and download generated DOCX files per session.
- Make DOCX template handling robust by auto-creating a minimal `tk_template.docx` when no binary template is present.

### Description
- Add `core/docx_generator.py` implementing `DocxGenerator` which ensures templates, can create a default `tk_template.docx`, render templates with `docxtpl`, and return `bytes` via `generate` and list templates via `list_templates`.
- Update `agents/formatter.py` to extract the Verifier output from `state`, parse labeled fields with `_extract_by_label` and `_parse_context`, generate DOCX bytes with `DocxGenerator.generate`, and store results in `state['docx_bytes']` and `state['final_output']` instead of `docx_payload`.
- Modify `api/routes/generate.py` to cache generated DOCX bytes in an in-memory `DOCX_CACHE`, return the `final_output` when available, and add a new download endpoint `GET /generate/tk/{session_id}/download` that serves the cached DOCX via a temporary file and `FileResponse`.
- Add `templates/README.md` documenting that binary templates are not stored and `tk_template.docx` is created on first use, and add `tests/test_docx_generator.py` plus update `agents/tests/test_agents.py` to assert the new DOCX generation behavior.

### Testing
- Ran unit tests including `tests/test_docx_generator.py` which asserts `DocxGenerator.generate` returns non-empty `bytes` and creates a `tk_template.docx`, and this test passed.
- Updated `agents/tests/test_agents.py` (notably `test_formatter_smoke`) to validate that `FormatterAgent.run` sets `state['docx_bytes']` and `state['final_output']['template'] == 'tk_template'`, and this test passed.
- Existing agent smoke tests (`test_verifier_smoke`, `test_legal_expert_smoke`, `test_calculator_smoke`) were executed and remained passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca8e5a684832fa8ee826b5becd7dd)