### PR TITLE
Fix Docker Build CI: add test .env, extend healthcheck wait, and surface logs on failure

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,6 +18,21 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
       - run: docker compose build
+      - name: Create test .env
+        run: |
+          cat > .env << 'EOF'
+          DEFAULT_LLM_PROVIDER=openai
+          OPENAI_API_KEY=test-key
+          API_KEYS=["test-key"]
+          SQLITE_DB_PATH=./data/construction_ai.db
+          CHROMA_PERSIST_DIR=./data/chroma
+          RAG_EMBEDDINGS_BACKEND=hash
+          BOT_TOKEN=
+          TELEGRAM_WEBHOOK_URL=
+          EOF
       - run: docker compose up -d
-      - run: sleep 5 && curl -f http://localhost:8000/health
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose logs --tail=50
+      - run: sleep 15 && curl -f http://localhost:8000/health
       - run: docker compose down


### PR DESCRIPTION
### Motivation
- The Docker Build CI job failed due to a missing `.env` file and needed more startup time and better failure diagnostics to make debugging reliable.

### Description
- Added a `Create test .env` step to `.github/workflows/docker-build.yml` before `docker compose up -d` that writes required environment variables, increased the healthcheck wait from `sleep 5` to `sleep 15`, and added a failure-only diagnostics step that runs `docker compose logs --tail=50` immediately after `docker compose up -d`.

### Testing
- Verified the workflow file contents in the workspace to confirm the `Create test .env` step, the `Show container logs on failure` step, and the updated `sleep 15` healthcheck wait are present in `.github/workflows/docker-build.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3199ab34832f98b7b5cdc9e88271)