### PR TITLE
Parse contradictions.mismatches and include legal_issues in analyze output

### DIFF
--- a/telegram/handlers.py
+++ b/telegram/handlers.py
@@ -288,7 +288,8 @@ def _format_analyze_response(data: Mapping) -> str:
         if not isinstance(mismatches, list):
             mismatches = contradictions.get("non_compliances", [])
     mismatches = mismatches if isinstance(mismatches, list) else []
-    legal_issues = data.get("legal_issues", []) if isinstance(data.get("legal_issues"), list) else []
+    legal_issues_raw = data.get("legal_issues", [])
+    legal_issues = legal_issues_raw if isinstance(legal_issues_raw, list) else []
     recommendation = data.get("recommendation", "УТОЧНИТЬ")
     confidence = data.get("confidence", 0)
     is_fraction = isinstance(confidence, (int, float)) and confidence <= 1

--- a/telegram/handlers.py
+++ b/telegram/handlers.py
@@ -281,10 +281,14 @@ async def _analyze_tender_pdf(filename: str, content: bytes) -> dict:
 
 def _format_analyze_response(data: Mapping) -> str:
     risks = data.get("risks", []) if isinstance(data.get("risks"), list) else []
-    mismatches = data.get("mismatches", [])
-    if not isinstance(mismatches, list):
-        mismatches = data.get("non_compliances", [])
+    contradictions = data.get("contradictions", {})
+    mismatches: list = []
+    if isinstance(contradictions, Mapping):
+        mismatches = contradictions.get("mismatches", [])
+        if not isinstance(mismatches, list):
+            mismatches = contradictions.get("non_compliances", [])
     mismatches = mismatches if isinstance(mismatches, list) else []
+    legal_issues = data.get("legal_issues", []) if isinstance(data.get("legal_issues"), list) else []
     recommendation = data.get("recommendation", "УТОЧНИТЬ")
     confidence = data.get("confidence", 0)
     is_fraction = isinstance(confidence, (int, float)) and confidence <= 1
@@ -292,12 +296,15 @@ def _format_analyze_response(data: Mapping) -> str:
 
     risks_block = "\\n".join([f"• {item}" for item in risks]) or "• Нет"
     mismatches_block = "\\n".join([f"• {item}" for item in mismatches]) or "• Нет"
+    legal_issues_block = "\\n".join([f"• {item}" for item in legal_issues]) or "• Нет"
 
     return (
         f"🔴 Риски ({len(risks)}):\\n"
         f"{risks_block}\\n\\n"
         f"🟡 Несоответствия ({len(mismatches)}):\\n"
         f"{mismatches_block}\\n\\n"
+        f"⚖️ Юр. замечания ({len(legal_issues)}):\\n"
+        f"{legal_issues_block}\\n\\n"
         f"✅ Рекомендация: {recommendation}\\n"
         f"Уверенность: {confidence_pct}%"
     )


### PR DESCRIPTION
### Motivation
- Adapt the tender analysis formatting to a changed API shape where non-compliances are nested under `contradictions` and to surface legal observations returned as `legal_issues`.

### Description
- Updated `_format_analyze_response` in `telegram/handlers.py` to read `contradictions` and extract `mismatches` with a fallback to `non_compliances` when `mismatches` is not a list.
- Added extraction of `legal_issues` and rendering of a new `⚖️ Юр. замечания` block in the formatted response including count and bullet list.
- Kept existing `risks`, `recommendation`, and `confidence` handling and preserved the text formatting logic for blocks and fallbacks.
- Added defensive type checks to ensure lists are only iterated when they are actual lists.

### Testing
- Ran `python -m compileall telegram/handlers.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a9bdc0c832f9fa72f3b13c08e17)