### PR TITLE
Add LLMRouter provider fallback, intent cache, and token usage tracking

### DIFF
--- a/core/llm_router.py
+++ b/core/llm_router.py
@@ -4,10 +4,14 @@
 Поддерживаемые провайдеры: Perplexity, OpenAI, Claude, Deepseek.
 """
 
+import asyncio
+from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
+import time
 
 import httpx
+import structlog
 
 from api.metrics import LLM_TOKENS_USED
 from config.settings import settings
@@ -70,6 +74,10 @@ class LLMRouter:
     def __init__(self, default_provider: LLMProvider | None = None):
         self.default_provider = default_provider or LLMProvider(settings.default_llm_provider)
         self._client = httpx.AsyncClient(timeout=60.0)
+        self._logger = structlog.get_logger("core.llm_router")
+        self._intent_cache: OrderedDict[int, tuple[str, float]] = OrderedDict()
+        self._intent_cache_ttl_seconds = 3600
+        self._intent_cache_max_entries = 1000
 
     async def query(
         self,
@@ -95,15 +103,7 @@ class LLMRouter:
             LLMResponse с текстом ответа и метаданными.
         """
         provider = provider or self.default_provider
-        config = PROVIDER_CONFIG[provider]
-        model = model or config["default_model"]
-        api_key = getattr(settings, config["api_key_field"])
-
-        if not api_key:
-            raise ValueError(
-                f"API-ключ для {provider.value} не настроен. "
-                f"Добавьте {config['api_key_field'].upper()} в .env"
-            )
+        providers_chain = [provider, *[p for p in LLMProvider if p != provider]]
 
         # Формируем messages
         messages = []
@@ -111,28 +111,138 @@ class LLMRouter:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
 
-        # Отправляем запрос (OpenAI-совместимый формат)
-        if provider == LLMProvider.CLAUDE:
-            response_data = await self._query_claude(
-                api_key, model, messages, temperature, max_tokens
-            )
-        else:
-            response_data = await self._query_openai_compatible(
-                config["base_url"], api_key, model, messages, temperature, max_tokens
-            )
+        cache_key = self._intent_cache_key(system_prompt, prompt)
+        if cache_key is not None:
+            cached_intent = self._get_cached_intent(cache_key)
+            if cached_intent is not None:
+                return LLMResponse(
+                    text=cached_intent,
+                    provider=provider,
+                    model=model or PROVIDER_CONFIG[provider]["default_model"],
+                    usage={"tokens_input": 0, "tokens_output": 0},
+                )
 
-        usage = response_data.get("usage") or {}
-        if isinstance(usage, dict) and "prompt_tokens" in usage:
-            LLM_TOKENS_USED.labels(provider=provider.value, direction="input").inc(
-                usage["prompt_tokens"]
-            )
+        response_data = None
+        used_provider = None
+        used_model = None
+        max_attempts = 3
+        last_error: Exception | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            current_provider = providers_chain[attempt - 1]
+            config = PROVIDER_CONFIG[current_provider]
+            current_model = model or config["default_model"]
+            api_key = getattr(settings, config["api_key_field"])
+            if not api_key:
+                last_error = ValueError(
+                    f"API-ключ для {current_provider.value} не настроен. "
+                    f"Добавьте {config['api_key_field'].upper()} в .env"
+                )
+                if attempt < max_attempts:
+                    await self._sleep_before_retry(attempt)
+                continue
+
+            try:
+                if current_provider == LLMProvider.CLAUDE:
+                    response_data = await self._query_claude(
+                        api_key, current_model, messages, temperature, max_tokens
+                    )
+                else:
+                    response_data = await self._query_openai_compatible(
+                        config["base_url"],
+                        api_key,
+                        current_model,
+                        messages,
+                        temperature,
+                        max_tokens,
+                    )
+                used_provider = current_provider
+                used_model = current_model
+                break
+            except Exception as exc:
+                last_error = exc
+                if not self._is_retryable_error(exc) or attempt >= max_attempts:
+                    raise
+
+                next_provider = providers_chain[attempt]
+                self._logger.warning(
+                    "llm_provider_fallback",
+                    attempt=attempt,
+                    from_provider=current_provider.value,
+                    to_provider=next_provider.value,
+                    error=str(exc),
+                )
+                await self._sleep_before_retry(attempt)
+
+        if response_data is None or used_provider is None or used_model is None:
+            if last_error:
+                raise last_error
+            raise RuntimeError("LLM query failed without explicit error")
+
+        usage = self._extract_usage(response_data.get("usage"))
+        self._update_token_metrics(used_provider, usage)
+
+        if cache_key is not None:
+            self._set_cached_intent(cache_key, response_data["text"])
 
         return LLMResponse(
             text=response_data["text"],
-            provider=provider,
-            model=model,
-            usage=response_data.get("usage"),
+            provider=used_provider,
+            model=used_model,
+            usage=usage,
         )
