### PR TITLE
Integrate tk-generator bridge into generate_tk with AI fallback

### DIFF
--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -166,6 +166,20 @@ async def generate_tk(payload: TKRequest, request: Request):
             session_id=session_id,
             role=payload.role,
             intent="generate_tk",
+            extra_state={
+                "work_type": payload.work_type,
+                "object_name": payload.object_name,
+                "volume": payload.volume,
+                "unit": payload.unit,
+                "norms": payload.norms,
+                "tk_generator_input": {
+                    "work_type": payload.work_type,
+                    "object_name": payload.object_name,
+                    "volume": payload.volume,
+                    "unit": payload.unit,
+                    "norms": payload.norms,
+                },
+            },
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"LLM processing error: {exc}") from exc
@@ -186,6 +200,9 @@ async def generate_tk(payload: TKRequest, request: Request):
     document = (
         state.get("final_output") or state.get("docx_payload") or {"content": result.get("reply")}
     )
+    tk_bridge_result = result.get("tk_bridge_result") if isinstance(result, dict) else None
+    if isinstance(document, dict) and tk_bridge_result:
+        document["tk_generator"] = tk_bridge_result
 
     return TKResponse(
         session_id=result["session_id"],

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -25,6 +25,7 @@ from agents.verifier import VerifierAgent
 from api.metrics import PIPELINE_DURATION
 from core.llm_router import LLMRouter
 from core.session_memory import SessionMemory
+from core.tk_bridge import TKGeneratorBridge
 
 
 class PipelineState(TypedDict):
@@ -54,6 +55,7 @@ class Orchestrator:
         self.config = self._load_config()
         self.llm_router = LLMRouter()
         self.session_memory = SessionMemory()
+        self.tk_bridge = TKGeneratorBridge()
         self.agents: dict[str, dict] = {agent["id"]: agent for agent in self.config["agents"]}
 
     def _load_config(self) -> dict:
@@ -167,6 +169,24 @@ class Orchestrator:
 
         return graph
 
+    def _build_tk_generator_input(
+        self,
+        message: str,
+        role: str,
+        extra_state: dict[str, Any] | None,
+        calculator_state: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Собрать payload для внешнего tk-generator."""
+        extra_state = extra_state or {}
+        payload = dict(extra_state.get("tk_generator_input", {}))
+        payload.setdefault("message", message)
+        payload.setdefault("role", role)
+        payload["calculations"] = {
+            "ks2_data": calculator_state.get("ks2_data", {}),
+            "ks3_data": calculator_state.get("ks3_data", {}),
+        }
+        return payload
+
     async def _run_pipeline(
         self,
         intent: str,
@@ -188,6 +208,46 @@ class Orchestrator:
                 "confidence": None,
             }
 
+        tk_bridge_result: dict[str, Any] | None = None
+        tk_bridge_enabled = intent == "generate_tk" and self.tk_bridge.is_available()
+        if tk_bridge_enabled:
+            try:
+                calculator_state: dict[str, Any] = {
+                    "history": [],
+                    "calculation_params": {
+                        "work_items": [
+                            {
+                                "name": (extra_state or {}).get("work_type", "Работы по ТК"),
+                                "unit": (extra_state or {}).get("unit", "шт."),
+                                "volume": float((extra_state or {}).get("volume", 1.0)),
+                                "norm_hours": 1.0,
+                                "price_per_unit": 0.0,
+                            }
+                        ]
+                    },
+                }
+                calculator_agent = self._get_agent("calculator")
+                calculator_state = await cast(Any, calculator_agent).run(calculator_state)
+                tk_input = self._build_tk_generator_input(message, role, extra_state, calculator_state)
+                tk_bridge_result = await self.tk_bridge.generate(tk_input)
+
+                bridge_context = (
+                    "\n\nДетерминированная часть подготовлена tk-generator. "
+                    f"Файлы: DOCX={tk_bridge_result.get('docx_path', '')}, "
+                    f"PDF={tk_bridge_result.get('pdf_path', '')}. "
+                    "Используй эти данные как основу и дополни описательную часть документа."
+                )
+                merged_state = dict(extra_state or {})
+                merged_state["tk_bridge_result"] = tk_bridge_result
+                merged_state["calculation_result"] = {
+                    "ks2_data": calculator_state.get("ks2_data", {}),
+                    "ks3_data": calculator_state.get("ks3_data", {}),
+                }
+                merged_state["context"] = f"{merged_state.get('context', '')}{bridge_context}".strip()
+                extra_state = merged_state
+            except Exception:
+                tk_bridge_result = None
+
         graph = self._build_graph(pipeline).compile()
         initial_state: PipelineState = {
             "message": message,
@@ -208,13 +268,16 @@ class Orchestrator:
         last_output = ""
         if history and isinstance(history[-1], dict):
             last_output = str(history[-1].get("output", ""))
-        return {
+        result_payload = {
             "reply": last_output,
             "session_id": session_id,
             "agents_used": pipeline,
             "confidence": final_state.get("confidence"),
             "state": final_state,
         }
+        if tk_bridge_result:
+            result_payload["tk_bridge_result"] = tk_bridge_result
+        return result_payload
 
     async def process(
         self,

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -228,7 +228,9 @@ class Orchestrator:
                 }
                 calculator_agent = self._get_agent("calculator")
                 calculator_state = await cast(Any, calculator_agent).run(calculator_state)
-                tk_input = self._build_tk_generator_input(message, role, extra_state, calculator_state)
+                tk_input = self._build_tk_generator_input(
+                    message, role, extra_state, calculator_state
+                )
                 tk_bridge_result = await self.tk_bridge.generate(tk_input)
 
                 bridge_context = (
@@ -243,7 +245,9 @@ class Orchestrator:
                     "ks2_data": calculator_state.get("ks2_data", {}),
                     "ks3_data": calculator_state.get("ks3_data", {}),
                 }
-                merged_state["context"] = f"{merged_state.get('context', '')}{bridge_context}".strip()
+                merged_state["context"] = (
+                    f"{merged_state.get('context', '')}{bridge_context}".strip()
+                )
                 extra_state = merged_state
             except Exception:
                 tk_bridge_result = None

--- a/core/tk_bridge.py
+++ b/core/tk_bridge.py
@@ -22,42 +22,55 @@ class TKGeneratorBridge:
         """Вызывает tk-generator через subprocess и возвращает результат."""
         generator_root = Path(self.path).expanduser().resolve()
         out_dir = Path(tempfile.mkdtemp(prefix="tk_generator_out_"))
+        timeout_seconds = 120
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as input_file:
             json.dump(input_json, input_file, ensure_ascii=False, indent=2)
             input_path = Path(input_file.name)
 
-        cmd = [
-            "node",
-            "src/index.js",
-            "--input",
-            str(input_path),
-            "--output",
-            str(out_dir),
-        ]
-        process = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=str(generator_root),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await process.communicate()
-
-        if process.returncode != 0:
-            raise RuntimeError(
-                "tk-generator failed: "
-                f"returncode={process.returncode}, stdout={stdout.decode(errors='ignore')}, "
-                f"stderr={stderr.decode(errors='ignore')}"
+        try:
+            cmd = [
+                "node",
+                "src/index.js",
+                "--input",
+                str(input_path),
+                "--output",
+                str(out_dir),
+            ]
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(generator_root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout_seconds
+                )
+            except TimeoutError as exc:
+                process.kill()
+                await process.wait()
+                raise RuntimeError(
+                    f"tk-generator timed out after {timeout_seconds} seconds"
+                ) from exc
 
-        docx_file = next(out_dir.rglob("*.docx"), None)
-        pdf_file = next(out_dir.rglob("*.pdf"), None)
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "tk-generator failed: "
+                    f"returncode={process.returncode}, stdout={stdout.decode(errors='ignore')}, "
+                    f"stderr={stderr.decode(errors='ignore')}"
+                )
 
-        return {
-            "output_dir": str(out_dir),
-            "docx_path": str(docx_file) if docx_file else "",
-            "pdf_path": str(pdf_file) if pdf_file else "",
-        }
+            docx_file = next(out_dir.rglob("*.docx"), None)
+            pdf_file = next(out_dir.rglob("*.pdf"), None)
+
+            return {
+                "output_dir": str(out_dir),
+                "docx_path": str(docx_file) if docx_file else "",
+                "pdf_path": str(pdf_file) if pdf_file else "",
+            }
+        finally:
+            input_path.unlink(missing_ok=True)
 
     def is_available(self) -> bool:
         """Проверяет что tk-generator установлен и Node.js доступен."""

--- a/core/tk_bridge.py
+++ b/core/tk_bridge.py
@@ -1,0 +1,67 @@
+"""Bridge для интеграции с внешним tk-generator (Node.js)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from config.settings import settings
+
+
+class TKGeneratorBridge:
+    """Вызывает внешний tk-generator и возвращает пути к артефактам."""
+
+    def __init__(self, tk_generator_path: str = settings.tk_generator_path):
+        self.path = tk_generator_path
+
+    async def generate(self, input_json: dict[str, Any]) -> dict[str, str]:
+        """Вызывает tk-generator через subprocess и возвращает результат."""
+        generator_root = Path(self.path).expanduser().resolve()
+        out_dir = Path(tempfile.mkdtemp(prefix="tk_generator_out_"))
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as input_file:
+            json.dump(input_json, input_file, ensure_ascii=False, indent=2)
+            input_path = Path(input_file.name)
+
+        cmd = [
+            "node",
+            "src/index.js",
+            "--input",
+            str(input_path),
+            "--output",
+            str(out_dir),
+        ]
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(generator_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+
+        if process.returncode != 0:
+            raise RuntimeError(
+                "tk-generator failed: "
+                f"returncode={process.returncode}, stdout={stdout.decode(errors='ignore')}, "
+                f"stderr={stderr.decode(errors='ignore')}"
+            )
+
+        docx_file = next(out_dir.rglob("*.docx"), None)
+        pdf_file = next(out_dir.rglob("*.pdf"), None)
+
+        return {
+            "output_dir": str(out_dir),
+            "docx_path": str(docx_file) if docx_file else "",
+            "pdf_path": str(pdf_file) if pdf_file else "",
+        }
+
+    def is_available(self) -> bool:
+        """Проверяет что tk-generator установлен и Node.js доступен."""
+        generator_root = Path(self.path).expanduser().resolve()
+        index_file = generator_root / "src" / "index.js"
+        node_binary = shutil.which("node")
+        return bool(node_binary and generator_root.exists() and index_file.exists())

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -10,7 +10,9 @@ from core.orchestrator import Orchestrator
 def test_detect_intent_generate_tk():
     """Фраза про ТК должна маршрутизироваться в generate_tk."""
     orchestrator = Orchestrator()
-    orchestrator.llm_router.query = AsyncMock(return_value=SimpleNamespace(text="generate_tk"))
+    orchestrator.llm_router.query = AsyncMock(
+        return_value=SimpleNamespace(text="generate_tk")
+    )
 
     intent = asyncio.run(orchestrator._detect_intent("сделай ТК на бетонирование"))
 
@@ -20,7 +22,9 @@ def test_detect_intent_generate_tk():
 def test_detect_intent_generate_letter():
     """Фраза про письмо подрядчику должна маршрутизироваться в generate_letter."""
     orchestrator = Orchestrator()
-    orchestrator.llm_router.query = AsyncMock(return_value=SimpleNamespace(text="generate_letter"))
+    orchestrator.llm_router.query = AsyncMock(
+        return_value=SimpleNamespace(text="generate_letter")
+    )
 
     intent = asyncio.run(orchestrator._detect_intent("напиши письмо подрядчику"))
 
@@ -45,7 +49,9 @@ def test_run_pipeline_generate_tk_uses_bridge_when_available():
 
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
-            ainvoke=AsyncMock(return_value={"history": [{"output": "готово"}], "confidence": 0.9})
+            ainvoke=AsyncMock(
+                return_value={"history": [{"output": "готово"}], "confidence": 0.9}
+            )
         )
     )
 
@@ -72,7 +78,9 @@ def test_run_pipeline_generate_tk_fallback_without_bridge():
 
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
-            ainvoke=AsyncMock(return_value={"history": [{"output": "ai-only"}], "confidence": 0.8})
+            ainvoke=AsyncMock(
+                return_value={"history": [{"output": "ai-only"}], "confidence": 0.8}
+            )
         )
     )
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -10,9 +10,7 @@ from core.orchestrator import Orchestrator
 def test_detect_intent_generate_tk():
     """Фраза про ТК должна маршрутизироваться в generate_tk."""
     orchestrator = Orchestrator()
