### PR TITLE
Add tender analysis endpoint and structured risk recommendation flow

### DIFF
--- a/agents/analyst.py
+++ b/agents/analyst.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import re
+
 from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
@@ -12,9 +14,17 @@ class AnalystAgent(BaseAgent):
     """📊 Analyst — выявляет противоречия и формирует отчёт о рисках."""
 
     system_prompt = (
-        "Проверь документ на противоречия нормативам. Выяви риски. "
-        "Ответ структурируй: Риски (список), Несоответствия (список), Рекомендации."
+        "Ты — эксперт по тендерному законодательству (44-ФЗ, 223-ФЗ). "
+        "Выяви риски, противоречия, нарушения. Структурируй ответ строго: "
+        "РИСКИ: ..., НЕСООТВЕТСТВИЯ: ..., РЕКОМЕНДАЦИЯ: ..."
     )
+
+    _RISKS_RE = re.compile(r"РИСКИ\s*:\s*(.*?)(?=\n\s*НЕСООТВЕТСТВИЯ\s*:|$)", re.IGNORECASE | re.DOTALL)
+    _CONTRADICTIONS_RE = re.compile(
+        r"НЕСООТВЕТСТВИЯ\s*:\s*(.*?)(?=\n\s*РЕКОМЕНДАЦИЯ\s*:|$)",
+        re.IGNORECASE | re.DOTALL,
+    )
+    _RECOMMENDATION_RE = re.compile(r"РЕКОМЕНДАЦИЯ\s*:\s*(.+)$", re.IGNORECASE | re.DOTALL)
 
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="02", llm_router=llm_router)
@@ -22,5 +32,31 @@ class AnalystAgent(BaseAgent):
     async def run(self, state: dict[str, Any]) -> dict[str, Any]:
         prompt = self._build_prompt(state)
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
-        state["risk_report"] = response.text
-        return self._update_state(state, response.text)
+
+        risk_report = response.text
+        state["risk_report"] = risk_report
+        state["risks"] = self._extract_section_items(self._RISKS_RE, risk_report)
+        state["contradictions"] = self._extract_section_items(self._CONTRADICTIONS_RE, risk_report)
+
+        recommendation_match = self._RECOMMENDATION_RE.search(risk_report)
+        if recommendation_match:
+            state["analyst_recommendation"] = recommendation_match.group(1).strip()
+
+        return self._update_state(state, risk_report)
+
+    @staticmethod
+    def _extract_section_items(pattern: re.Pattern[str], text: str) -> list[str]:
+        match = pattern.search(text)
+        if not match:
+            return []
+
+        section = match.group(1).strip()
+        if not section:
+            return []
+
+        items: list[str] = []
+        for raw_item in re.split(r"\n|;", section):
+            normalized = raw_item.strip().strip("-•")
+            if normalized and normalized not in items:
+                items.append(normalized)
+        return items

--- a/agents/analyst.py
+++ b/agents/analyst.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import re
+from typing import Any
 
 from agents.base import BaseAgent
 from core.llm_router import LLMRouter
@@ -19,7 +18,10 @@ class AnalystAgent(BaseAgent):
         "РИСКИ: ..., НЕСООТВЕТСТВИЯ: ..., РЕКОМЕНДАЦИЯ: ..."
     )
 
-    _RISKS_RE = re.compile(r"РИСКИ\s*:\s*(.*?)(?=\n\s*НЕСООТВЕТСТВИЯ\s*:|$)", re.IGNORECASE | re.DOTALL)
+    _RISKS_RE = re.compile(
+        r"РИСКИ\s*:\s*(.*?)(?=\n\s*НЕСООТВЕТСТВИЯ\s*:|$)",
+        re.IGNORECASE | re.DOTALL,
+    )
     _CONTRADICTIONS_RE = re.compile(
         r"НЕСООТВЕТСТВИЯ\s*:\s*(.*?)(?=\n\s*РЕКОМЕНДАЦИЯ\s*:|$)",
         re.IGNORECASE | re.DOTALL,

--- a/agents/verifier.py
+++ b/agents/verifier.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-
 from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 

--- a/agents/verifier.py
+++ b/agents/verifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+
 from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 
@@ -22,6 +23,14 @@ class VerifierAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="05", llm_router=llm_router)
 
+    @staticmethod
+    def _resolve_recommendation(confidence: float, risks: list[str]) -> str:
+        if confidence >= 0.85 and len(risks) <= 2:
+            return "УЧАСТВОВАТЬ"
+        if confidence < 0.7 or len(risks) > 5:
+            return "НЕ УЧАСТВОВАТЬ"
+        return "УТОЧНИТЬ"
+
     async def run(self, state: dict[str, Any]) -> dict[str, Any]:
         confidence = float(state.get("confidence", 0.0))
         conflict_rate = float(state.get("conflict_rate", 1.0))
