### PR TITLE
Add Telegram webhook mode and /analyze PDF tender workflow

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,9 +2,10 @@
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi.errors import RateLimitExceeded
+from aiogram.types import Update
 
 from api.middleware import (
     APIKeyMiddleware,
@@ -18,6 +19,9 @@ from api.middleware import (
 from api.routes import chat, generate, health
 from config.settings import settings
 from core.database import init_db
+from telegram.bot import create_bot, create_dispatcher
+
+telegram_router = APIRouter()
 
 
 @asynccontextmanager
@@ -25,8 +29,17 @@ async def lifespan(app: FastAPI):
     """Startup / shutdown events."""
     configure_structlog()
     await init_db(settings.sqlite_db_path)
+    app.state.telegram_bot = None
+    app.state.telegram_dp = None
+    if settings.telegram_webhook_url and settings.bot_token:
+        app.state.telegram_bot = create_bot()
+        app.state.telegram_dp = create_dispatcher()
+        await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url)
     print("🚀 Construction AI Core запускается...")
     yield
+    if app.state.telegram_bot is not None:
+        await app.state.telegram_bot.delete_webhook(drop_pending_updates=False)
+        await app.state.telegram_bot.session.close()
     print("🛑 Construction AI Core останавливается...")
 
 
@@ -59,3 +72,19 @@ app.include_router(health.router, tags=["health"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
 app.include_router(generate.router, prefix="/api", tags=["generate"])
 setup_rate_limiter(app.routes)
+
+
+@telegram_router.post("/telegram/webhook")
+async def telegram_webhook_handler(request: Request) -> dict[str, bool]:
+    bot = request.app.state.telegram_bot
+    dp = request.app.state.telegram_dp
+    if bot is None or dp is None:
+        raise HTTPException(status_code=503, detail="Telegram webhook is not configured")
+
+    payload = await request.json()
+    update = Update.model_validate(payload, context={"bot": bot})
+    await dp.feed_update(bot, update)
+    return {"ok": True}
+
+
+app.include_router(telegram_router, tags=["telegram"])

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     bot_token: str = ""
     core_api_url: str = "http://api:8000"
     telegram_bot_token: str = ""
+    telegram_webhook_url: str = ""
 
     # ── tk-generator ───────────────────────────
     tk_generator_path: str = "../tk-generator"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,9 +41,16 @@ services:
       - api
     env_file:
       - .env
+    environment:
+      TELEGRAM_WEBHOOK_URL: ${TELEGRAM_WEBHOOK_URL:-}
     volumes:
       - .:/app
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
 # volumes:
 #   redis_data:

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -16,16 +16,25 @@ def create_dispatcher() -> Dispatcher:
     return dp
 
 
+def create_bot() -> Bot:
+    return Bot(
+        token=settings.bot_token,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+
+
 async def main() -> None:
     if not settings.bot_token:
         raise RuntimeError("BOT_TOKEN не задан в настройках")
 
-    bot = Bot(
-        token=settings.bot_token,
-        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
-    )
+    bot = create_bot()
     dp = create_dispatcher()
-    await dp.start_polling(bot)
+    if not settings.telegram_webhook_url:
+        await dp.start_polling(bot)
+        return
+
+    await bot.set_webhook(settings.telegram_webhook_url)
+    await asyncio.Event().wait()
 
 
 if __name__ == "__main__":

--- a/telegram/handlers.py
+++ b/telegram/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from io import BytesIO
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -14,7 +15,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import BufferedInputFile, CallbackQuery, Message, ReplyKeyboardRemove
 
 from config.settings import settings
-from telegram.keyboards import cancel_keyboard, role_keyboard
+from telegram.keyboards import cancel_keyboard, main_menu_keyboard, role_keyboard
 
 router = Router()
 
@@ -43,6 +44,7 @@ class TelegramCoreClient:
 
 
 api_client = TelegramCoreClient(base_url=settings.core_api_url.rstrip("/"))
+MAX_PDF_SIZE_BYTES = 20_971_520
 
 
 class TKForm(StatesGroup):
@@ -59,12 +61,20 @@ class LetterForm(StatesGroup):
     body_points = State()
 
 
+class AnalyzeForm(StatesGroup):
+    document = State()
+
+
 def _get_user_role(user_id: int) -> str:
     return user_roles.get(user_id, "pto_engineer")
 
 
 @router.message(Command("start"))
 async def start_handler(message: Message) -> None:
+    await message.answer(
+        "Привет! Я Construction AI Bot.",
+        reply_markup=main_menu_keyboard(),
+    )
     await message.answer(
         "Привет! Я Construction AI Bot. Выберите роль для работы:",
         reply_markup=role_keyboard(),
@@ -178,6 +188,38 @@ async def letter_body_points_handler(message: Message, state: FSMContext) -> Non
     await _send_generated_document(message, response, "letter")
 
 
+@router.message(Command("analyze"))
+@router.message(F.text == "📋 Анализ тендера")
+async def analyze_start_handler(message: Message, state: FSMContext) -> None:
+    await state.set_state(AnalyzeForm.document)
+    await message.answer("Отправь PDF-документ для анализа", reply_markup=cancel_keyboard())
+
+
+@router.message(AnalyzeForm.document, F.document)
+async def analyze_document_handler(message: Message, state: FSMContext) -> None:
+    document = message.document
+    if document is None:
+        await message.answer("Отправь документ в формате PDF.")
+        return
+
+    if document.file_size and document.file_size > MAX_PDF_SIZE_BYTES:
+        await message.answer("Файл слишком большой (макс. 20 МБ)")
+        return
+
+    file_name = document.file_name or ""
+    if document.mime_type != "application/pdf" and not file_name.lower().endswith(".pdf"):
+        await message.answer("Поддерживаются только PDF-документы.")
+        return
+
+    file_bytes = BytesIO()
+    await message.bot.download(document, destination=file_bytes)
+    file_bytes.seek(0)
+
+    result = await _analyze_tender_pdf(file_name or "tender.pdf", file_bytes.getvalue())
+    await state.clear()
+    await message.answer(_format_analyze_response(result), reply_markup=ReplyKeyboardRemove())
+
+
 @router.message(F.text.casefold() == "отмена")
 async def cancel_handler(message: Message, state: FSMContext) -> None:
     await state.clear()
@@ -206,3 +248,36 @@ async def _send_generated_document(message: Message, response: Mapping, doc_pref
     input_file = BufferedInputFile(file_data, filename=f"{doc_prefix}_{message.from_user.id}.txt")
     await message.answer_document(input_file, caption="Документ сформирован.")
     await message.answer("Готово ✅", reply_markup=ReplyKeyboardRemove())
+
+
+async def _analyze_tender_pdf(filename: str, content: bytes) -> dict:
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{settings.core_api_url.rstrip('/')}/api/analyze/tender",
+            files={"file": (filename, content, "application/pdf")},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _format_analyze_response(data: Mapping) -> str:
+    risks = data.get("risks", []) if isinstance(data.get("risks"), list) else []
+    mismatches = (
+        data.get("mismatches", []) if isinstance(data.get("mismatches"), list) else data.get("non_compliances", [])
+    )
+    mismatches = mismatches if isinstance(mismatches, list) else []
+    recommendation = data.get("recommendation", "УТОЧНИТЬ")
+    confidence = data.get("confidence", 0)
+    confidence_pct = int(float(confidence) * 100) if isinstance(confidence, (int, float)) and confidence <= 1 else int(confidence)
+
+    risks_block = "\\n".join([f"• {item}" for item in risks]) or "• Нет"
+    mismatches_block = "\\n".join([f"• {item}" for item in mismatches]) or "• Нет"
+
+    return (
+        f"🔴 Риски ({len(risks)}):\\n"
+        f"{risks_block}\\n\\n"
+        f"🟡 Несоответствия ({len(mismatches)}):\\n"
+        f"{mismatches_block}\\n\\n"
+        f"✅ Рекомендация: {recommendation}\\n"
+        f"Уверенность: {confidence_pct}%"
+    )

--- a/telegram/keyboards.py
+++ b/telegram/keyboards.py
@@ -26,3 +26,11 @@ def cancel_keyboard() -> ReplyKeyboardMarkup:
         resize_keyboard=True,
         one_time_keyboard=True,
     )
+
+
+def main_menu_keyboard() -> ReplyKeyboardMarkup:
+    """Главное меню бота."""
+    return ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text="📋 Анализ тендера")]],
+        resize_keyboard=True,
+    )

--- a/tests/test_telegram_handlers.py
+++ b/tests/test_telegram_handlers.py
@@ -59,6 +59,7 @@ def _install_aiogram_stubs() -> None:
     types_mod.InlineKeyboardMarkup = object
     types_mod.KeyboardButton = object
     types_mod.ReplyKeyboardMarkup = object
+    types_mod.Document = object
 
     sys.modules["aiogram"] = aiogram
     sys.modules["aiogram.filters"] = filters
@@ -93,3 +94,64 @@ def test_text_handler_calls_chat_endpoint(monkeypatch):
         },
     )
     message.answer.assert_awaited_once_with("ok")