-    orchestrator.llm_router.query = AsyncMock(
-        return_value=SimpleNamespace(text="generate_tk")
-    )
+    orchestrator.llm_router.query = AsyncMock(return_value=SimpleNamespace(text="generate_tk"))
 
     intent = asyncio.run(orchestrator._detect_intent("сделай ТК на бетонирование"))
 
@@ -22,9 +20,7 @@ def test_detect_intent_generate_tk():
 def test_detect_intent_generate_letter():
     """Фраза про письмо подрядчику должна маршрутизироваться в generate_letter."""
     orchestrator = Orchestrator()
-    orchestrator.llm_router.query = AsyncMock(
-        return_value=SimpleNamespace(text="generate_letter")
-    )
+    orchestrator.llm_router.query = AsyncMock(return_value=SimpleNamespace(text="generate_letter"))
 
     intent = asyncio.run(orchestrator._detect_intent("напиши письмо подрядчику"))
 
@@ -40,18 +36,14 @@ def test_run_pipeline_generate_tk_uses_bridge_when_available():
     )
 
     mock_calculator = AsyncMock()
-    mock_calculator.run = AsyncMock(
-        return_value={"history": [], "ks2_data": {}, "ks3_data": {}}
-    )
+    mock_calculator.run = AsyncMock(return_value={"history": [], "ks2_data": {}, "ks3_data": {}})
     orchestrator._get_agent = lambda name: mock_calculator
 
     orchestrator.session_memory.get = AsyncMock(return_value=[])
 
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
-            ainvoke=AsyncMock(
-                return_value={"history": [{"output": "готово"}], "confidence": 0.9}
-            )
+            ainvoke=AsyncMock(return_value={"history": [{"output": "готово"}], "confidence": 0.9})
         )
     )
 
