### PR TITLE
Require API key for /api/generate endpoints and update generation tests

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -23,7 +23,6 @@ from starlette.routing import BaseRoute
 from config.settings import settings
 
 EXCLUDED_PATHS = {"/health", "/docs", "/openapi.json"}
-EXCLUDED_PREFIXES = ("/api/generate/",)
 limiter = Limiter(key_func=get_remote_address, default_limits=[])
 
 
@@ -35,7 +34,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        if request.url.path in EXCLUDED_PATHS or request.url.path.startswith(EXCLUDED_PREFIXES):
+        if request.url.path in EXCLUDED_PATHS:
             return await call_next(request)
 
         provided_key = request.headers.get("X-API-Key")

--- a/tests/test_generate_ks.py
+++ b/tests/test_generate_ks.py
@@ -5,8 +5,8 @@ import importlib.util
 from unittest.mock import AsyncMock
 
 from agents.calculator import CalculatorAgent
-from core.llm_router import LLMRouter
 from config.settings import settings
+from core.llm_router import LLMRouter
 
 
 def test_calculator_totals_match_subtotals_for_3_items():

--- a/tests/test_generate_ks.py
+++ b/tests/test_generate_ks.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 from agents.calculator import CalculatorAgent
 from core.llm_router import LLMRouter
+from config.settings import settings
 
 
 def test_calculator_totals_match_subtotals_for_3_items():