+
+    def _intent_cache_key(self, system_prompt: str | None, prompt: str) -> int | None:
+        if system_prompt and "Определи intent запроса" in system_prompt:
+            return hash(prompt[:100])
+        return None
+
+    def _get_cached_intent(self, cache_key: int) -> str | None:
+        record = self._intent_cache.get(cache_key)
+        if not record:
+            return None
+        cached_intent, expires_at = record
+        if expires_at < time.time():
+            self._intent_cache.pop(cache_key, None)
+            return None
+        self._intent_cache.move_to_end(cache_key)
+        return cached_intent
+
+    def _set_cached_intent(self, cache_key: int, intent: str) -> None:
+        self._intent_cache[cache_key] = (intent, time.time() + self._intent_cache_ttl_seconds)
+        self._intent_cache.move_to_end(cache_key)
+        if len(self._intent_cache) > self._intent_cache_max_entries:
+            self._intent_cache.popitem(last=False)
+
+    def _extract_usage(self, usage: dict | None) -> dict[str, int]:
+        usage = usage or {}
+        tokens_input = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+        tokens_output = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+        return {
+            "tokens_input": tokens_input,
+            "tokens_output": tokens_output,
+        }
+
+    def _update_token_metrics(self, provider: LLMProvider, usage: dict[str, int]) -> None:
+        if usage["tokens_input"]:
+            LLM_TOKENS_USED.labels(provider=provider.value, direction="input").inc(
+                usage["tokens_input"]
+            )
+        if usage["tokens_output"]:
+            LLM_TOKENS_USED.labels(provider=provider.value, direction="output").inc(
+                usage["tokens_output"]
+            )
+
+    def _is_retryable_error(self, exc: Exception) -> bool:
+        if isinstance(exc, httpx.TimeoutException):
+            return True
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code in {429, 500}
+        return False
+
+    async def _sleep_before_retry(self, attempt: int) -> None:
+        backoff_seconds = 2 ** (attempt - 1)
+        await asyncio.sleep(backoff_seconds)
 
     async def _query_openai_compatible(
         self,

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,92 @@
+"""Тесты fallback и usage в LLMRouter."""
+
+import asyncio
+import httpx
+
+from config.settings import settings
+from core.llm_router import LLMProvider, LLMRouter
+
+
+def test_query_fallback_to_next_provider_on_500(monkeypatch):
+    """Если первый провайдер вернул 500, роутер должен переключиться на следующий."""
+    router = LLMRouter(default_provider=LLMProvider.OPENAI)
+
+    monkeypatch.setattr(settings, "openai_api_key", "openai-test")
+    monkeypatch.setattr(settings, "perplexity_api_key", "perplexity-test")
+    monkeypatch.setattr(settings, "anthropic_api_key", "anthropic-test")
+    monkeypatch.setattr(settings, "deepseek_api_key", "deepseek-test")
+
+    async def _no_sleep(_attempt: int):
+        return None
+
+    monkeypatch.setattr(router, "_sleep_before_retry", _no_sleep)
+
+    calls: list[str] = []
+
+    async def _mock_query_openai_compatible(
+        base_url: str,
+        api_key: str,
+        model: str,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int,
+    ) -> dict:
+        calls.append(base_url)
+        if "openai" in base_url:
+            request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+            response = httpx.Response(500, request=request)
+            raise httpx.HTTPStatusError("500", request=request, response=response)
+        return {
+            "text": "ok from fallback",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+        }
+
+    monkeypatch.setattr(router, "_query_openai_compatible", _mock_query_openai_compatible)
+
+    response = asyncio.run(router.query("test prompt"))
+
+    assert response.text == "ok from fallback"
+    assert response.provider == LLMProvider.PERPLEXITY
+    assert response.usage == {"tokens_input": 10, "tokens_output": 20}
+    assert len(calls) == 2
+    assert "openai" in calls[0]
+    assert "perplexity" in calls[1]
+
+
+def test_intent_detection_cache(monkeypatch):
+    """Intent detection должен использовать in-memory кеш по hash(message[:100])."""
+    router = LLMRouter(default_provider=LLMProvider.OPENAI)
+
+    monkeypatch.setattr(settings, "openai_api_key", "openai-test")
+
+    calls = 0
+
+    async def _mock_query_openai_compatible(
+        base_url: str,
+        api_key: str,
+        model: str,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int,
+    ) -> dict:
+        nonlocal calls
+        calls += 1
+        return {
+            "text": "generate_tk",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1},
+        }
+
+    monkeypatch.setattr(router, "_query_openai_compatible", _mock_query_openai_compatible)
+
+    system_prompt = (
+        "Определи intent запроса. Верни ровно одно слово из списка: "
+        "generate_tk, generate_letter, analyze_tender, generate_ks, chat."
+    )
+
+    first = asyncio.run(router.query("сделай ТК на бетон", system_prompt=system_prompt))
+    second = asyncio.run(router.query("сделай ТК на бетон", system_prompt=system_prompt))
+
+    assert first.text == "generate_tk"
+    assert second.text == "generate_tk"
+    assert calls == 1
+    assert second.usage == {"tokens_input": 0, "tokens_output": 0}


