### PR TITLE
Generate DOCX templates via script and integrate with DocxGenerator and Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ node_modules/
 .coverage
 htmlcov/
 .mypy_cache/
+
+# ── Generated DOCX templates ───────────
+templates/*.docx

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /install /usr/local
 COPY . .
 
+RUN python scripts/generate_templates.py
 RUN mkdir -p data/chroma data/db templates
 
 EXPOSE 8000

--- a/core/docx_generator.py
+++ b/core/docx_generator.py
@@ -51,13 +51,20 @@ class DocxGenerator:
         tpl.save(buffer)
         return buffer.getvalue()
 
+    def _collect_templates(self) -> list[str]:
+        return sorted(
+            path.stem
+            for path in self.templates_dir.glob("*.docx")
+            if path.is_file()
+        )
+
     def list_templates(self) -> list[str]:
         """Реальный список доступных DOCX-шаблонов (без расширения)."""
         self.templates_dir.mkdir(parents=True, exist_ok=True)
-        templates = sorted(path.stem for path in self.templates_dir.glob("*.docx") if path.is_file())
+        templates = self._collect_templates()
 
         if not templates:
             self._run_template_generator()
-            templates = sorted(path.stem for path in self.templates_dir.glob("*.docx") if path.is_file())
+            templates = self._collect_templates()
 
         return templates

--- a/core/docx_generator.py
+++ b/core/docx_generator.py
@@ -52,11 +52,7 @@ class DocxGenerator:
         return buffer.getvalue()
 
     def _collect_templates(self) -> list[str]:
-        return sorted(
-            path.stem
-            for path in self.templates_dir.glob("*.docx")
-            if path.is_file()
-        )
+        return sorted(path.stem for path in self.templates_dir.glob("*.docx") if path.is_file())
 
     def list_templates(self) -> list[str]:
         """Реальный список доступных DOCX-шаблонов (без расширения)."""

--- a/core/docx_generator.py
+++ b/core/docx_generator.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from io import BytesIO
 from pathlib import Path
 
-from docx import Document
 from docxtpl import DocxTemplate
 
 
@@ -13,126 +14,28 @@ class DocxGenerator:
     """Генератор DOCX на базе docxtpl."""
 
     def __init__(self, templates_dir: str | Path | None = None) -> None:
-        base_dir = Path(__file__).resolve().parent.parent
-        self.templates_dir = Path(templates_dir) if templates_dir else base_dir / "templates"
+        self.base_dir = Path(__file__).resolve().parent.parent
+        self.templates_dir = Path(templates_dir) if templates_dir else self.base_dir / "templates"
+        self.generate_script = self.base_dir / "scripts" / "generate_templates.py"
 
-    def _create_default_tk_template(self, template_path: Path) -> None:
-        """Создать минимальный tk_template.docx, если бинарный шаблон отсутствует."""
-        template_path.parent.mkdir(parents=True, exist_ok=True)
+    def _run_template_generator(self) -> None:
+        if not self.generate_script.exists():
+            raise FileNotFoundError(f"Template generator script not found: {self.generate_script}")
 
-        doc = Document()
-        doc.add_heading("ТЕХНОЛОГИЧЕСКАЯ КАРТА на {{work_type}}", level=1)
-
-        doc.add_heading("1. Область применения", level=2)
-        doc.add_paragraph("{{scope}}")
-
-        doc.add_heading("2. Организация и технология производства работ", level=2)
-        doc.add_paragraph("{{technology}}")
-
-        doc.add_heading("3. Требования к качеству работ", level=2)
-        doc.add_paragraph("{{quality_requirements}}")
-
-        doc.add_heading("4. Нормативные документы", level=2)
-        doc.add_paragraph(
-            "{% for doc_name in normative_docs %}"
-            "• {{doc_name}}"
-            "{% if not loop.last %}\n{% endif %}"
-            "{% endfor %}"
+        subprocess.run(
+            [sys.executable, str(self.generate_script), str(self.templates_dir)],
+            cwd=str(self.base_dir),
+            check=True,
         )
-
-        footer = doc.sections[0].footer
-        footer.paragraphs[0].text = "ГОСТ Р 21.1101 · SHA256: {{sha256}}"
-        doc.save(str(template_path))
-
-    def _create_default_ks_template(self, template_path: Path) -> None:
-        """Создать минимальный ks_template.docx, если бинарный шаблон отсутствует."""
-        template_path.parent.mkdir(parents=True, exist_ok=True)
-
-        doc = Document()
-        doc.add_heading("АКТ о приёмке выполненных работ (КС-2)", level=1)
-        doc.add_paragraph("Объект: {{object_name}}")
-        doc.add_paragraph("Договор: {{contract_number}}")
-        doc.add_paragraph("Период: {{period_from}} — {{period_to}}")
-
-        table = doc.add_table(rows=2, cols=6)
-        header = table.rows[0].cells
-        header[0].text = "№"
-        header[1].text = "Наименование работ"
-        header[2].text = "Ед.изм."
-        header[3].text = "Объём"
-        header[4].text = "Цена/ед."
-        header[5].text = "Стоимость"
-
-        row = table.rows[1].cells
-        row[0].text = "{%tr for item in work_items %}{{item.index}}"
-        row[1].text = "{{item.name}}"
-        row[2].text = "{{item.unit}}"
-        row[3].text = "{{item.volume}}"
-        row[4].text = "{{item.price_per_unit}}"
-        row[5].text = "{{item.subtotal_cost}}{%tr endfor %}"
-
-        doc.add_paragraph("Итого: {{total_cost}} руб., {{total_hours}} чел.-ч")
-        doc.save(str(template_path))
-
-    def _create_default_ppr_template(self, template_path: Path) -> None:
-        """Создать минимальный ppr_template.docx, если бинарный шаблон отсутствует."""
-        template_path.parent.mkdir(parents=True, exist_ok=True)
-
-        doc = Document()
-        doc.add_heading("ПРОЕКТ ПРОИЗВОДСТВА РАБОТ на {{work_type}}", level=1)
-        doc.add_paragraph("Объект: {{object_name}}")
-
-        doc.add_heading("1. Общие данные", level=2)
-        doc.add_paragraph("{{general_data}}")
-
-        doc.add_heading("2. Состав ППР", level=2)
-        sections_table = doc.add_table(rows=2, cols=2)
-        sections_table.rows[0].cells[0].text = "Раздел"
-        sections_table.rows[0].cells[1].text = "Описание"
-        sections_table.rows[1].cells[0].text = "{%tr for row in ppr_sections %}{{row.name}}"
-        sections_table.rows[1].cells[1].text = "{{row.description}}{%tr endfor %}"
-
-        doc.add_heading("3. Стройгенплан", level=2)
-        doc.add_paragraph("{{site_plan_description}}")
-
-        doc.add_heading("4. Календарный план работ", level=2)
-        schedule_table = doc.add_table(rows=2, cols=3)
-        schedule_table.rows[0].cells[0].text = "Этап"
-        schedule_table.rows[0].cells[1].text = "Дата начала"
-        schedule_table.rows[0].cells[2].text = "Длительность, дни"
-        schedule_table.rows[1].cells[0].text = "{%tr for item in schedule_table %}{{item.stage}}"
-        schedule_table.rows[1].cells[1].text = "{{item.start_date}}"
-        schedule_table.rows[1].cells[2].text = "{{item.duration_days}}{%tr endfor %}"
-
-        doc.add_heading("5. Мероприятия по охране труда", level=2)
-        doc.add_paragraph(
-            "{% for measure in safety_measures %}"
-            "• {{measure}}"
-            "{% if not loop.last %}\n{% endif %}"
-            "{% endfor %}"
-        )
-
-        doc.add_heading("6. Нормативные документы", level=2)
-        doc.add_paragraph("{{normative_docs}}")
-
-        doc.add_paragraph("Разработал: {{developer}}")
-        doc.add_paragraph("Дата: {{start_date}}")
-
-        doc.save(str(template_path))
 
     def _ensure_template(self, template_name: str) -> Path:
         template_path = self.templates_dir / f"{template_name}.docx"
         if template_path.exists():
             return template_path
 
-        if template_name == "tk_template":
-            self._create_default_tk_template(template_path)
-            return template_path
-        if template_name == "ks_template":
-            self._create_default_ks_template(template_path)
-            return template_path
-        if template_name == "ppr_template":
-            self._create_default_ppr_template(template_path)
+        self._run_template_generator()
+
+        if template_path.exists():
             return template_path
 
         raise FileNotFoundError(f"Template not found: {template_path}")
@@ -149,10 +52,12 @@ class DocxGenerator:
         return buffer.getvalue()
 
     def list_templates(self) -> list[str]:
-        """Список доступных DOCX-шаблонов (без расширения)."""
+        """Реальный список доступных DOCX-шаблонов (без расширения)."""
         self.templates_dir.mkdir(parents=True, exist_ok=True)
-        templates = {path.stem for path in self.templates_dir.glob("*.docx") if path.is_file()}
-        templates.add("tk_template")
-        templates.add("ks_template")
-        templates.add("ppr_template")
-        return sorted(templates)
+        templates = sorted(path.stem for path in self.templates_dir.glob("*.docx") if path.is_file())
+
+        if not templates:
+            self._run_template_generator()
+            templates = sorted(path.stem for path in self.templates_dir.glob("*.docx") if path.is_file())
+
+        return templates

--- a/scripts/generate_templates.py
+++ b/scripts/generate_templates.py
@@ -1,0 +1,157 @@
+"""Генерация DOCX-шаблонов в каталоге templates/."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml.ns import qn
+from docx.shared import Pt
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+
+def _apply_default_font(document: Document) -> None:
+    style = document.styles["Normal"]
+    style.font.name = "Times New Roman"
+    style.font.size = Pt(12)
+    style.element.rPr.rFonts.set(qn("w:eastAsia"), "Times New Roman")
+
+
+def _add_heading(document: Document, text: str) -> None:
+    paragraph = document.add_paragraph()
+    run = paragraph.add_run(text)
+    run.bold = True
+    run.font.name = "Times New Roman"
+    run.font.size = Pt(14)
+    run._element.rPr.rFonts.set(qn("w:eastAsia"), "Times New Roman")
+
+
+def build_tk_template(output_path: Path) -> None:
+    doc = Document()
+    _apply_default_font(doc)
+
+    _add_heading(doc, "ТЕХНОЛОГИЧЕСКАЯ КАРТА на {{work_type}}")
+    doc.add_paragraph()
+
+    sections = [
+        ("Область применения", "{{scope}}"),
+        ("Организация работ", "{{technology}}"),
+        ("Технология производства", "{{technology}}"),
+        ("Требования к качеству", "{{quality_requirements}}"),
+        ("Техника безопасности", "{{safety}}"),
+        ("Нормативные документы", "{{normative_docs}}"),
+    ]
+
+    for title, body in sections:
+        _add_heading(doc, title)
+        doc.add_paragraph(body)
+
+    footer = doc.sections[0].footer
+    footer.paragraphs[0].text = "ГОСТ Р 21.1101 · SHA256: {{sha256}}"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(output_path)
+
+
+def build_letter_template(output_path: Path) -> None:
+    doc = Document()
+    _apply_default_font(doc)
+
+    header = doc.add_table(rows=1, cols=2)
+    header.rows[0].cells[0].text = "{{sender_org}}"
+    header.rows[0].cells[1].text = "{{addressee}}"
+    header.rows[0].cells[1].paragraphs[0].alignment = WD_ALIGN_PARAGRAPH.RIGHT
+
+    doc.add_paragraph("Исх. №{{outgoing_number}} от {{date}}")
+    doc.add_paragraph("Этап 24 — DOCX-шаблоны для всех типов документов (2 дня)")
+
+    _add_heading(doc, "Тема: {{subject}}")
+    doc.add_paragraph("{{body}}")
+    doc.add_paragraph("Подпись: {{signer_position}} _________ {{signer_name}}")
+    doc.add_paragraph("Правовое основание: {{legal_references}}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(output_path)
+
+
+def build_ks_template(output_path: Path) -> None:
+    doc = Document()
+    _apply_default_font(doc)
+
+    _add_heading(doc, "АКТ о приёмке выполненных работ (форма КС-2)")
+    doc.add_paragraph("Объект: {{object_name}}, Договор: {{contract_number}}")
+    doc.add_paragraph("Период: {{period_from}} — {{period_to}}")
+
+    table = doc.add_table(rows=2, cols=6)
+    headers = ["№", "Наименование", "Ед.изм.", "Объём", "Цена/ед.", "Стоимость"]
+    for index, text in enumerate(headers):
+        table.rows[0].cells[index].text = text
+
+    row = table.rows[1].cells
+    row[0].text = "{%tr for item in work_items %}{{item.index}}"
+    row[1].text = "{{item.name}}"
+    row[2].text = "{{item.unit}}"
+    row[3].text = "{{item.volume}}"
+    row[4].text = "{{item.price_per_unit}}"
+    row[5].text = "{{item.subtotal_cost}}{%tr endfor %}"
+
+    doc.add_paragraph("Итого: {{total_cost}} руб., {{total_hours}} чел.-ч")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(output_path)
+
+
+def build_ppr_template(output_path: Path) -> None:
+    doc = Document()
+    _apply_default_font(doc)
+
+    _add_heading(doc, "ПРОЕКТ ПРОИЗВОДСТВА РАБОТ на {{work_type}}")
+
+    sections = [
+        "Общие данные",
+        "Состав ППР",
+        "Стройгенплан",
+        "Календарный план",
+        "Охрана труда",
+        "Нормативные документы",
+    ]
+    for title in sections:
+        _add_heading(doc, title)
+        doc.add_paragraph(f"{{{{{title.lower().replace(' ', '_')}}}}}")
+
+    doc.add_paragraph("Разработал: {{developer}}")
+    doc.add_paragraph("Дата: {{date}}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(output_path)
+
+
+def generate_all_templates(templates_dir: Path = TEMPLATES_DIR) -> list[Path]:
+    templates_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "tk_template.docx": build_tk_template,
+        "letter_template.docx": build_letter_template,
+        "ks_template.docx": build_ks_template,
+        "ppr_template.docx": build_ppr_template,
+    }
+
+    generated: list[Path] = []
+    for filename, builder in files.items():
+        output_path = templates_dir / filename
+        builder(output_path)
+        generated.append(output_path)
+
+    return generated
+
+
+if __name__ == "__main__":
+    target_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else TEMPLATES_DIR
+    created = generate_all_templates(target_dir)
+    for path in created:
+        print(f"generated: {path}")

--- a/scripts/generate_templates.py
+++ b/scripts/generate_templates.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 from docx import Document
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml.ns import qn
 from docx.shared import Pt
-
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 TEMPLATES_DIR = BASE_DIR / "templates"

--- a/scripts/generate_templates.py
+++ b/scripts/generate_templates.py
@@ -111,20 +111,41 @@ def build_ppr_template(output_path: Path) -> None:
 
     _add_heading(doc, "ПРОЕКТ ПРОИЗВОДСТВА РАБОТ на {{work_type}}")
 
-    sections = [
-        "Общие данные",
-        "Состав ППР",
-        "Стройгенплан",
-        "Календарный план",
-        "Охрана труда",
-        "Нормативные документы",
-    ]
-    for title in sections:
-        _add_heading(doc, title)
-        doc.add_paragraph(f"{{{{{title.lower().replace(' ', '_')}}}}}")
+    _add_heading(doc, "Общие данные")
+    doc.add_paragraph("{{general_data}}")
+
+    _add_heading(doc, "Состав ППР")
+    sections_table = doc.add_table(rows=2, cols=2)
+    sections_table.rows[0].cells[0].text = "Раздел"
+    sections_table.rows[0].cells[1].text = "Описание"
+    sections_table.rows[1].cells[0].text = "{%tr for row in ppr_sections %}{{row.name}}"
+    sections_table.rows[1].cells[1].text = "{{row.description}}{%tr endfor %}"
+
+    _add_heading(doc, "Стройгенплан")
+    doc.add_paragraph("{{site_plan_description}}")
+
+    _add_heading(doc, "Календарный план")
+    schedule_table = doc.add_table(rows=2, cols=3)
+    schedule_table.rows[0].cells[0].text = "Этап"
+    schedule_table.rows[0].cells[1].text = "Дата начала"
+    schedule_table.rows[0].cells[2].text = "Длительность, дни"
+    schedule_table.rows[1].cells[0].text = "{%tr for item in schedule_table %}{{item.stage}}"
+    schedule_table.rows[1].cells[1].text = "{{item.start_date}}"
+    schedule_table.rows[1].cells[2].text = "{{item.duration_days}}{%tr endfor %}"
+
+    _add_heading(doc, "Охрана труда")
+    doc.add_paragraph(
+        "{% for measure in safety_measures %}"
+        "• {{measure}}"
+        "{% if not loop.last %}\n{% endif %}"
+        "{% endfor %}"
+    )
+
+    _add_heading(doc, "Нормативные документы")
+    doc.add_paragraph("{{normative_docs}}")
 
     doc.add_paragraph("Разработал: {{developer}}")
-    doc.add_paragraph("Дата: {{date}}")
+    doc.add_paragraph("Дата: {{start_date}}")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     doc.save(output_path)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,11 +1,17 @@
 # Templates
 
-В репозитории не храним бинарные `.docx` файлы.
+В репозитории **не храним** бинарные `.docx` файлы.
 
-`tk_template.docx` создаётся автоматически в рантайме классом `DocxGenerator`
-при первом вызове `generate("tk_template", context)`.
+Все шаблоны создаются скриптом:
 
-`ks_template.docx` также создаётся автоматически в рантайме (или скриптом `python scripts/generate_ks_template.py`).
+```bash
+python scripts/generate_templates.py
+```
 
-`ppr_template.docx` создаётся автоматически в рантайме классом `DocxGenerator`
-при первом вызове `generate("ppr_template", context)`.
+Скрипт генерирует:
+- `tk_template.docx`
+- `letter_template.docx`
+- `ks_template.docx`
+- `ppr_template.docx`
+
+`DocxGenerator` также автоматически запускает генерацию, если нужного шаблона нет в `templates/`.


### PR DESCRIPTION
### Motivation
- Avoid storing binary `.docx` files in the repository by generating templates programmatically. 
- Centralize DOCX template creation into a single script so the `DocxGenerator` no longer contains inline binary template builders. 
- Ensure templates are available at runtime and optionally pre-generated in the Docker image to avoid first-run overhead.

### Description
- Add `scripts/generate_templates.py` which programmatically builds `tk_template.docx`, `letter_template.docx`, `ks_template.docx`, and `ppr_template.docx` using `python-docx` and writes them into the `templates/` directory. 
- Update `core/docx_generator.py` to remove inline template construction, detect missing templates and call the generator script via `subprocess` (`_run_template_generator`), and to refresh `list_templates()` by invoking the generator when no templates are present. 
- Modify `Dockerfile` to run `python scripts/generate_templates.py` during image build so templates are present in the container image. 
- Add `templates/*.docx` to `.gitignore` and update `templates/README.md` with usage instructions and list of generated templates. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3f28565c832fa81406e3356c9099)