+
+
+def test_analyze_document_downloads_and_posts(monkeypatch):
+    _install_aiogram_stubs()
+
+    handlers = importlib.import_module("telegram.handlers")
+
+    analyze_mock = AsyncMock(
+        return_value={
+            "risks": ["Риск 1"],
+            "mismatches": ["Несоответствие 1"],
+            "recommendation": "УЧАСТВОВАТЬ",
+            "confidence": 0.84,
+        }
+    )
+    monkeypatch.setattr(handlers, "_analyze_tender_pdf", analyze_mock)
+    state = SimpleNamespace(clear=AsyncMock())
+
+    document = SimpleNamespace(file_size=1024, mime_type="application/pdf", file_name="tender.pdf")
+    bot = SimpleNamespace(download=AsyncMock())
+    message = SimpleNamespace(
+        document=document,
+        bot=bot,
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handlers.analyze_document_handler(message, state))
+
+    bot.download.assert_awaited_once()
+    analyze_mock.assert_awaited_once()
+    state.clear.assert_awaited_once()
+    assert message.answer.await_count == 1
+
+
+def test_analyze_helper_posts_to_tender_endpoint(monkeypatch):
+    _install_aiogram_stubs()
+    handlers = importlib.import_module("telegram.handlers")
+
+    response = SimpleNamespace(
+        raise_for_status=lambda: None,
+        json=lambda: {"ok": True},
+    )
+    post_mock = AsyncMock(return_value=response)
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return SimpleNamespace(post=post_mock)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(handlers.httpx, "AsyncClient", DummyAsyncClient)
+
+    asyncio.run(handlers._analyze_tender_pdf("x.pdf", b"123"))
+
+    post_mock.assert_awaited_once()
+    called_url = post_mock.await_args.args[0]
+    assert called_url.endswith("/api/analyze/tender")