@@ -78,9 +70,7 @@ def test_run_pipeline_generate_tk_fallback_without_bridge():
 
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
-            ainvoke=AsyncMock(
-                return_value={"history": [{"output": "ai-only"}], "confidence": 0.8}
-            )
+            ainvoke=AsyncMock(return_value={"history": [{"output": "ai-only"}], "confidence": 0.8})
         )
     )
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -34,6 +34,15 @@ def test_run_pipeline_generate_tk_uses_bridge_when_available():
     orchestrator.tk_bridge.generate = AsyncMock(
         return_value={"docx_path": "/tmp/tk.docx", "pdf_path": "/tmp/tk.pdf"}
     )
+
+    mock_calculator = AsyncMock()
+    mock_calculator.run = AsyncMock(
+        return_value={"history": [], "ks2_data": {}, "ks3_data": {}}
+    )
+    orchestrator._get_agent = lambda name: mock_calculator
+
+    orchestrator.session_memory.get = AsyncMock(return_value=[])
+
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
             ainvoke=AsyncMock(return_value={"history": [{"output": "готово"}], "confidence": 0.9})
@@ -58,6 +67,9 @@ def test_run_pipeline_generate_tk_fallback_without_bridge():
     """При недоступности bridge пайплайн продолжает работать в AI-only режиме."""
     orchestrator = Orchestrator()
     orchestrator.tk_bridge.is_available = lambda: False
