### PR TITLE
Add middleware stack for API key auth, rate limiting, and structured logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ DEFAULT_LLM_PROVIDER=perplexity
 API_HOST=0.0.0.0
 API_PORT=8000
 DEBUG=true
+LOG_LEVEL=INFO
+API_KEYS=["key1","key2"]
 
 # ── База данных ────────────────────────────────
 DATABASE_URL=sqlite:///./data/construction_ai.db

--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,17 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi.errors import RateLimitExceeded
 
+from api.middleware import (
+    APIKeyMiddleware,
+    RequestLoggingMiddleware,
+    SlowAPIMiddleware,
+    configure_structlog,
+    limiter,
+    rate_limit_exceeded_handler,
+    setup_rate_limiter,
+)
 from api.routes import chat, generate, health
 from config.settings import settings
 from core.database import init_db
@@ -13,6 +23,7 @@ from core.database import init_db
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown events."""
+    configure_structlog()
     await init_db(settings.sqlite_db_path)
     print("🚀 Construction AI Core запускается...")
     yield
@@ -37,8 +48,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(APIKeyMiddleware)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # ── Routes ─────────────────────────────────────
 app.include_router(health.router, tags=["health"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
 app.include_router(generate.router, prefix="/api", tags=["generate"])
+setup_rate_limiter(app.routes)

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -1,0 +1,158 @@
+"""Middleware and infrastructure for API security, rate limits and logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import traceback
+from collections.abc import Awaitable, Callable
+
+import structlog
+from fastapi import Request
+from fastapi.responses import JSONResponse, Response
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import BaseRoute
+
+from config.settings import settings
+
+EXCLUDED_PATHS = {"/health", "/docs", "/openapi.json"}
+limiter = Limiter(key_func=get_remote_address, default_limits=[])
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Simple API key middleware based on `X-API-Key` header."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if request.url.path in EXCLUDED_PATHS:
+            return await call_next(request)
+
+        provided_key = request.headers.get("X-API-Key")
+        if provided_key not in settings.api_keys:
+            return JSONResponse(status_code=401, content={"detail": "Invalid API key"})
+        return await call_next(request)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Structured logging for every incoming request."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        started = time.perf_counter()
+        logger = structlog.get_logger("api.requests")
+        session_id = request.headers.get("X-Session-ID") or request.query_params.get("session_id")
+        traceback_text: str | None = None
+
+        if session_id is None:
+            body = await request.body()
+            if body:
+                try:
+                    payload = json.loads(body.decode("utf-8"))
+                    if isinstance(payload, dict):
+                        session_id = payload.get("session_id")
+                except (ValueError, UnicodeDecodeError):
+                    session_id = None
+
+            async def _receive() -> dict[str, object]:
+                return {"type": "http.request", "body": body, "more_body": False}
+
+            request._receive = _receive  # type: ignore[attr-defined]
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            traceback_text = traceback.format_exc()
+            duration_ms = round((time.perf_counter() - started) * 1000, 2)
+            logger.exception(
+                "request_failed",
+                method=request.method,
+                path=request.url.path,
+                status_code=500,
+                duration_ms=duration_ms,
+                session_id=session_id,
+                traceback=traceback_text,
+            )
+            raise
+
+        duration_ms = round((time.perf_counter() - started) * 1000, 2)
+        logger.info(
+            "request_finished",
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration_ms=duration_ms,
+            session_id=session_id,
+        )
+        return response
+
+
+def configure_structlog() -> None:
+    """Initialize stdlib logging and structlog processors."""
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level.upper(), logging.INFO),
+        format="%(message)s",
+    )
+    if settings.debug:
+        processors: list[object] = [
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.dev.ConsoleRenderer(colors=True),
+        ]
+    else:
+        processors = [
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ]
+
+    structlog.configure(
+        processors=processors,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Custom 429 body for exceeded limits."""
+    return JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"})
+
+
+def setup_rate_limiter(app_routes: list[BaseRoute]) -> None:
+    """Attach per-route limits according to project rules."""
+    for route in app_routes:
+        path = getattr(route, "path", "")
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            continue
+
+        if path == "/api/chat":
+            route.endpoint = limiter.limit("60/minute")(endpoint)
+        elif path.startswith("/api/generate/"):
+            route.endpoint = limiter.limit("10/minute")(endpoint)
+        elif path.startswith("/api/analyze/"):
+            route.endpoint = limiter.limit("5/minute")(endpoint)
+
+
+__all__ = [
+    "APIKeyMiddleware",
+    "RequestLoggingMiddleware",
+    "SlowAPIMiddleware",
+    "configure_structlog",
+    "limiter",
+    "rate_limit_exceeded_handler",
+    "setup_rate_limiter",
+]

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from core.orchestrator import Orchestrator
@@ -29,12 +29,13 @@ class ChatResponse(BaseModel):
 
 
 @router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+async def chat(payload: ChatRequest, request: Request):
     """Обработать сообщение пользователя через оркестратор."""
-    session_id = request.session_id or str(uuid.uuid4())
+    _ = request
+    session_id = payload.session_id or str(uuid.uuid4())
     result = await orchestrator.process(
-        message=request.message,
+        message=payload.message,
         session_id=session_id,
-        role=request.role,
+        role=payload.role,
     )
     return result

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -7,7 +7,7 @@ import uuid
 from enum import Enum
 from pathlib import Path
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, field_validator
 
@@ -131,15 +131,16 @@ class LetterResponse(BaseModel):
 
 
 @router.post("/generate/tk", response_model=TKResponse)
-async def generate_tk(request: TKRequest):
+async def generate_tk(payload: TKRequest, request: Request):
     """Генерация технологической карты (ТК) через orchestrator."""
-    session_id = request.session_id or str(uuid.uuid4())
-    norms_text = ", ".join(request.norms) if request.norms else "не указаны"
+    _ = request
+    session_id = payload.session_id or str(uuid.uuid4())
+    norms_text = ", ".join(payload.norms) if payload.norms else "не указаны"
     message = (
         "Сформируй технологическую карту на русском языке.\n"
-        f"Вид работ: {request.work_type}.\n"
-        f"Наименование объекта: {request.object_name}.\n"
-        f"Объём работ: {request.volume} {request.unit}.\n"
+        f"Вид работ: {payload.work_type}.\n"
+        f"Наименование объекта: {payload.object_name}.\n"
+        f"Объём работ: {payload.volume} {payload.unit}.\n"
         f"Нормативы: {norms_text}.\n"
         "Подготовь структурированный документ для последующего DOCX-форматирования."
     )
@@ -148,7 +149,7 @@ async def generate_tk(request: TKRequest):
         result = await orchestrator.process(
             message=message,
             session_id=session_id,
-            role=request.role,
+            role=payload.role,
             intent="generate_tk",
         )
     except Exception as exc:
@@ -206,15 +207,16 @@ def _extract_legal_references(history: list[dict]) -> list[str]:
 
 
 @router.post("/generate/letter", response_model=LetterResponse)
-async def generate_letter_v2(request: LetterRequest):
+async def generate_letter_v2(payload: LetterRequest, request: Request):
     """Генерация делового письма через orchestrator."""
-    session_id = request.session_id or str(uuid.uuid4())
-    body_points_text = "; ".join(request.body_points)
-    contract_number = request.contract_number or "не указан"
+    _ = request
+    session_id = payload.session_id or str(uuid.uuid4())
+    body_points_text = "; ".join(payload.body_points)
+    contract_number = payload.contract_number or "не указан"
     message = (
-        f"Тип: {request.letter_type.value}. "
-        f"Получатель: {request.addressee}. "
-        f"Тема: {request.subject}. "
+        f"Тип: {payload.letter_type.value}. "
+        f"Получатель: {payload.addressee}. "
+        f"Тема: {payload.subject}. "
         f"Тезисы: {body_points_text}. "
         f"Договор: {contract_number}."
     )
@@ -223,9 +225,9 @@ async def generate_letter_v2(request: LetterRequest):
         result = await orchestrator.process(
             message=message,
             session_id=session_id,
-            role=request.role,
+            role=payload.role,
             intent="generate_letter",
-            include_legal_expert=request.include_npa,
+            include_legal_expert=payload.include_npa,
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
@@ -245,24 +247,25 @@ async def generate_letter_v2(request: LetterRequest):
 
 
 @router.post("/generate/ks", response_model=KSResponse)
-async def generate_ks(request: KSRequest):
+async def generate_ks(payload: KSRequest, request: Request):
     """Генерация КС-2/КС-3 через orchestrator pipeline."""
-    session_id = request.session_id or str(uuid.uuid4())
-    work_names = ", ".join(item.name for item in request.work_items)
+    _ = request
+    session_id = payload.session_id or str(uuid.uuid4())
+    work_names = ", ".join(item.name for item in payload.work_items)
     message = (
         "Сформируй КС-2/КС-3 на русском языке. "
-        f"Объект: {request.object_name}. "
-        f"Договор: {request.contract_number}. "
-        f"Период: {request.period_from} — {request.period_to}. "
+        f"Объект: {payload.object_name}. "
+        f"Договор: {payload.contract_number}. "
+        f"Период: {payload.period_from} — {payload.period_to}. "
         f"Наименования работ: {work_names}."
     )
 
     extra_state = {
-        "object_name": request.object_name,
-        "contract_number": request.contract_number,
-        "period_from": request.period_from,
-        "period_to": request.period_to,
-        "calculation_params": {"work_items": [item.model_dump() for item in request.work_items]},
+        "object_name": payload.object_name,
+        "contract_number": payload.contract_number,
+        "period_from": payload.period_from,
+        "period_to": payload.period_to,
+        "calculation_params": {"work_items": [item.model_dump() for item in payload.work_items]},
         "context": (
             "Подготовь описательную часть КС-2 для следующих работ: "
             f"{work_names}."
@@ -273,7 +276,7 @@ async def generate_ks(request: KSRequest):
         result = await orchestrator.process(
             message=message,
             session_id=session_id,
-            role=request.role,
+            role=payload.role,
             intent="generate_ks",
             extra_state=extra_state,
         )
@@ -327,11 +330,13 @@ def _extract_risks(analysis: str) -> list[str]:
 
 @router.post("/analyze/document")
 async def analyze_document(
+    request: Request,
     file: UploadFile = File(...),
     role: str = Form("tender_specialist"),
     session_id: str | None = Form(None),
 ):
     """Анализ загруженного PDF-документа через orchestrator."""
+    _ = request
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Supported format: PDF only")
 
@@ -382,8 +387,9 @@ async def analyze_document(
 
 
 @router.get("/generate/tk/{session_id}/download")
-async def download_tk_docx(session_id: str):
+async def download_tk_docx(session_id: str, request: Request):
     """Скачать ранее сгенерированный DOCX по session_id."""
+    _ = request
     documents = await session_memory.get_session_documents(session_id)
     tk_document = next((doc for doc in documents if doc.get("doc_type") == "tk"), None)
     docx_bytes = tk_document.get("docx_bytes") if tk_document else None
@@ -405,8 +411,9 @@ async def download_tk_docx(session_id: str):
 
 
 @router.get("/generate/ks/{session_id}/download")
-async def download_ks_docx(session_id: str):
+async def download_ks_docx(session_id: str, request: Request):
     """Скачать ранее сгенерированный DOCX КС-2/КС-3 по session_id."""
+    _ = request
     documents = await session_memory.get_session_documents(session_id)
     ks_document = next((doc for doc in documents if doc.get("doc_type") == "ks"), None)
     docx_bytes = ks_document.get("docx_bytes") if ks_document else None

--- a/config/settings.py
+++ b/config/settings.py
@@ -9,7 +9,9 @@ class Settings(BaseSettings):
     # ── API ────────────────────────────────────
     api_host: str = "0.0.0.0"
     api_port: int = 8000
-    debug: bool = True
+    debug: bool = False
+    log_level: str = "INFO"
+    api_keys: list[str] = []
 
     # ── LLM Providers ──────────────────────────
     perplexity_api_key: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "chromadb>=0.5.0",
     "sentence-transformers>=3.0.0",
     "aiosqlite>=0.20.0",
+    "slowapi>=0.1.9",
+    "structlog>=24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,72 @@
+"""Tests for API key middleware behavior."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.main import app
+from config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_request_without_api_key_returns_401():
+    """Protected endpoint should reject requests without X-API-Key."""
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post("/api/chat", json={"message": "ping"})
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid API key"}
+
+
+@pytest.mark.asyncio
+async def test_request_with_valid_api_key_returns_200(monkeypatch: pytest.MonkeyPatch):
+    """Protected endpoint should pass with a valid API key."""
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+
+    async def _fake_process(message: str, session_id: str, role: str):
+        return {
+            "reply": f"echo: {message}",
+            "session_id": session_id,
+            "agents_used": ["mock"],
+            "confidence": 1.0,
+        }
+
+    monkeypatch.setattr("api.routes.chat.orchestrator.process", _fake_process)
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/chat",
+                json={"message": "ping"},
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["reply"] == "echo: ping"
+    assert data["agents_used"] == ["mock"]
+
+
+@pytest.mark.asyncio
+async def test_health_is_accessible_without_api_key():
+    """Health endpoint should be excluded from API key check."""
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
### Motivation
- Защитить HTTP API простыми API-ключами и исключить публичные эндпойнты (`/health`, `/docs`, `/openapi.json`).
- Ограничить нагрузку на тяжёлые маршруты через rate limiting (per-IP) для `/api/chat`, `/api/generate/*` и `/api/analyze/*`.
- Обеспечить структурированный вывод логов (JSON в prod, цветной в dev) с полями `method`, `path`, `status_code`, `duration_ms` и `session_id` для удобства мониторинга и отладки.

### Description
- Добавлен `api/middleware.py` с `APIKeyMiddleware` (читает `X-API-Key` и сверяет с `settings.api_keys`), `RequestLoggingMiddleware` (structlog, тайминг, session_id extraction, traceback при 500), конфигом `configure_structlog()`, `slowapi`-лимитером и кастомным обработчиком превышения лимита (`429` с `{"detail": "Rate limit exceeded"}`).
- Интегрировано в `api/main.py`: инициализация `structlog` в `lifespan`, регистрация `SlowAPIMiddleware`, `RequestLoggingMiddleware`, `APIKeyMiddleware`, установка `app.state.limiter` и обработчика `RateLimitExceeded`, а также вызов `setup_rate_limiter(app.routes)` после регистрации роутов.
- Обновления конфигурации и окружения: в `config/settings.py` добавлены `api_keys: list[str] = []`, `log_level: str = "INFO"` и значение `debug` по умолчанию изменено на `False`, а в `.env.example` добавлены `API_KEYS` и `LOG_LEVEL`.
- Обновлён `pyproject.toml` чтобы добавить зависимости `slowapi>=0.1.9` и `structlog>=24.0.0`, скорректированы сигнатуры защищённых endpoint'ов в `api/routes/*` (добавлен `Request` аргумент), и добавлены тесты `tests/test_middleware.py` для проверки поведения middleware.

### Testing
- Включён тест `tests/test_middleware.py` с проверками: без `X-API-Key` → `401`, с валидным ключом → `200`, и `/health` без ключа → `200` (тесты добавлены в PR).
- Запуск `pytest -q tests/test_middleware.py tests/test_health.py` завершился ошибкой во время импорта из-за отсутствия зависимости `slowapi` (`ModuleNotFoundError`).
- Попытка установить зависимости `pip install slowapi>=0.1.9 structlog>=24.0.0` не удалась из-за сетевых/proxy ограничений в окружении, поэтому автоматический прогон тестов не прошёл в этой среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb219f7a0832f89a4d398ef743e9f)