### PR TITLE
Add aiogram Telegram bot with FSM handlers, keyboards and docker service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,9 @@ CHROMA_PERSIST_DIR=./data/chroma
 # ── Redis (только для серверного деплоя) ───────
 # REDIS_URL=redis://localhost:6379/0
 
-# ── Telegram Bot (из laughing-memory) ──────────
+# ── Telegram Bot ───────────────────────────────
+BOT_TOKEN=xxxxxxxxxxxxxxxxxxxx
+CORE_API_URL=http://api:8000
 TELEGRAM_BOT_TOKEN=xxxxxxxxxxxxxxxxxxxx
 
 # ── tk-generator (Node.js) ─────────────────────

--- a/config/settings.py
+++ b/config/settings.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     redis_url: str | None = None
 
     # ── Telegram ───────────────────────────────
+    bot_token: str = ""
+    core_api_url: str = "http://api:8000"
     telegram_bot_token: str = ""
 
     # ── tk-generator ───────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,19 @@ services:
   #     - redis_data:/data
   #   restart: unless-stopped
 
+
+  telegram-bot:
+    image: python:3.11-slim
+    container_name: construction-ai-telegram-bot
+    working_dir: /app
+    command: python -m telegram.bot
+    depends_on:
+      - api
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+    restart: unless-stopped
+
 # volumes:
 #   redis_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-openai>=0.2.0",
     "langchain-community>=0.3.0",
     "httpx>=0.27.0",