+
+    orchestrator.session_memory.get = AsyncMock(return_value=[])
+
     orchestrator._build_graph = lambda pipeline: SimpleNamespace(
         compile=lambda: SimpleNamespace(
             ainvoke=AsyncMock(return_value={"history": [{"output": "ai-only"}], "confidence": 0.8})

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -25,3 +25,53 @@ def test_detect_intent_generate_letter():
     intent = asyncio.run(orchestrator._detect_intent("напиши письмо подрядчику"))
 
     assert intent == "generate_letter"
+
+
+def test_run_pipeline_generate_tk_uses_bridge_when_available():
+    """При доступности bridge оркестратор добавляет артефакты tk-generator в результат."""
+    orchestrator = Orchestrator()
+    orchestrator.tk_bridge.is_available = lambda: True
+    orchestrator.tk_bridge.generate = AsyncMock(
+        return_value={"docx_path": "/tmp/tk.docx", "pdf_path": "/tmp/tk.pdf"}
+    )
+    orchestrator._build_graph = lambda pipeline: SimpleNamespace(
+        compile=lambda: SimpleNamespace(
+            ainvoke=AsyncMock(return_value={"history": [{"output": "готово"}], "confidence": 0.9})
+        )
+    )
+
+    result = asyncio.run(
+        orchestrator._run_pipeline(
+            intent="generate_tk",
+            message="сформируй тк",
+            session_id="s1",
+            role="pto_engineer",
+            extra_state={"work_type": "Бетон", "unit": "м³", "volume": 10},
+        )
+    )
+
+    assert result["reply"] == "готово"
+    assert result["tk_bridge_result"]["docx_path"] == "/tmp/tk.docx"
+
+
+def test_run_pipeline_generate_tk_fallback_without_bridge():
+    """При недоступности bridge пайплайн продолжает работать в AI-only режиме."""
+    orchestrator = Orchestrator()
+    orchestrator.tk_bridge.is_available = lambda: False
+    orchestrator._build_graph = lambda pipeline: SimpleNamespace(
+        compile=lambda: SimpleNamespace(
+            ainvoke=AsyncMock(return_value={"history": [{"output": "ai-only"}], "confidence": 0.8})
+        )
+    )
+
+    result = asyncio.run(
+        orchestrator._run_pipeline(
+            intent="generate_tk",
+            message="сформируй тк",
+            session_id="s2",
+            role="pto_engineer",
+        )
+    )
+
+    assert result["reply"] == "ai-only"
+    assert "tk_bridge_result" not in result


### PR DESCRIPTION
### Motivation
- Добавить мост к существующему Node.js `tk-generator` для вывода детерминированной части ТК и артефактов (DOCX/PDF). 
- Передавать в `tk-generator` расчётные данные из `CalculatorAgent` и использовать его результат как основу для дальнейших AI-агентов (Author/Critic/Formatter). 
- Обеспечить безопасный fallback на существующий AI-only pipeline, если `tk-generator` или `node` недоступны.

### Description
- Добавлен новый файл `core/tk_bridge.py` с классом `TKGeneratorBridge`, реализующим `generate(input_json)` через `asyncio.create_subprocess_exec` и `is_available()` (проверяет `node` и наличие `src/index.js`).
- В `core/orchestrator.py` инициализирован `TKGeneratorBridge`, добавлен хелпер `._build_tk_generator_input(...)`, и при intent `generate_tk` при доступности моста выполняется предварительный запуск `CalculatorAgent`, затем вызов `tk_bridge.generate(...)`, слияние `tk_bridge_result` и расчётов в `extra_state` и добавление контекста для AI-агентов.
- Результат `_run_pipeline` теперь может включать ключ `tk_bridge_result` с путями `docx_path`/`pdf_path`, и `process`/`generate_tk` endpoint теперь передаёт структурированный `extra_state.tk_generator_input` в orchestrator.
- Обновлён `api/routes/generate.py` (`/generate/tk`) чтобы передавать `extra_state` с полями `work_type`, `object_name`, `volume`, `unit`, `norms` и включать `tk_generator` block в `document` ответа при наличии артефактов.
- Добавлены тесты в `tests/test_orchestrator.py` для сценариев: мост доступен (bridge-enabled) и мост недоступен (fallback to AI-only).

### Testing
- Запущено `pytest -q tests/test_orchestrator.py tests/test_generate_tk.py` и все тесты прошли: `6 passed, 1 warning` (warning: `Unknown config option: asyncio_mode`).
- Тесты покрывают intent-детекцию и оба сценария `generate_tk` (bridge available и fallback), и все утверждения в новых тестах успешно выполняются.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd44ac637c832f8d703b9d3f0cc5f1)