### PR TITLE
Add Prometheus/Grafana observability and custom metrics

### DIFF
--- a/agents/analyst.py
+++ b/agents/analyst.py
@@ -31,7 +31,7 @@ class AnalystAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="02", llm_router=llm_router)
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         prompt = self._build_prompt(state)
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
 

--- a/agents/author.py
+++ b/agents/author.py
@@ -19,7 +19,7 @@ class AuthorAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="03", llm_router=llm_router)
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         prompt = self._build_prompt(state)
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
         state["draft"] = response.text

--- a/agents/base.py
+++ b/agents/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from api.metrics import AGENT_RUNS
 from core.llm_router import LLMRouter
 
 
@@ -18,9 +19,19 @@ class BaseAgent(ABC):
         self.agent_id = agent_id
         self.llm_router = llm_router
 
-    @abstractmethod
     async def run(self, state: dict[str, Any]) -> dict[str, Any]:
         """Запустить агента и вернуть обновлённый state."""
+        try:
+            result = await self._run(state)
+            AGENT_RUNS.labels(agent_id=self.agent_id, status="success").inc()
+            return result
+        except Exception:
+            AGENT_RUNS.labels(agent_id=self.agent_id, status="error").inc()
+            raise
+
+    @abstractmethod
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Внутренняя реализация выполнения конкретного агента."""
 
     def _build_prompt(self, state: dict[str, Any]) -> str:
         """Собрать финальный prompt из message и context."""

--- a/agents/calculator.py
+++ b/agents/calculator.py
@@ -27,7 +27,7 @@ class CalculatorAgent(BaseAgent):
             return max((end - start).days + 1, 1)
         return 1
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         calc_params = state.get("calculation_params", {})
         if not isinstance(calc_params, dict):
             raise TypeError("state['calculation_params'] must be a dict")

--- a/agents/critic.py
+++ b/agents/critic.py
@@ -19,7 +19,7 @@ class CriticAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="04", llm_router=llm_router)
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         history = state.get("history", [])
         if not isinstance(history, list):
             raise TypeError("state['history'] must be a list")

--- a/agents/formatter.py
+++ b/agents/formatter.py
@@ -76,7 +76,7 @@ class FormatterAgent(BaseAgent):
             "sha256": sha256 or "n/a",
         }
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         if "ks2_data" in state and "ks3_data" in state:
             ks2_data = state.get("ks2_data", {})
             ks3_data = state.get("ks3_data", {})

--- a/agents/legal_expert.py
+++ b/agents/legal_expert.py
@@ -19,7 +19,7 @@ class LegalExpertAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="06", llm_router=llm_router)
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         prompt = self._build_prompt(state)
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
         state["legal_review"] = response.text

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -22,7 +22,7 @@ class ResearcherAgent(BaseAgent):
         super().__init__(agent_id="01", llm_router=llm_router)
         self.rag_engine = RAGEngine()
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         message = str(state.get("message", ""))
         role = str(state.get("role", "")) or None
         chunks = await self.rag_engine.search(message, filter_scope=role)

--- a/agents/verifier.py
+++ b/agents/verifier.py
@@ -30,7 +30,7 @@ class VerifierAgent(BaseAgent):
             return "НЕ УЧАСТВОВАТЬ"
         return "УТОЧНИТЬ"
 
-    async def run(self, state: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         confidence = float(state.get("confidence", 0.0))
         conflict_rate = float(state.get("conflict_rate", 1.0))
 

--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 from slowapi.errors import RateLimitExceeded
 
+from api.metrics import AGENT_RUNS, PIPELINE_DURATION, Instrumentator
 from api.middleware import (
     APIKeyMiddleware,
     RequestLoggingMiddleware,
@@ -24,6 +25,7 @@ from config.settings import settings
 from core.database import init_db
 from telegram.bot import create_bot, create_dispatcher
 
+_ = (AGENT_RUNS, PIPELINE_DURATION)
 telegram_router = APIRouter()
 
 
@@ -55,6 +57,8 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+Instrumentator().instrument(app).expose(app, endpoint="/metrics")
 
 # CORS — для Tauri и Web UI
 app.add_middleware(

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -1,0 +1,32 @@
+from prometheus_client import Counter, Gauge, Histogram
+from prometheus_fastapi_instrumentator import Instrumentator
+
+# Кастомные метрики:
+AGENT_RUNS = Counter(
+    "construction_ai_agent_runs_total",
+    "Количество запусков агентов",
+    ["agent_id", "status"],  # status: success/error
+)
+PIPELINE_DURATION = Histogram(
+    "construction_ai_pipeline_duration_seconds",
+    "Время выполнения pipeline",
+    ["intent"],
+    buckets=[1, 5, 10, 30, 60, 120],
+)
+ACTIVE_SESSIONS = Gauge(
+    "construction_ai_active_sessions",
+    "Количество активных сессий",
+)
+LLM_TOKENS_USED = Counter(
+    "construction_ai_llm_tokens_total",
+    "Использовано LLM токенов",
+    ["provider", "direction"],  # direction: input/output
+)
+
+__all__ = [
+    "Instrumentator",
+    "AGENT_RUNS",
+    "PIPELINE_DURATION",
+    "ACTIVE_SESSIONS",
+    "LLM_TOKENS_USED",
+]

--- a/core/llm_router.py
+++ b/core/llm_router.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 import httpx
 
+from api.metrics import LLM_TOKENS_USED
 from config.settings import settings
 
 
@@ -118,6 +119,12 @@ class LLMRouter:
         else:
             response_data = await self._query_openai_compatible(
                 config["base_url"], api_key, model, messages, temperature, max_tokens
+            )
+
+        usage = response_data.get("usage") or {}
+        if isinstance(usage, dict) and "prompt_tokens" in usage:
+            LLM_TOKENS_USED.labels(provider=provider.value, direction="input").inc(
+                usage["prompt_tokens"]
             )
 
         return LLMResponse(

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -22,6 +22,7 @@ from agents.formatter import FormatterAgent
 from agents.legal_expert import LegalExpertAgent
 from agents.researcher import ResearcherAgent
 from agents.verifier import VerifierAgent
+from api.metrics import PIPELINE_DURATION
 from core.llm_router import LLMRouter
 from core.session_memory import SessionMemory
 
@@ -200,7 +201,8 @@ class Orchestrator:
         if extra_state:
             initial_state = cast(PipelineState, {**initial_state, **extra_state})
 
-        final_state = await cast(Any, graph).ainvoke(initial_state)
+        with PIPELINE_DURATION.labels(intent=intent).time():
+            final_state = await cast(Any, graph).ainvoke(initial_state)
         return {
             "reply": final_state.get("final_output"),
             "session_id": session_id,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,3 +54,18 @@ services:
 
 # volumes:
 #   redis_data:
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+

--- a/monitoring/grafana_dashboard.json
+++ b/monitoring/grafana_dashboard.json
@@ -1,0 +1,69 @@
+{
+  "title": "Construction AI Core Overview",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "15s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Requests per second (HTTP)",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[1m]))",
+          "legendFormat": "RPS"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Pipeline duration p50/p95/p99",
+      "targets": [
+        {"expr": "histogram_quantile(0.50, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p95"},
+        {"expr": "histogram_quantile(0.99, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p99"}
+      ],
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+    },
+    {
+      "id": 3,
+      "type": "barchart",
+      "title": "Agent runs by agent_id (stacked bar)",
+      "options": {"stacking": "normal"},
+      "targets": [
+        {
+          "expr": "sum by (agent_id, status) (increase(construction_ai_agent_runs_total[5m]))",
+          "legendFormat": "{{agent_id}} {{status}}"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8}
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "LLM tokens per minute",
+      "targets": [
+        {
+          "expr": "sum by (provider, direction) (rate(construction_ai_llm_tokens_total[1m])) * 60",
+          "legendFormat": "{{provider}} {{direction}}"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8}
+    },
+    {
+      "id": 5,
+      "type": "gauge",
+      "title": "Active sessions gauge",
+      "targets": [
+        {
+          "expr": "construction_ai_active_sessions",
+          "legendFormat": "active sessions"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16}
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: construction-ai
+    static_configs:
+      - targets: ["api:8000"]
+    metrics_path: /metrics
+    scrape_interval: 15s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "structlog>=24.0.0",
     "tqdm>=4.66.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Motivation
- Add Prometheus-compatible observability to expose HTTP and custom application metrics for monitoring pipeline performance, agent executions, LLM usage and active sessions.
- Provide a basic Grafana dashboard and local Prometheus scrape configuration to visualize key metrics during development and deployments.

### Description
- Added `api/metrics.py` which defines `Instrumentator` export and custom Prometheus metrics: `AGENT_RUNS`, `PIPELINE_DURATION`, `ACTIVE_SESSIONS`, and `LLM_TOKENS_USED`.
- Enabled metrics exposure by calling `Instrumentator().instrument(app).expose(app, endpoint="/metrics")` and importing metrics in `api/main.py`.
- Wrapped agent execution in `BaseAgent.run()` to record success/error counts via `AGENT_RUNS` and moved per-agent implementations to `async def _run(...)` (updated agent modules accordingly) to keep the wrapper consistent with metrics reporting.
- Timed orchestrator pipelines using `with PIPELINE_DURATION.labels(intent=intent).time():` in `core/orchestrator.py` and recorded prompt token usage in `core/llm_router.py` with `LLM_TOKENS_USED.labels(..., direction="input").inc(...)` when `usage["prompt_tokens"]` is present.
- Added `prometheus-fastapi-instrumentator>=7.0.0` to `pyproject.toml`, extended `docker-compose.yml` with `prometheus` and `grafana` services, and added `monitoring/prometheus.yml` and a baseline `monitoring/grafana_dashboard.json` dashboard.

### Testing
- Ran `python -m compileall api agents core monitoring` which completed without errors.
- Ran `ruff check api agents core` and all lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce6995a80832f986166b58c17daa2)