### PR TITLE
Lazy RAG initialization with `RAG_EMBEDDINGS_BACKEND` and CI override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       OPENAI_API_KEY: "test-key"
       API_KEYS: '["test-key"]'
       SQLITE_DB_PATH: ":memory:"
+      RAG_EMBEDDINGS_BACKEND: hash
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -20,9 +20,11 @@ class ResearcherAgent(BaseAgent):
 
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="01", llm_router=llm_router)
-        self.rag_engine = RAGEngine()
+        self.rag_engine: RAGEngine | None = None
 
     async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
+        if self.rag_engine is None:
+            self.rag_engine = RAGEngine()
         message = str(state.get("message", ""))
         role = str(state.get("role", "")) or None
         chunks = await self.rag_engine.search(message, filter_scope=role)

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from fastapi import APIRouter, HTTPException, Request
 
 from config.settings import settings
 from core.rag_engine import RAGEngine
 
 router = APIRouter()
-rag_engine = RAGEngine()
+
+
+@lru_cache(maxsize=1)
+def get_rag_engine() -> RAGEngine:
+    return RAGEngine()
 
 
 @router.get("/stats")
@@ -17,4 +23,4 @@ async def rag_stats(request: Request) -> dict:
     api_key = request.headers.get("X-API-Key")
     if not api_key or api_key not in settings.admin_api_keys:
         raise HTTPException(status_code=403, detail="Admin role required")
-    return rag_engine.get_stats()
+    return get_rag_engine().get_stats()

--- a/core/rag_engine.py
+++ b/core/rag_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -26,7 +27,8 @@ class RAGEngine:
         self.collection_name = collection_name
         self.client = chromadb.PersistentClient(path=settings.chroma_persist_dir)
         self.embedding_model_name = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
-        self.embedding_model = self._load_embedding_model()
+        self.embedding_model: Any | None = None
+        self.embedding_backend = os.getenv("RAG_EMBEDDINGS_BACKEND", "sentence_transformers")
         self.collection = self.client.get_or_create_collection(name=collection_name)
 
     async def search(
@@ -119,17 +121,28 @@ class RAGEngine:
             "last_updated": last_updated,
         }
 
-    def _load_embedding_model(self) -> Any | None:
-        if SentenceTransformer is None:
+    def _get_embedding_model(self) -> Any | None:
+        if self.embedding_backend != "sentence_transformers":
             return None
+
+        if self.embedding_model is not None:
+            return self.embedding_model
+
+        if SentenceTransformer is None:
+            self.embedding_backend = "hash"
+            return None
+
         try:
-            return SentenceTransformer(self.embedding_model_name)
+            self.embedding_model = SentenceTransformer(self.embedding_model_name)
+            return self.embedding_model
         except Exception:
+            self.embedding_backend = "hash"
             return None
 
     def _embed_texts(self, texts: list[str]) -> list[list[float]]:
-        if self.embedding_model is not None:
-            model_vectors = self.embedding_model.encode(texts, normalize_embeddings=True)
+        embedding_model = self._get_embedding_model()
+        if embedding_model is not None:
+            model_vectors = embedding_model.encode(texts, normalize_embeddings=True)
             return cast(list[list[float]], model_vectors.tolist())
 
         vectors: list[list[float]] = []


### PR DESCRIPTION
### Motivation
- Prevent heavy `SentenceTransformer` model downloads and long initialization during module import (e.g., when importing `api.main`).
- Provide a safe, fast fallback embedding backend for CI and environments without `sentence_transformers` installed.

### Description
- In `core/rag_engine.py` removed eager model load from `__init__`, added `RAG_EMBEDDINGS_BACKEND` env flag and `self.embedding_backend`, implemented lazy loader `_get_embedding_model()` that loads `SentenceTransformer` on first use and falls back to hash embeddings on failure or if backend != `sentence_transformers`.
- Updated `_embed_texts()` to call the lazy `_get_embedding_model()` and use hash-based deterministic embeddings when no model is available.
- In `api/routes/rag.py` removed the global `rag_engine = RAGEngine()` and added a cached accessor `get_rag_engine()` decorated with `@lru_cache(maxsize=1)`; endpoints now call `get_rag_engine()` to obtain the engine.
- In `agents/researcher.py` stopped creating `RAGEngine` in `__init__` and instead instantiate it lazily on first `_run()` invocation.
- In CI workflow `.github/workflows/ci.yml` set `RAG_EMBEDDINGS_BACKEND: hash` in the test job environment to avoid model downloads during CI runs.

### Testing
- Ran `pytest tests/ -v`, which aborted during collection due to missing optional environment dependencies (`slowapi` and `prometheus_client`), so full test suite did not complete in this environment.
- Verified import-time behavior with `RAG_EMBEDDINGS_BACKEND=hash python - <<'PY'\nimport api.routes.rag\nprint('ok')\nPY` which succeeded and confirmed no eager `SentenceTransformer` load on import.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd01bf43c4832f8ef571cf1cb5eedd)