### PR DESCRIPTION
### Motivation
- Enable running the Telegram bot in either polling (dev) or webhook mode depending on configuration to support production deployments behind an HTTP endpoint. 
- Provide an interactive `/analyze` flow so users can upload tender PDF files for automated analysis by the Core API. 

### Description
- Added `telegram_webhook_url` setting and dual startup in `telegram/bot.py`: polling when `settings.telegram_webhook_url` is empty, and webhook mode (set webhook and wait) when it is configured via `create_bot()` and `create_dispatcher()`. 
- Registered a FastAPI webhook endpoint `POST /telegram/webhook` and wired lifecycle in `api/main.py` to initialize the bot/dispatcher at startup and delete the webhook / close session on shutdown. 
- Implemented `/analyze` FSM in `telegram/handlers.py` that prompts for a PDF, enforces a 20 MB size limit (`20_971_520` bytes), downloads the file with `message.bot.download(...)`, sends it as multipart `POST` to `/api/analyze/tender`, and formats the API response into the required risks/mismatches/recommendation/confidence message. 
- Added main menu button `📋 Анализ тендера` in `telegram/keyboards.py` and added `TELEGRAM_WEBHOOK_URL` env passthrough plus a healthcheck to `docker-compose.yml`. 

### Testing
- Added tests in `tests/test_telegram_handlers.py` for the `/analyze` flow including mocking file download and mocking the `httpx.AsyncClient` `POST` to `/api/analyze/tender`. 
- Ran `pytest -q tests/test_telegram_handlers.py` and all tests passed (`3 passed`, 1 warning about pytest config).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb392c338832f8b00c50b8757ea6e)