### PR TITLE
Update chat roles and role selector labels

### DIFF
--- a/desktop/src/components/RoleSelector.tsx
+++ b/desktop/src/components/RoleSelector.tsx
@@ -1,10 +1,10 @@
 import { useChatStore, type ChatRole } from '../store/chatStore';
 
 const ROLES: Array<{ id: ChatRole; label: string }> = [
-  { id: 'estimator', label: 'Сметчик' },
-  { id: 'lawyer', label: 'Юрист' },
-  { id: 'engineer', label: 'Инженер' },
-  { id: 'manager', label: 'Менеджер' }
+  { id: 'pto_engineer', label: 'ПТО' },
+  { id: 'foreman', label: 'Прораб' },
+  { id: 'tender_specialist', label: 'Тендеры' },
+  { id: 'admin', label: 'Админ' }
 ];
 
 export default function RoleSelector() {

--- a/desktop/src/store/chatStore.ts
+++ b/desktop/src/store/chatStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type ChatRole = 'estimator' | 'lawyer' | 'engineer' | 'manager';
+export type ChatRole = 'pto_engineer' | 'foreman' | 'tender_specialist' | 'admin';
 export type MessageRole = 'user' | 'assistant';
 
 export interface ChatMessage {
@@ -32,7 +32,7 @@ const createSessionId = () => crypto.randomUUID();
 
 export const useChatStore = create<ChatState>((set, get) => ({
   sessionId: createSessionId(),
-  role: 'manager',
+  role: 'admin',
   messages: [],
   sessions: [],
   isTyping: false,


### PR DESCRIPTION
### Motivation
- Привести набор ролей чата к новым доменно-специфичным идентификаторам для ПТО, прораба, тендерного специалиста и админа. 
- Обновить UI селектор ролей чтобы кнопки отображали соответствующие новые роли и метки.

### Description
- Заменён `ChatRole` в `desktop/src/store/chatStore.ts` на `pto_engineer | foreman | tender_specialist | admin`.
- Изменён дефолтный `role` в сторе с `manager` на `admin` в `desktop/src/store/chatStore.ts`.
- Обновлён массив `ROLES` в `desktop/src/components/RoleSelector.tsx` с новыми `id` и метками: `ПТО`, `Прораб`, `Тендеры`, `Админ`.

### Testing
- Выполнен поиск с `rg` (`rg "estimator|lawyer|engineer|manager|pto_engineer|foreman|tender_specialist|admin" desktop/src -n`) чтобы подтвердить, что старые id удалены и новые присутствуют, и команда завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0ff7d01c832fbbe698e438e69d67)