### PR TITLE
Migrate session memory and generated docs to SQLite

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -7,12 +7,13 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.routes import chat, generate, health
 from config.settings import settings
+from core.database import init_db
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown events."""
-    # TODO: инициализация ChromaDB, загрузка orchestrator.json
+    await init_db(settings.sqlite_db_path)
     print("🚀 Construction AI Core запускается...")
     yield
     print("🛑 Construction AI Core останавливается...")

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -14,15 +14,16 @@ from pydantic import BaseModel, Field, field_validator
 from core.orchestrator import Orchestrator
 from core.pdf_parser import PDFParser
 
+
 router = APIRouter()
 orchestrator = Orchestrator()
+session_memory = orchestrator.session_memory
 pdf_parser = PDFParser()
 
 ALLOWED_UNITS = ["м³", "м²", "пог.м.", "шт.", "т", "кг"]
 MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024
 ANALYZE_TIMEOUT_SECONDS = 120
 
-DOCX_CACHE: dict[str, bytes] = {}
 
 
 class TKRequest(BaseModel):
@@ -156,7 +157,13 @@ async def generate_tk(request: TKRequest):
     state = result.get("state", {}) if isinstance(result, dict) else {}
     docx_bytes = state.get("docx_bytes")
     if isinstance(docx_bytes, bytes):
-        DOCX_CACHE[session_id] = docx_bytes
+        await session_memory.save_document(
+            session_id=session_id,
+            doc_type="tk",
+            filename=f"tk_{session_id}.docx",
+            docx_bytes=docx_bytes,
+            sha256=(state.get("verification", {}) or {}).get("sha256") if isinstance(state, dict) else None,
+        )
 
     document = (
         state.get("final_output")
@@ -282,7 +289,13 @@ async def generate_ks(request: KSRequest):
     docx_bytes = state.get("docx_bytes")
     docx_bytes_key = session_id
     if isinstance(docx_bytes, bytes):
-        DOCX_CACHE[docx_bytes_key] = docx_bytes
+        await session_memory.save_document(
+            session_id=docx_bytes_key,
+            doc_type="ks",
+            filename=f"ks_{docx_bytes_key}.docx",
+            docx_bytes=docx_bytes,
+            sha256=(state.get("verification", {}) or {}).get("sha256") if isinstance(state, dict) else None,
+        )
 
     return KSResponse(
         session_id=result["session_id"],
@@ -371,7 +384,9 @@ async def analyze_document(
 @router.get("/generate/tk/{session_id}/download")
 async def download_tk_docx(session_id: str):
     """Скачать ранее сгенерированный DOCX по session_id."""
-    docx_bytes = DOCX_CACHE.get(session_id)
+    documents = await session_memory.get_session_documents(session_id)
+    tk_document = next((doc for doc in documents if doc.get("doc_type") == "tk"), None)
+    docx_bytes = tk_document.get("docx_bytes") if tk_document else None
     if not docx_bytes:
         raise HTTPException(status_code=404, detail="DOCX not found for this session")
 
@@ -385,14 +400,16 @@ async def download_tk_docx(session_id: str):
         media_type=(
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         ),
-        filename=f"tk_{session_id}.docx",
+        filename=tk_document.get("filename") if tk_document else f"tk_{session_id}.docx",
     )
 
 
 @router.get("/generate/ks/{session_id}/download")
 async def download_ks_docx(session_id: str):
     """Скачать ранее сгенерированный DOCX КС-2/КС-3 по session_id."""
-    docx_bytes = DOCX_CACHE.get(session_id)
+    documents = await session_memory.get_session_documents(session_id)
+    ks_document = next((doc for doc in documents if doc.get("doc_type") == "ks"), None)
+    docx_bytes = ks_document.get("docx_bytes") if ks_document else None
     if not docx_bytes:
         raise HTTPException(status_code=404, detail="DOCX not found for this session")
 
@@ -406,5 +423,5 @@ async def download_ks_docx(session_id: str):
         media_type=(
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         ),
-        filename=f"ks_{session_id}.docx",
+        filename=ks_document.get("filename") if ks_document else f"ks_{session_id}.docx",
     )

--- a/config/settings.py
+++ b/config/settings.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
 
     # ── Database ───────────────────────────────
     database_url: str = "sqlite:///./data/construction_ai.db"
+    sqlite_db_path: str = "./data/construction_ai.db"
 
     # ── ChromaDB ───────────────────────────────
     # ENV: CHROMA_PERSIST_DIR

--- a/core/database.py
+++ b/core/database.py
@@ -1,0 +1,71 @@
+"""Утилиты работы с SQLite для хранения сессий и документов."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiosqlite
+
+
+def _is_sqlite_uri(db_path: str) -> bool:
+    return db_path.startswith("file:")
+
+
+@asynccontextmanager
+async def get_db(db_path: str) -> AsyncIterator[aiosqlite.Connection]:
+    """Вернуть контекстный менеджер подключения к SQLite."""
+    if not _is_sqlite_uri(db_path):
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    connection = await aiosqlite.connect(db_path, uri=_is_sqlite_uri(db_path))
+    connection.row_factory = aiosqlite.Row
+    await connection.execute("PRAGMA foreign_keys = ON;")
+    try:
+        yield connection
+    finally:
+        await connection.close()
+
+
+async def init_db(db_path: str) -> None:
+    """Инициализировать таблицы хранилища сессий."""
+    async with get_db(db_path) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+              id TEXT PRIMARY KEY,
+              role TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              last_active TEXT NOT NULL
+            );
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              role TEXT NOT NULL,
+              content TEXT NOT NULL,
+              agent_id TEXT,
+              timestamp TEXT NOT NULL,
+              FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session_id TEXT NOT NULL,
+              doc_type TEXT NOT NULL,
+              filename TEXT NOT NULL,
+              docx_bytes BLOB,
+              sha256 TEXT,
+              created_at TEXT NOT NULL,
+              FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+            """
+        )
+        await db.commit()

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -197,7 +197,7 @@ class Orchestrator:
             "message": message,
             "session_id": session_id,
             "role": role,
-            "conversation_history": self.session_memory.get(session_id, last_n=10),
+            "conversation_history": await self.session_memory.get(session_id, last_n=10),
             "history": [],
             "audit_log": [],
             "critic_iterations": 0,
@@ -241,7 +241,7 @@ class Orchestrator:
             Словарь с ответом и метаданными.
         """
         session_id = session_id or str(uuid.uuid4())
