### PR TITLE
fix: resolve 'no space left on device' in Docker CI build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo docker image prune --all --force
+          df -h /
+
       - uses: docker/setup-buildx-action@v3
       - run: docker compose build
       - run: docker compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Зависимости Python — напрямую без hatchling build
+# Сначала ставим CPU-only PyTorch (без CUDA — экономит ~2.5 ГБ)
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir \
+    torch --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir \
     "fastapi>=0.115.0" \
     "uvicorn[standard]>=0.30.0" \
     "langgraph>=0.2.0" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # ── Construction AI Core API ─────────────────
   api:


### PR DESCRIPTION
## Проблема

Сборка Docker-образа в GitHub Actions завершается ошибкой:
```
write /usr/local/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so: no space left on device
```

Пакет `sentence-transformers` тянет полный PyTorch с CUDA-библиотеками NVIDIA (~2.5 ГБ), что переполняет диск runner'а.

## Изменения

### 1. `Dockerfile` — CPU-only PyTorch
Устанавливаем PyTorch из CPU-индекса (`https://download.pytorch.org/whl/cpu`) **до** остальных зависимостей. Когда затем ставится `sentence-transformers`, pip видит уже установленный torch и не качает CUDA-версию.

**Экономия**: ~2.5 ГБ (образ ~0.8 ГБ вместо ~3.0 ГБ).

### 2. `docker-build.yml` — очистка диска runner'а
Добавлен шаг `Free disk space`, который удаляет неиспользуемые SDK (Android, .NET, GHC) и очищает кэш Docker-образов перед сборкой. Это даёт дополнительно ~20 ГБ свободного места.

### 3. `docker-compose.yml` — удалён устаревший `version`
Убран атрибут `version: "3.9"`, который вызывал warning при каждой сборке. В современных версиях Docker Compose он не нужен.

## Примечание
Если в будущем понадобится GPU-инференс в контейнере, нужно будет убрать `--index-url https://download.pytorch.org/whl/cpu` и использовать runner с большим диском или multi-stage build.