### PR TITLE
Add production automation scripts (backup, deploy, cron) and update Grafana dashboard

### DIFF
--- a/monitoring/grafana_dashboard.json
+++ b/monitoring/grafana_dashboard.json
@@ -2,16 +2,16 @@
   "title": "Construction AI Core Overview",
   "timezone": "browser",
   "schemaVersion": 38,
-  "version": 1,
+  "version": 2,
   "refresh": "15s",
   "panels": [
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Requests per second (HTTP)",
+      "title": "HTTP Requests per second",
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total[1m]))",
+          "expr": "sum(rate(http_requests_total[5m]))",
           "legendFormat": "RPS"
         }
       ],
@@ -20,50 +20,50 @@
     {
       "id": 2,
       "type": "timeseries",
-      "title": "Pipeline duration p50/p95/p99",
+      "title": "Pipeline duration p95",
       "targets": [
-        {"expr": "histogram_quantile(0.50, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p50"},
-        {"expr": "histogram_quantile(0.95, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p95"},
-        {"expr": "histogram_quantile(0.99, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))", "legendFormat": "p99"}
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(construction_ai_pipeline_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        }
       ],
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
     },
     {
       "id": 3,
-      "type": "barchart",
-      "title": "Agent runs by agent_id (stacked bar)",
-      "options": {"stacking": "normal"},
+      "type": "timeseries",
+      "title": "Agent runs by agent_id",
       "targets": [
         {
-          "expr": "sum by (agent_id, status) (increase(construction_ai_agent_runs_total[5m]))",
-          "legendFormat": "{{agent_id}} {{status}}"
+          "expr": "sum by (agent_id) (construction_ai_agent_runs_total)",
+          "legendFormat": "{{agent_id}}"
         }
       ],
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8}
     },
     {
       "id": 4,
-      "type": "timeseries",
-      "title": "LLM tokens per minute",
-      "targets": [
-        {
-          "expr": "sum by (provider, direction) (rate(construction_ai_llm_tokens_total[1m])) * 60",
-          "legendFormat": "{{provider}} {{direction}}"
-        }
-      ],
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8}
-    },
-    {
-      "id": 5,
       "type": "gauge",
-      "title": "Active sessions gauge",
+      "title": "Active sessions",
       "targets": [
         {
           "expr": "construction_ai_active_sessions",
           "legendFormat": "active sessions"
         }
       ],
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16}
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8}
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Error rate",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx rate"
+        }
+      ],
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16}
     }
   ]
 }

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+BACKUP_DIR="/opt/backups/construction-ai"
+DATE=$(date +%Y%m%d_%H%M%S)
+
+mkdir -p "$BACKUP_DIR"
+
+# Бэкап SQLite
+cp /opt/construction-ai-core/data/construction_ai.db \
+  "$BACKUP_DIR/db_$DATE.sqlite"
+
+# Бэкап ChromaDB
+tar -czf "$BACKUP_DIR/chroma_$DATE.tar.gz" \
+  -C /opt/construction-ai-core/data chroma/
+
+# Удалить бэкапы старше 14 дней
+find "$BACKUP_DIR" -type f -mtime +14 -delete
+
+echo "Backup completed: $DATE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+cd /opt/construction-ai-core
+
+echo "=== Pulling latest code ==="
+git pull origin main
+
+echo "=== Building containers ==="
+docker compose build
+
+echo "=== Restarting services ==="
+docker compose down
+docker compose up -d
+
+echo "=== Waiting for startup ==="
+sleep 15
+
+if curl -sf http://localhost:8000/health > /dev/null; then
+  echo "✅ Deploy successful"
+else
+  echo "❌ Health check failed!"
+  docker compose logs --tail=30
+  exit 1
+fi

--- a/scripts/setup_cron.sh
+++ b/scripts/setup_cron.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Добавляет cron-задачи на сервер
+(crontab -l 2>/dev/null; echo "0 3 * * * /opt/construction-ai-core/scripts/backup.sh") | crontab -
+(crontab -l 2>/dev/null; echo "0 4 1,15 * * certbot renew --quiet") | crontab -
+
+echo "Cron jobs installed"


### PR DESCRIPTION
### Motivation
- Prepare production-ready automation for a VDS: scheduled backups, a simple deploy workflow, and cron installation for recurring tasks. 
- Provide monitoring visibility for key production metrics in Grafana (RPS, pipeline latency, agent runs, sessions, and error rate).

### Description
- Added `scripts/backup.sh` which creates `/opt/backups/construction-ai`, copies the SQLite DB, archives the ChromaDB directory, and removes backups older than 14 days.  
- Added `scripts/deploy.sh` which pulls `main`, builds Docker Compose services, restarts them, waits, and performs a `/health` check with logs on failure.  
- Added `scripts/setup_cron.sh` which installs two cron jobs: nightly backup at `03:00` and `certbot renew` at `04:00` on the 1st and 15th.  
- Updated `monitoring/grafana_dashboard.json` to include the requested panels and PromQL expressions for HTTP RPS, pipeline p95, agent runs by `agent_id`, active sessions, and 5xx error rate.

### Testing
- Ran `bash -n scripts/backup.sh scripts/deploy.sh scripts/setup_cron.sh` and it reported no syntax errors.  
- Validated `monitoring/grafana_dashboard.json` with `python -m json.tool monitoring/grafana_dashboard.json` which succeeded.  
- Files were made executable and changes were committed; automated validations listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd42d85600832f957f60d73c7af2f0)