### PR DESCRIPTION
### Motivation
- Improve reliability by falling back to alternative LLM providers when the primary provider fails with retryable errors.
- Reduce repeated intent-detection calls and latency by caching recent intent results used by the orchestrator.
- Account tokens consumed by LLMs in metrics and return normalized usage in responses.

### Description
- Implemented a provider fallback chain in `LLMRouter.query` that tries the selected/default provider first and then remaining providers, with up to 3 attempts and exponential backoff (`1s`, `2s`, `4s`).
- Added retryable-error detection for `timeout` and HTTP status `429`/`500`, and logged each fallback event via `structlog` under the event `llm_provider_fallback` with `from_provider`, `to_provider`, `attempt`, and `error` fields.
- Added an in-memory LRU intent cache keyed by `hash(message[:100])` that activates for the orchestrator intent-detection system prompt, with TTL `3600` seconds and max `1000` entries, returning cached responses without calling external providers.
- Normalized and returned usage as `{"tokens_input": N, "tokens_output": M}` and incremented `LLM_TOKENS_USED` metrics for both `input` and `output` after each successful provider response.

### Testing
- Added `tests/test_llm_router.py` with two tests that mock provider calls: one verifies fallback to the next provider on HTTP 500, and the other verifies the intent-detection cache prevents duplicate provider calls.
- Ran the new tests with `pytest -q tests/test_llm_router.py`; initial run failed due to async test style lacking a plugin and was then adapted to use `asyncio.run`, after which the test suite passed (`2 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de445c3400832f86964beb211c3ea9)