-        self.session_memory.add(session_id, role="user", content=message)
+        await self.session_memory.add(session_id, role="user", content=message)
 
         intent = intent or await self._detect_intent(message)
 
@@ -255,7 +255,7 @@ class Orchestrator:
                 extra_state=extra_state,
             )
             if result.get("reply"):
-                self.session_memory.add(
+                await self.session_memory.add(
                     session_id, role="assistant", content=str(result["reply"])
                 )
             return result
@@ -269,7 +269,7 @@ class Orchestrator:
                 prompt=message,
                 system_prompt=system_prompt,
             )
-            self.session_memory.add(session_id, role="assistant", content=response.text)
+            await self.session_memory.add(session_id, role="assistant", content=response.text)
             return {
                 "reply": response.text,
                 "session_id": session_id,
@@ -277,7 +277,7 @@ class Orchestrator:
                 "confidence": None,
             }
         except Exception as e:
-            self.session_memory.add(
+            await self.session_memory.add(
                 session_id,
                 role="assistant",
                 content=f"Ошибка обработки: {e}",

--- a/core/session_memory.py
+++ b/core/session_memory.py
@@ -1,37 +1,130 @@
-"""In-memory хранилище истории сообщений сессии."""
+"""SQLite-хранилище истории сообщений сессии и документов."""
 
 from __future__ import annotations
 
-from collections import defaultdict
 from datetime import datetime, timezone
+
+from config.settings import settings
+from core.database import get_db
 
 
 class SessionMemory:
-    """Простое in-memory хранилище истории по session_id."""
+    """Хранилище истории по session_id в SQLite."""
 
-    def __init__(self, max_messages: int = 50) -> None:
+    def __init__(self, max_messages: int = 50, db_path: str | None = None) -> None:
         self.max_messages = max_messages
-        self._store: dict[str, list[dict[str, str]]] = defaultdict(list)
+        self.db_path = db_path or settings.sqlite_db_path
 
-    def add(self, session_id: str, role: str, content: str) -> None:
+    async def _ensure_session(self, session_id: str, role: str, timestamp: str) -> None:
+        async with get_db(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO sessions (id, role, created_at, last_active)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    role = excluded.role,
+                    last_active = excluded.last_active
+                """,
+                (session_id, role, timestamp, timestamp),
+            )
+            await db.commit()
+
+    async def add(self, session_id: str, role: str, content: str) -> None:
         """Добавить сообщение в историю сессии."""
-        message = {
-            "role": role,
-            "content": content,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        history = self._store[session_id]
-        history.append(message)
-        if len(history) > self.max_messages:
-            del history[0 : len(history) - self.max_messages]
+        timestamp = datetime.now(timezone.utc).isoformat()
+        await self._ensure_session(session_id=session_id, role=role, timestamp=timestamp)
 
-    def get(self, session_id: str, last_n: int = 10) -> list[dict[str, str]]:
+        async with get_db(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO messages (session_id, role, content, agent_id, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (session_id, role, content, None, timestamp),
+            )
+            await db.execute(
+                """
+                DELETE FROM messages
+                WHERE id IN (
+                    SELECT id FROM messages
+                    WHERE session_id = ?
+                    ORDER BY id DESC
+                    LIMIT -1 OFFSET ?
+                )
+                """,
+                (session_id, self.max_messages),
+            )
+            await db.execute(
+                "UPDATE sessions SET last_active = ? WHERE id = ?",
+                (timestamp, session_id),
+            )
+            await db.commit()
+
+    async def get(self, session_id: str, last_n: int = 10) -> list[dict[str, str]]:
         """Вернуть последние N сообщений сессии."""
-        history = self._store.get(session_id, [])
         if last_n <= 0:
             return []
-        return history[-last_n:]
 
-    def clear(self, session_id: str) -> None:
-        """Очистить историю конкретной сессии."""
-        self._store.pop(session_id, None)
+        async with get_db(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT role, content, timestamp
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (session_id, last_n),
+            )
+            rows = await cursor.fetchall()
+
+        return [dict(row) for row in reversed(rows)]
+
+    async def clear(self, session_id: str) -> None:
+        """Очистить историю и документы конкретной сессии."""
+        async with get_db(self.db_path) as db:
+            await db.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            await db.execute("DELETE FROM documents WHERE session_id = ?", (session_id,))
+            await db.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            await db.commit()
+
+    async def get_session_documents(self, session_id: str) -> list[dict]:
+        """Получить список документов сессии (новые первыми)."""
+        async with get_db(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT id, session_id, doc_type, filename, docx_bytes, sha256, created_at
+                FROM documents
+                WHERE session_id = ?
+                ORDER BY id DESC
+                """,
+                (session_id,),
+            )
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    async def save_document(
+        self,
+        session_id: str,
+        doc_type: str,
+        filename: str,
+        docx_bytes: bytes,
+        sha256: str | None,
+    ) -> None:
+        """Сохранить сгенерированный документ в SQLite."""
+        timestamp = datetime.now(timezone.utc).isoformat()
+        await self._ensure_session(session_id=session_id, role="assistant", timestamp=timestamp)
+
+        async with get_db(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO documents (session_id, doc_type, filename, docx_bytes, sha256, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (session_id, doc_type, filename, docx_bytes, sha256, timestamp),
+            )
+            await db.execute(
+                "UPDATE sessions SET last_active = ? WHERE id = ?",
+                (timestamp, session_id),
+            )
+            await db.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pdfplumber>=0.11.0",
     "chromadb>=0.5.0",
     "sentence-transformers>=3.0.0",
+    "aiosqlite>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_session_memory.py
+++ b/tests/test_session_memory.py
@@ -1,41 +1,80 @@
-"""Тесты SessionMemory."""
+"""Тесты SessionMemory c SQLite backend."""
 
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from core.database import init_db
 from core.session_memory import SessionMemory
 
 
-def test_session_memory_fifo_limit() -> None:
+@pytest.fixture
+async def memory() -> SessionMemory:
+    """SessionMemory на in-memory SQLite (shared cache)."""
+    db_path = "file::memory:?cache=shared"
+    keeper = await aiosqlite.connect(db_path, uri=True)
+    try:
+        await init_db(db_path)
+        yield SessionMemory(max_messages=50, db_path=db_path)
+    finally:
+        await keeper.close()
+
+
+@pytest.mark.asyncio
+async def test_session_memory_fifo_limit(memory: SessionMemory) -> None:
     """При переполнении хранилища старые сообщения удаляются по FIFO."""
-    memory = SessionMemory(max_messages=50)
     session_id = "s-fifo"
 
     for idx in range(55):
-        memory.add(session_id, role="user", content=f"msg-{idx}")
+        await memory.add(session_id, role="user", content=f"msg-{idx}")
 
-    history = memory.get(session_id, last_n=100)
+    history = await memory.get(session_id, last_n=100)
     assert len(history) == 50
     assert history[0]["content"] == "msg-5"
     assert history[-1]["content"] == "msg-54"
 
 
-def test_session_memory_get_last_n() -> None:
+@pytest.mark.asyncio
+async def test_session_memory_get_last_n(memory: SessionMemory) -> None:
     """get(last_n) должен возвращать только последние N сообщений."""
-    memory = SessionMemory()
     session_id = "s-last-n"
 
     for idx in range(6):
-        memory.add(session_id, role="assistant", content=f"reply-{idx}")
+        await memory.add(session_id, role="assistant", content=f"reply-{idx}")
 
-    history = memory.get(session_id, last_n=3)
+    history = await memory.get(session_id, last_n=3)
     assert [item["content"] for item in history] == ["reply-3", "reply-4", "reply-5"]
 
 
-def test_session_memory_clear() -> None:
+@pytest.mark.asyncio
+async def test_session_memory_clear(memory: SessionMemory) -> None:
     """clear должен удалять историю сессии."""
-    memory = SessionMemory()
     session_id = "s-clear"
 
-    memory.add(session_id, role="agent", content="internal-note")
-    assert len(memory.get(session_id)) == 1
+    await memory.add(session_id, role="agent", content="internal-note")
+    assert len(await memory.get(session_id)) == 1
 
-    memory.clear(session_id)
-    assert memory.get(session_id) == []
+    await memory.clear(session_id)
+    assert await memory.get(session_id) == []
+
+
+@pytest.mark.asyncio
+async def test_session_memory_documents(memory: SessionMemory) -> None:
+    """save_document/get_session_documents должны работать через SQLite."""
+    session_id = "s-docs"
+    payload = b"docx-content"
+
+    await memory.save_document(
+        session_id=session_id,
+        doc_type="tk",
+        filename="tk_s-docs.docx",
+        docx_bytes=payload,
+        sha256="abc123",
+    )
+
+    docs = await memory.get_session_documents(session_id)
+    assert len(docs) == 1
+    assert docs[0]["doc_type"] == "tk"
+    assert docs[0]["docx_bytes"] == payload
+    assert docs[0]["sha256"] == "abc123"


### PR DESCRIPTION
### Motivation
- Replace in-memory session storage and ephemeral DOCX cache with a durable SQLite backend so sessions, messages and generated documents persist across restarts.
- Provide an async DB layer compatible with the existing async application flow and keep the same public session API surface to minimize caller changes.

### Description
- Added `core/database.py` with an async context manager `get_db(db_path)` and schema bootstrap `init_db(db_path)` to create `sessions`, `messages`, and `documents` tables.
- Rewrote `core/session_memory.py` to use `aiosqlite` (no in-memory dict); methods `add`, `get`, `clear` remain (now `async`), and new methods `save_document(...)` and `get_session_documents(...)` were added.
- Updated `core/orchestrator.py` to `await` session memory calls so conversation history and message writes use the async SQLite backend.
- Replaced in-memory `DOCX_CACHE` in `api/routes/generate.py` with calls to `session_memory.save_document(...)` and updated download endpoints to fetch bytes via `session_memory.get_session_documents(...)`.
- Wired DB initialization into FastAPI lifespan in `api/main.py` by calling `await init_db(settings.sqlite_db_path)` at startup.
- Added `sqlite_db_path = "./data/construction_ai.db"` to `config/settings.py` and added `aiosqlite>=0.20.0` to `pyproject.toml` dependencies.
- Updated `tests/test_session_memory.py` to async tests using an in-memory shared-cache SQLite (`file::memory:?cache=shared`) and added tests for document persistence.

### Testing
- Ran static/compile checks: `python -m compileall core api config tests` succeeded and `python -m py_compile api/routes/generate.py core/session_memory.py core/database.py core/orchestrator.py` succeeded.
- Ran `pytest -q tests/test_session_memory.py tests/test_generate_tk.py tests/test_generate_ks.py` which failed during collection with `ModuleNotFoundError: No module named 'aiosqlite'` due to the test environment missing the `aiosqlite` package.
- Attempted to install dependencies with `pip install aiosqlite pytest-asyncio`, but installation failed because the environment cannot access the package index (proxy returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb0c8d5a0832fb543df4fac76b579)