### PR TITLE
Remove telegram-bot healthcheck from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,6 @@ services:
     volumes:
       - .:/app
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
 # volumes:
 #   redis_data:
 


### PR DESCRIPTION
### Motivation
- Remove the `healthcheck` block from the `telegram-bot` service to avoid spurious health failures while preserving service startup ordering and restart behavior via `depends_on: api` and `restart: unless-stopped`.

### Description
- Deleted the `healthcheck` section under the `telegram-bot` service in `docker-compose.yml` and left `depends_on: api` and `restart: unless-stopped` unchanged.

### Testing
- Inspected `docker-compose.yml` with `sed`/`nl`, applied the edit via a small Python script to update the file, and verified the resulting diff shows only the removal of the `healthcheck` block.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd07ea62ec832f8f967c406415d721)