@@ -65,6 +66,8 @@ def test_generate_ks_endpoint_forces_intent_generate_ks():
     from api.routes import generate
 
     client = TestClient(app)
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
     mocked_process = AsyncMock(
         return_value={
             "session_id": "session-ks-1",
@@ -85,24 +88,28 @@ def test_generate_ks_endpoint_forces_intent_generate_ks():
     )
     generate.orchestrator.process = mocked_process
 
-    response = client.post(
-        "/api/generate/ks",
-        json={
-            "object_name": "ЖК Север",
-            "contract_number": "Д-77",
-            "period_from": "2026-01-01",
-            "period_to": "2026-01-31",
-            "work_items": [
-                {
-                    "name": "Бетонирование",
-                    "unit": "м³",
-                    "volume": 1,
-                    "norm_hours": 1,
-                    "price_per_unit": 1,
-                }
-            ],
-        },
-    )
+    try:
+        response = client.post(
+            "/api/generate/ks",
+            json={
+                "object_name": "ЖК Север",
+                "contract_number": "Д-77",
+                "period_from": "2026-01-01",
+                "period_to": "2026-01-31",
+                "work_items": [
+                    {
+                        "name": "Бетонирование",
+                        "unit": "м³",
+                        "volume": 1,
+                        "norm_hours": 1,
+                        "price_per_unit": 1,
+                    }
+                ],
+            },
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_generate_letter.py
+++ b/tests/test_generate_letter.py
@@ -6,11 +6,14 @@ from fastapi.testclient import TestClient
 
 from api.main import app
 from api.routes import generate
+from config.settings import settings
 
 
 def test_generate_letter_with_npa_pipeline():
     """POST /api/generate/letter с include_npa=True использует Legal Expert."""
     client = TestClient(app)
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
     mocked_process = AsyncMock(
         return_value={
             "session_id": "session-legal",
@@ -38,19 +41,23 @@ def test_generate_letter_with_npa_pipeline():
 
     generate.orchestrator.process = mocked_process
 
-    response = client.post(
-        "/api/generate/letter",
-        json={
-            "letter_type": "запрос",
-            "addressee": "ООО Ромашка",
-            "subject": "Предоставление графика работ",
-            "body_points": ["Просим прислать график", "Срок до 15.05.2026"],
-            "contract_number": "Д-123",
-            "include_npa": True,
-            "role": "foreman",
-            "session_id": "session-legal",
-        },
-    )
+    try:
+        response = client.post(
+            "/api/generate/letter",
+            json={
+                "letter_type": "запрос",
+                "addressee": "ООО Ромашка",
+                "subject": "Предоставление графика работ",
+                "body_points": ["Просим прислать график", "Срок до 15.05.2026"],
+                "contract_number": "Д-123",
+                "include_npa": True,
+                "role": "foreman",
+                "session_id": "session-legal",
+            },
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 200
     data = response.json()
@@ -68,6 +75,8 @@ def test_generate_letter_with_npa_pipeline():
 def test_generate_letter_without_npa_pipeline():
     """POST /api/generate/letter с include_npa=False отключает Legal Expert."""
     client = TestClient(app)
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
     mocked_process = AsyncMock(
         return_value={
             "session_id": "session-no-legal",
@@ -83,16 +92,20 @@ def test_generate_letter_without_npa_pipeline():
 
     generate.orchestrator.process = mocked_process
 
-    response = client.post(
-        "/api/generate/letter",
-        json={
-            "letter_type": "ответ",
-            "addressee": "АО Заказчик",
-            "subject": "Ответ по замечаниям",
-            "body_points": ["Замечания устранены"],
-            "include_npa": False,
-        },
-    )
+    try:
+        response = client.post(
+            "/api/generate/letter",
+            json={
+                "letter_type": "ответ",
+                "addressee": "АО Заказчик",
+                "subject": "Ответ по замечаниям",
+                "body_points": ["Замечания устранены"],
+                "include_npa": False,
+            },
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_generate_tk.py
+++ b/tests/test_generate_tk.py
@@ -6,11 +6,14 @@ from fastapi.testclient import TestClient
 
 from api.main import app
 from api.routes import generate
+from config.settings import settings
 
 
 def test_generate_tk_happy_path():
     """POST /api/generate/tk возвращает TKResponse при успешной обработке."""
     client = TestClient(app)
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
     mocked_process = AsyncMock(
         return_value={
             "session_id": "session-1",
@@ -23,17 +26,21 @@ def test_generate_tk_happy_path():
 
     generate.orchestrator.process = mocked_process
 
-    response = client.post(
-        "/api/generate/tk",
-        json={
-            "work_type": "бетонирование монолитных конструкций",
-            "object_name": "ЖК Север",
-            "volume": 120.5,
-            "unit": "м³",
-            "norms": ["СП 70.13330", "ГОСТ 7473"],
-            "role": "pto_engineer",
-        },
-    )
+    try:
+        response = client.post(
+            "/api/generate/tk",
+            json={
+                "work_type": "бетонирование монолитных конструкций",
+                "object_name": "ЖК Север",
+                "volume": 120.5,
+                "unit": "м³",
+                "norms": ["СП 70.13330", "ГОСТ 7473"],
+                "role": "pto_engineer",
+            },
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 200
     data = response.json()
@@ -50,15 +57,21 @@ def test_generate_tk_happy_path():
 def test_generate_tk_validation_error():
     """POST /api/generate/tk должен вернуть 422 при невалидных данных."""
     client = TestClient(app)
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
 
-    response = client.post(
-        "/api/generate/tk",
-        json={
-            "work_type": "бетон",
-            "object_name": "ЖК Север",
-            "volume": 0,
-            "unit": "литр",
-        },
-    )
+    try:
+        response = client.post(
+            "/api/generate/tk",
+            json={
+                "work_type": "бетон",
+                "object_name": "ЖК Север",
+                "volume": 0,
+                "unit": "литр",
+            },
+            headers={"X-API-Key": "valid-key"},
+        )
+    finally:
+        settings.api_keys = old_keys
 
     assert response.status_code == 422


### PR DESCRIPTION
### Motivation
- Закрыть генерационные API под проверкой `X-API-Key`, оставив без проверки только `/health`, `/docs` и `/openapi.json`.
- Обновить тесты генерации для сопровождения изменения поведения middleware и обеспечить изоляцию ключей в тестах.

### Description
- Удалено исключение `/api/generate/` из проверки в `api/middleware.py`, теперь `APIKeyMiddleware` пропускает только пути в `EXCLUDED_PATHS` (`/health`, `/docs`, `/openapi.json`).
- Обновлены тесты генерации в `tests/test_generate_tk.py`, `tests/test_generate_letter.py` и `tests/test_generate_ks.py` для отправки заголовка `X-API-Key` с запросами.
- В этих тестах временно устанавливается `settings.api_keys = ["valid-key"]` перед запросом и восстанавливается исходное значение в `finally` для изоляции окружения.

### Testing
- Запущена команда `pytest -q tests/test_generate_tk.py tests/test_generate_letter.py tests/test_generate_ks.py tests/test_middleware.py` в CI-подобном окружении.
- Тестовая прогонка завершилась ошибкой на этапе сбора тестов из-за отсутствующей зависимости `prometheus_client`, поэтому обновлённые тесты не были полностью выполнены в этом окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd118e8118832f940726fa6e7d184b)