@@ -33,6 +42,10 @@ class VerifierAgent(BaseAgent):
         version_hash = hashlib.sha256(final_text.encode("utf-8")).hexdigest()
 
         approved = confidence >= self.MIN_CONFIDENCE and conflict_rate <= self.MAX_CONFLICT_RATE
+        risks = state.get("risks", [])
+        if not isinstance(risks, list):
+            risks = []
+        recommendation = self._resolve_recommendation(confidence, [str(item) for item in risks])
         audit_entry = {
             "agent": self.agent_id,
             "confidence": confidence,
@@ -50,6 +63,8 @@ class VerifierAgent(BaseAgent):
             "approved": approved,
             "sha256": version_hash,
             "details": response.text,
+            "recommendation": recommendation,
         }
+        state["recommendation"] = recommendation
 
         return self._update_state(state, response.text)

--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,7 @@ from api.middleware import (
     setup_rate_limiter,
 )
 from api.routes import chat, generate, health
+from api.routes.analyze import router as analyze_router
 from config.settings import settings
 from core.database import init_db
 from telegram.bot import create_bot, create_dispatcher
@@ -79,6 +80,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 app.include_router(health.router, tags=["health"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
 app.include_router(generate.router, prefix="/api", tags=["generate"])
+app.include_router(analyze_router, prefix="/api/analyze", tags=["analyze"])
 setup_rate_limiter(app.routes)
 
 

--- a/api/routes/analyze.py
+++ b/api/routes/analyze.py
@@ -1,0 +1,118 @@
+"""Analyze endpoints — анализ тендерной документации."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from core.orchestrator import Orchestrator
+from core.pdf_parser import PDFParser
+
+router = APIRouter()
+orchestrator = Orchestrator()
+pdf_parser = PDFParser()
+
+MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024
+ANALYZE_TIMEOUT_SECONDS = 120
+
+
+class TenderAnalysisRequest(BaseModel):
+    session_id: str | None = None
+    role: str = "tender_specialist"
+
+    @classmethod
+    def as_form(
+        cls,
+        session_id: Annotated[str | None, Form()] = None,
+        role: Annotated[str, Form()] = "tender_specialist",
+    ) -> "TenderAnalysisRequest":
+        return cls(session_id=session_id, role=role)
+
+
+class TenderAnalysisResponse(BaseModel):
+    session_id: str
+    risks: list[str]
+    contradictions: list[str]
+    legal_issues: list[str]
+    normative_refs: list[str]
+    confidence: float
+    recommendation: str
+
+
+def _extract_list_items(text: str) -> list[str]:
+    items: list[str] = []
+    for line in text.splitlines():
+        normalized = line.strip().strip("-•")
+        if normalized and normalized not in items:
+            items.append(normalized)
+    return items
+
+
+@router.post("/tender", response_model=TenderAnalysisResponse)
+async def analyze_tender(
+    file: UploadFile = File(...),
+    payload: TenderAnalysisRequest = Depends(TenderAnalysisRequest.as_form),
+):
+    """Анализ тендерного PDF через pipeline Researcher→Analyst→LegalExpert→Verifier."""
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Supported format: PDF only")
+
+    file_bytes = await file.read()
+    if len(file_bytes) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="File size exceeds 20 MB limit")
+
+    try:
+        parsed = pdf_parser.parse(file_bytes=file_bytes, filename=file.filename)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"PDF parsing error: {exc}") from exc
+
+    joined_text = "\n".join(parsed.text_chunks)
+    normative_refs = pdf_parser.extract_normative_refs(joined_text)
+
+    message = (
+        f"Проанализируй тендерный документ: {parsed.filename}.\n"
+        f"Текст:\n{joined_text}\n"
+        f"Нормативные ссылки: {', '.join(normative_refs) if normative_refs else 'не найдены'}."
+    )
+
+    session_id = payload.session_id or str(uuid.uuid4())
+
+    try:
+        result = await asyncio.wait_for(
+            orchestrator.process(
+                message=message,
+                session_id=session_id,
+                role=payload.role,
+                intent="analyze_tender",
+                extra_state={"normative_refs": normative_refs},
+            ),
+            timeout=ANALYZE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="Processing timeout (120 seconds)") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
+
+    state = result.get("state", {}) if isinstance(result, dict) else {}
+    legal_review = str(state.get("legal_review", ""))
+    verification = state.get("verification", {}) if isinstance(state, dict) else {}
+
+    confidence_value = float(state.get("confidence", 0.0) or 0.0)
+    recommendation = str(verification.get("recommendation") or "УТОЧНИТЬ")
+
+    contradictions = state.get("contradictions", []) if isinstance(state, dict) else []
+    legal_issues = state.get("legal_issues") or _extract_list_items(legal_review)
+
+    return TenderAnalysisResponse(
+        session_id=result.get("session_id", session_id),
+        risks=list(state.get("risks", [])),
+        contradictions=list(contradictions),
+        legal_issues=list(legal_issues),
+        normative_refs=list(normative_refs),
+        confidence=confidence_value,
+        recommendation=recommendation,
+    )

--- a/api/routes/analyze.py
+++ b/api/routes/analyze.py
@@ -29,7 +29,7 @@ class TenderAnalysisRequest(BaseModel):
         cls,
         session_id: Annotated[str | None, Form()] = None,
         role: Annotated[str, Form()] = "tender_specialist",
-    ) -> "TenderAnalysisRequest":
+    ) -> TenderAnalysisRequest:
         return cls(session_id=session_id, role=role)
 
 

--- a/api/routes/analyze.py
+++ b/api/routes/analyze.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel
 
 from core.orchestrator import Orchestrator
@@ -54,10 +54,12 @@ def _extract_list_items(text: str) -> list[str]:
 
 @router.post("/tender", response_model=TenderAnalysisResponse)
 async def analyze_tender(
+    request: Request,
     file: UploadFile = File(...),
     payload: TenderAnalysisRequest = Depends(TenderAnalysisRequest.as_form),
 ):
     """Анализ тендерного PDF через pipeline Researcher→Analyst→LegalExpert→Verifier."""
+    _ = request
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Supported format: PDF only")
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -205,7 +205,7 @@ class Orchestrator:
             "reply": final_state.get("final_output"),
             "session_id": session_id,
             "agents_used": pipeline,
-            "confidence": None,
+            "confidence": final_state.get("confidence"),
             "state": final_state,
         }
 

--- a/core/pdf_parser.py
+++ b/core/pdf_parser.py
@@ -25,7 +25,7 @@ class PDFParser:
     CHUNK_SIZE = 512
     CHUNK_OVERLAP = 64
     NORMATIVE_PATTERN = re.compile(
-        r"(СП\s*\d+\.\d+|СНиП\s*\d+-\d+-\d+|ГОСТ\s*Р?\s*\d+(?:\.\d+)?|ФЗ-\d+|ГК\s*РФ\s*ст\.\s*\d+)",
+        r"(СП\s*\d+\.\d+|СНиП\s*\d+-\d+-\d+|ГОСТ\s*Р?\s*\d+(?:\.\d+)?|ФЗ-\d+|\d+\s*-\s*ФЗ|ГК\s*РФ\s*ст\.\s*\d+)",
         flags=re.IGNORECASE,
     )
 
@@ -62,6 +62,9 @@ class PDFParser:
             value = " ".join(match.group(0).split())
             if value.upper().startswith("ГОСТ"):
                 value = value.replace("ГОСТ ", "ГОСТ ")
+            if re.match(r"^\d+\s*-\s*ФЗ$", value, flags=re.IGNORECASE):
+                digits = re.sub(r"\D", "", value)
+                value = f"{digits}-ФЗ"
             if value and value not in refs:
                 refs.append(value)
         return refs

--- a/tests/test_analyze_tender.py
+++ b/tests/test_analyze_tender.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from api.main import app
 from api.routes import analyze
+from config.settings import settings
 from core.pdf_parser import ParsedDocument
 
 PDF_BYTES = (
@@ -55,11 +56,17 @@ def test_analyze_tender_contains_44fz_reference():
         }
     )
 
-    response = client.post(
-        "/api/analyze/tender",
-        files={"file": ("tender.pdf", PDF_BYTES, "application/pdf")},
-        data={"role": "tender_specialist"},
-    )
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+    try:
+        response = client.post(
+            "/api/analyze/tender",
+            files={"file": ("tender.pdf", PDF_BYTES, "application/pdf")},
+            data={"role": "tender_specialist"},
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_analyze_tender.py
+++ b/tests/test_analyze_tender.py
@@ -1,0 +1,68 @@
+"""Тесты /api/analyze/tender."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import analyze
+from core.pdf_parser import ParsedDocument
+
+
+PDF_BYTES = (
+    b"%PDF-1.4\n"
+    b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+    b"2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n"
+    b"3 0 obj\n"
+    b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+    b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\n"
+    b"endobj\n"
+    b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n"
+    b"5 0 obj\n<< /Length 29 >>\nstream\n"
+    b"BT /F1 12 Tf 72 720 Td (44-FZ) Tj ET\n"
+    b"endstream\nendobj\n"
+    b"xref\n0 6\n"
+    b"0000000000 65535 f \n"
+    b"0000000010 00000 n \n"
+    b"0000000063 00000 n \n"
+    b"0000000120 00000 n \n"
+    b"0000000246 00000 n \n"
+    b"0000000316 00000 n \n"
+    b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n426\n%%EOF\n"
+)
+
+
+def test_analyze_tender_contains_44fz_reference():
+    """POST /api/analyze/tender возвращает ссылки на 44-ФЗ."""
+    client = TestClient(app)
+
+    analyze.pdf_parser.parse = lambda file_bytes, filename: ParsedDocument(
+        filename=filename,
+        total_pages=1,
+        text_chunks=["согласно 44-ФЗ ст.42"],
+        tables=[],
+        metadata={},
+    )
+    analyze.orchestrator.process = AsyncMock(
+        return_value={
+            "session_id": "s-44",
+            "state": {
+                "risks": ["короткий срок подачи"],
+                "contradictions": [],
+                "legal_review": "Нужна детализация сроков.",
+                "confidence": 0.9,
+                "verification": {"recommendation": "УЧАСТВОВАТЬ"},
+            },
+        }
+    )
+
+    response = client.post(
+        "/api/analyze/tender",
+        files={"file": ("tender.pdf", PDF_BYTES, "application/pdf")},
+        data={"role": "tender_specialist"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "44-ФЗ" in data["normative_refs"]
+    assert data["recommendation"] == "УЧАСТВОВАТЬ"

--- a/tests/test_analyze_tender.py
+++ b/tests/test_analyze_tender.py
@@ -8,7 +8,6 @@ from api.main import app
 from api.routes import analyze
 from core.pdf_parser import ParsedDocument
 
-
 PDF_BYTES = (
     b"%PDF-1.4\n"
     b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"


### PR DESCRIPTION
### Motivation
- Provide a dedicated API for analyzing tender PDF documentation and return structured findings (risks, contradictions, legal issues, normative references, confidence and a participation recommendation).
- Make the Analyst and Verifier agents produce structured, machine-parsable outputs for tender workflows to allow deterministic downstream decisions.

### Description
- Added `api/routes/analyze.py` implementing `POST /api/analyze/tender` which accepts a PDF upload plus `TenderAnalysisRequest` (form data), parses the PDF via `PDFParser`, runs the `analyze_tender` pipeline (`researcher → analyst → legal_expert → verifier`) and returns `TenderAnalysisResponse` with `risks`, `contradictions`, `legal_issues`, `normative_refs`, `confidence` and `recommendation`.
- Updated `agents/analyst.py` to use a tender-specialized `system_prompt` (mentions `44-ФЗ, 223-ФЗ`) and added regex-based parsing of structured sections `РИСКИ`, `НЕСООТВЕТСТВИЯ`, `РЕКОМЕНДАЦИЯ` with extracted `state` fields (`risks`, `contradictions`, `analyst_recommendation`).
- Updated `agents/verifier.py` to compute `recommendation` using the provided rules and store it in `state` and `state['verification']` via a new `_resolve_recommendation` helper:
  - `confidence >= 0.85` and `len(risks) <= 2` → `УЧАСТВОВАТЬ`
  - `confidence < 0.7` or `len(risks) > 5` → `НЕ УЧАСТВОВАТЬ`
  - otherwise → `УТОЧНИТЬ`
- Extended `core/pdf_parser.py` `NORMATIVE_PATTERN` and normalization to recognize variants like `44-ФЗ` (`\d+-ФЗ`) and normalize them.
- Propagated pipeline `confidence` from `final_state` through `_run_pipeline` in `core/orchestrator.py` so API endpoints can surface it.
- Registered the new analyze router in `api/main.py` under prefix `/api/analyze`.
- Added `tests/test_analyze_tender.py` which mocks PDF parsing and the orchestrator to validate the endpoint returns `normative_refs` containing `44-ФЗ` and surface the recommendation.

### Testing
- Compiled new/modified modules with `python -m compileall` which completed successfully.
- Ran `pytest -q tests/test_pdf_parser.py` and it passed (`2 passed` for parser tests).
- Attempted to run `pytest` including `tests/test_analyze_tender.py` and `tests/test_pipeline_integration.py`, but test collection failed in this environment due to missing optional dependencies (`aiogram` and `aiosqlite`), so those higher-level tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd55f9fd0832f80508410abb99afa)