+    "aiogram>=3.13.0",
     "pydantic>=2.9.0",
     "pydantic-settings>=2.5.0",
     "python-dotenv>=1.0.0",

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -1,0 +1,1 @@
+"""Telegram bot package."""

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,0 +1,32 @@
+"""Точка входа Telegram-бота на aiogram 3."""
+
+import asyncio
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+
+from config.settings import settings
+from telegram.handlers import router
+
+
+def create_dispatcher() -> Dispatcher:
+    dp = Dispatcher()
+    dp.include_router(router)
+    return dp
+
+
+async def main() -> None:
+    if not settings.bot_token:
+        raise RuntimeError("BOT_TOKEN не задан в настройках")
+
+    bot = Bot(
+        token=settings.bot_token,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+    dp = create_dispatcher()
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/telegram/handlers.py
+++ b/telegram/handlers.py
@@ -1,0 +1,208 @@
+"""Хэндлеры Telegram-бота."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import httpx
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import BufferedInputFile, CallbackQuery, Message, ReplyKeyboardRemove
+
+from config.settings import settings
+from telegram.keyboards import cancel_keyboard, role_keyboard
+
+router = Router()
+
+user_roles: dict[int, str] = {}
+
+
+ROLE_NAMES = {
+    "pto_engineer": "ПТО",
+    "foreman": "Прораб",
+    "tender_specialist": "Тендеры",
+    "admin": "Админ",
+}
+
+
+@dataclass
+class TelegramCoreClient:
+    """Клиент для запросов к Construction AI Core API."""
+
+    base_url: str
+
+    async def post(self, path: str, payload: dict) -> dict:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(f"{self.base_url}{path}", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+
+api_client = TelegramCoreClient(base_url=settings.core_api_url.rstrip("/"))
+
+
+class TKForm(StatesGroup):
+    work_type = State()
+    object_name = State()
+    volume = State()
+    unit = State()
+
+
+class LetterForm(StatesGroup):
+    letter_type = State()
+    addressee = State()
+    subject = State()
+    body_points = State()
+
+
+def _get_user_role(user_id: int) -> str:
+    return user_roles.get(user_id, "pto_engineer")
+
+
+@router.message(Command("start"))
+async def start_handler(message: Message) -> None:
+    await message.answer(
+        "Привет! Я Construction AI Bot. Выберите роль для работы:",
+        reply_markup=role_keyboard(),
+    )
+
+
+@router.message(Command("role"))
+async def role_handler(message: Message) -> None:
+    await message.answer("Выберите новую роль:", reply_markup=role_keyboard())
+
+
+@router.callback_query(F.data.startswith("role:"))
+async def role_callback_handler(callback: CallbackQuery) -> None:
+    role = callback.data.split(":", maxsplit=1)[1]
+    user_roles[callback.from_user.id] = role
+    await callback.message.answer(f"Роль переключена: {ROLE_NAMES.get(role, role)}")
+    await callback.answer("Роль сохранена")
+
+
+@router.message(Command("tk"))
+async def tk_start_handler(message: Message, state: FSMContext) -> None:
+    await state.set_state(TKForm.work_type)
+    await message.answer("Введите вид работ:", reply_markup=cancel_keyboard())
+
+
+@router.message(TKForm.work_type)
+async def tk_work_type_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(work_type=message.text)
+    await state.set_state(TKForm.object_name)
+    await message.answer("Введите наименование объекта:")
+
+
+@router.message(TKForm.object_name)
+async def tk_object_name_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(object_name=message.text)
+    await state.set_state(TKForm.volume)
+    await message.answer("Введите объём работ (число):")
+
+
+@router.message(TKForm.volume)
+async def tk_volume_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(volume=message.text)
+    await state.set_state(TKForm.unit)
+    await message.answer("Введите единицу измерения (например: м², м³, шт.):")
+
+
+@router.message(TKForm.unit)
+async def tk_unit_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(unit=message.text)
+    data = await state.get_data()
+    await state.clear()
+
+    payload = {
+        "work_type": data["work_type"],
+        "object_name": data["object_name"],
+        "volume": float(data["volume"]),
+        "unit": data["unit"],
+        "session_id": str(message.from_user.id),
+        "role": _get_user_role(message.from_user.id),
+    }
+    response = await api_client.post("/api/generate/tk", payload)
+    await _send_generated_document(message, response, "tk")
+
+
+@router.message(Command("letter"))
+async def letter_start_handler(message: Message, state: FSMContext) -> None:
+    await state.set_state(LetterForm.letter_type)
+    await message.answer(
+        "Введите тип письма (запрос, претензия, уведомление, ответ):",
+        reply_markup=cancel_keyboard(),
+    )
+
+
+@router.message(LetterForm.letter_type)
+async def letter_type_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(letter_type=message.text)
+    await state.set_state(LetterForm.addressee)
+    await message.answer("Введите адресата:")
+
+
+@router.message(LetterForm.addressee)
+async def letter_addressee_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(addressee=message.text)
+    await state.set_state(LetterForm.subject)
+    await message.answer("Введите тему письма:")
+
+
+@router.message(LetterForm.subject)
+async def letter_subject_handler(message: Message, state: FSMContext) -> None:
+    await state.update_data(subject=message.text)
+    await state.set_state(LetterForm.body_points)
+    await message.answer("Введите тезисы письма (через ';'):")
+
+
+@router.message(LetterForm.body_points)
+async def letter_body_points_handler(message: Message, state: FSMContext) -> None:
+    body_points = [p.strip() for p in (message.text or "").split(";") if p.strip()]
+    await state.update_data(body_points=body_points)
+    data = await state.get_data()
+    await state.clear()
+
+    payload = {
+        "letter_type": data["letter_type"],
+        "addressee": data["addressee"],
+        "subject": data["subject"],
+        "body_points": data["body_points"],
+        "session_id": str(message.from_user.id),
+        "role": _get_user_role(message.from_user.id),
+    }
+    response = await api_client.post("/api/generate/letter", payload)
+    await _send_generated_document(message, response, "letter")
+
+
+@router.message(F.text.casefold() == "отмена")
+async def cancel_handler(message: Message, state: FSMContext) -> None:
+    await state.clear()
+    await message.answer("Действие отменено.", reply_markup=ReplyKeyboardRemove())
+
+
+@router.message()
+async def text_message_handler(message: Message) -> None:
+    payload = {
+        "message": message.text,
+        "session_id": str(message.from_user.id),
+        "role": _get_user_role(message.from_user.id),
+    }
+    response = await api_client.post("/api/chat", payload)
+    await message.answer(response.get("reply", "Нет ответа от API"))
+
+
+async def _send_generated_document(message: Message, response: Mapping, doc_prefix: str) -> None:
+    document = response.get("document")
+    if isinstance(document, Mapping):
+        text_payload = json.dumps(document, ensure_ascii=False, indent=2)
+    else:
+        text_payload = str(document)
+
+    file_data = text_payload.encode("utf-8")
+    input_file = BufferedInputFile(file_data, filename=f"{doc_prefix}_{message.from_user.id}.txt")
+    await message.answer_document(input_file, caption="Документ сформирован.")
+    await message.answer("Готово ✅", reply_markup=ReplyKeyboardRemove())

--- a/telegram/keyboards.py
+++ b/telegram/keyboards.py
@@ -1,0 +1,28 @@
+"""Клавиатуры для Telegram-бота."""
+
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, KeyboardButton, ReplyKeyboardMarkup
+
+ROLE_BUTTONS = [
+    ("ПТО", "pto_engineer"),
+    ("Прораб", "foreman"),
+    ("Тендеры", "tender_specialist"),
+    ("Админ", "admin"),
+]
+
+
+def role_keyboard() -> InlineKeyboardMarkup:
+    """Inline-клавиатура выбора роли."""
+    buttons = [
+        [InlineKeyboardButton(text=title, callback_data=f"role:{role}")]
+        for title, role in ROLE_BUTTONS
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def cancel_keyboard() -> ReplyKeyboardMarkup:
+    """Reply-клавиатура с отменой текущего сценария."""
+    return ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text="Отмена")]],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    )

--- a/tests/test_telegram_handlers.py
+++ b/tests/test_telegram_handlers.py
@@ -1,0 +1,95 @@
+"""Тесты Telegram хэндлеров."""
+
+import asyncio
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+def _install_aiogram_stubs() -> None:
+    aiogram = types.ModuleType("aiogram")
+
+    class DummyRouter:
+        def message(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def callback_query(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    class DummyF:
+        def __getattr__(self, _name):
+            return self
+
+        def startswith(self, *_args, **_kwargs):
+            return self
+
+        def casefold(self):
+            return self
+
+        def __eq__(self, _other):
+            return self
+
+    aiogram.F = DummyF()
+    aiogram.Router = DummyRouter
+
+    filters = types.ModuleType("aiogram.filters")
+    filters.Command = lambda value: value
+
+    fsm_context = types.ModuleType("aiogram.fsm.context")
+    fsm_context.FSMContext = object
+
+    fsm_state = types.ModuleType("aiogram.fsm.state")
+    fsm_state.State = object
+    fsm_state.StatesGroup = object
+
+    types_mod = types.ModuleType("aiogram.types")
+    types_mod.BufferedInputFile = object
+    types_mod.CallbackQuery = object
+    types_mod.Message = object
+    types_mod.ReplyKeyboardRemove = object
+    types_mod.InlineKeyboardButton = object
+    types_mod.InlineKeyboardMarkup = object
+    types_mod.KeyboardButton = object
+    types_mod.ReplyKeyboardMarkup = object
+
+    sys.modules["aiogram"] = aiogram
+    sys.modules["aiogram.filters"] = filters
+    sys.modules["aiogram.fsm.context"] = fsm_context
+    sys.modules["aiogram.fsm.state"] = fsm_state
+    sys.modules["aiogram.types"] = types_mod
+
+
+def test_text_handler_calls_chat_endpoint(monkeypatch):
+    _install_aiogram_stubs()
+
+    handlers = importlib.import_module("telegram.handlers")
+
+    post_mock = AsyncMock(return_value={"reply": "ok"})
+    monkeypatch.setattr(handlers.api_client, "post", post_mock)
+    handlers.user_roles[42] = "foreman"
+
+    message = SimpleNamespace(
+        text="Привет",
+        from_user=SimpleNamespace(id=42),
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handlers.text_message_handler(message))
+
+    post_mock.assert_awaited_once_with(
+        "/api/chat",
+        {
+            "message": "Привет",
+            "session_id": "42",
+            "role": "foreman",
+        },
+    )
+    message.answer.assert_awaited_once_with("ok")


### PR DESCRIPTION
### Motivation
- Добавить Telegram-интерфейс для взаимодействия с Core API, чтобы пользователи могли общаться с оркестратором и запускать генерацию документов через бота. 
- Реализовать пошаговые FSM-диалоги для формирования запросов на генерацию ТК и деловых писем и вернуть результат в виде файла. 
- Обеспечить простую конфигурацию через переменные окружения и возможность запуска бота в `docker-compose`.

### Description
- Добавлен пакет `telegram/` с файлами `bot.py`, `handlers.py`, `keyboards.py` реализующими инициализацию `Bot`/`Dispatcher`, хэндлеры для `/start`, `/role`, обработку текста и FSM для `/tk` и `/letter`, а также отправку сгенерированных документов пользователю. 
- В `config/settings.py` добавлены настройки `bot_token` и `core_api_url` и `settings` настроен на чтение из `.env`. 
- Обновлён `.env.example` с переменными `BOT_TOKEN` и `CORE_API_URL`. 
- В `docker-compose.yml` добавлен сервис `telegram-bot` с командой `python -m telegram.bot`. 
- В `pyproject.toml` добавлена зависимость `aiogram>=3.13.0`. 
- Добавлен тест `tests/test_telegram_handlers.py`, который мокирует `api_client.post` и проверяет, что обработчик текстового сообщения вызывает `POST /api/chat` с правильным `message`, `session_id` и `role`.

### Testing
- Запущен тест `pytest -q tests/test_telegram_handlers.py`, который мокирует транспорт и проверяет поведение текстового хэндлера, и он прошёл (`1 passed`, предупреждение `pytest` про `asyncio_mode` не влияет на результат). 
- Тест проверяет корректность вызова API через мок `handlers.api_client.post` и валидацию ответа бота (проверяется вызов `message.answer`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcaa6da7c0832f85184703f49e5512)