### PR TITLE
Handle WeasyPrint import failures and install required system libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /app
 # Системные зависимости
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    libcairo2 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libgdk-pixbuf2.0-0 \
+    libffi-dev \
+    shared-mime-info \
     && rm -rf /var/lib/apt/lists/*
 
 # Зависимости Python

--- a/core/pdf_exporter.py
+++ b/core/pdf_exporter.py
@@ -60,7 +60,7 @@ class PDFExporter:
     def _convert_with_weasyprint(self, docx_path: Path, pdf_path: Path) -> bool:
         try:
             from weasyprint import HTML
-        except ImportError:
+        except Exception:
             return False
 
         html_content = self._docx_to_html(docx_path)


### PR DESCRIPTION
### Motivation
- Importing `weasyprint` can raise non-`ImportError` exceptions (for example when native libraries are missing), which should be handled to allow fallbacks to run. 
- The container image must include native libraries required by WeasyPrint to reduce runtime import errors. 

### Description
- Change `PDFExporter._convert_with_weasyprint` to catch `Exception` on import and return `False` as a graceful fallback instead of only catching `ImportError`. 
- Add system packages in `Dockerfile` needed by WeasyPrint rendering: `libcairo2`, `libpango-1.0-0`, `libpangocairo-1.0-0`, `libgdk-pixbuf2.0-0`, `libffi-dev`, and `shared-mime-info`. 

### Testing
- Ran `pytest -q tests/test_pdf_exporter.py` and the suite passed with `2 passed` (one pytest warning about config); the tests did not fail on import.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd04235234832fa5f7c897eb7b06ca)