### PR TITLE
Add admin PDF ingest workflow for RAG via Telegram and API

### DIFF
--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from tempfile import NamedTemporaryFile
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 
 from config.settings import settings
+from core.pdf_parser import PDFParser
 from core.rag_engine import RAGEngine
 
 router = APIRouter()
+pdf_parser = PDFParser()
 
 
 @lru_cache(maxsize=1)
@@ -17,10 +20,51 @@ def get_rag_engine() -> RAGEngine:
     return RAGEngine()
 
 
-@router.get("/stats")
-async def rag_stats(request: Request) -> dict:
-    """Вернуть статистику RAG (доступно только admin)."""
+def _require_admin(request: Request) -> None:
     api_key = request.headers.get("X-API-Key")
     if not api_key or api_key not in settings.admin_api_keys:
         raise HTTPException(status_code=403, detail="Admin role required")
+
+
+@router.get("/stats")
+async def rag_stats(request: Request) -> dict:
+    """Вернуть статистику RAG (доступно только admin)."""
+    _require_admin(request)
     return get_rag_engine().get_stats()
+
+
+@router.post("/ingest")
+async def rag_ingest(
+    request: Request,
+    file: UploadFile = File(...),
+    source_name: str = Form(...),
+) -> dict[str, int | str]:
+    """Загрузить PDF в RAG-индекс (доступно только admin)."""
+    _require_admin(request)
+    filename = file.filename or source_name
+    if file.content_type != "application/pdf" and not filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are supported")
+
+    file_bytes = await file.read()
+    pdf_parser.parse(file_bytes, filename=filename)
+
+    with NamedTemporaryFile(suffix=".pdf", delete=True) as tmp:
+        tmp.write(file_bytes)
+        tmp.flush()
+        chunks_added = get_rag_engine().ingest_pdf(tmp.name, source_name=source_name)
+    return {"chunks_added": int(chunks_added), "source": source_name}
+
+
+@router.get("/sources")
+async def rag_sources(request: Request) -> dict[str, list[dict[str, int | str]]]:
+    """Вернуть список источников RAG с количеством чанков (доступно только admin)."""
+    _require_admin(request)
+    payload = get_rag_engine().collection.get(include=["metadatas"])
+    metadatas = payload.get("metadatas") or []
+    counters: dict[str, int] = {}
+    for meta in metadatas:
+        source = str((meta or {}).get("source", "unknown"))
+        counters[source] = counters.get(source, 0) + 1
+
+    sources = [{"source": source, "chunks": count} for source, count in sorted(counters.items())]
+    return {"sources": sources}

--- a/config/settings.py
+++ b/config/settings.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     core_api_url: str = "http://api:8000"
     telegram_bot_token: str = ""
     telegram_webhook_url: str = ""
+    admin_telegram_ids: list[int] = []
 
     # ── tk-generator ───────────────────────────
     tk_generator_path: str = "../tk-generator"

--- a/telegram/handlers.py
+++ b/telegram/handlers.py
@@ -30,7 +30,7 @@ from telegram.keyboards import (
     skip_keyboard,
     unit_keyboard,
 )
-from telegram.states import AnalyzeForm, KSStates, LetterStates, TKStates
+from telegram.states import AnalyzeForm, KSStates, LetterStates, TKStates, UploadForm
 
 router = Router()
 
@@ -52,6 +52,13 @@ def _get_api_key() -> str:
     if settings.api_keys:
         return settings.api_keys[0]
     return ""
+
+
+def _get_admin_api_key() -> str:
+    """Возвращает первый admin API-ключ из настроек."""
+    if settings.admin_api_keys:
+        return settings.admin_api_keys[0]
+    return _get_api_key()
 
 
 @dataclass
@@ -500,6 +507,65 @@ async def analyze_document_handler(message: Message, state: FSMContext) -> None:
     await message.answer(_format_analyze_response(result), reply_markup=ReplyKeyboardRemove())
 
 
+# ── Загрузка нормативов в RAG ────────────────────────────────────────────────
+
+
+@router.message(Command("upload"))
+async def upload_start_handler(message: Message, state: FSMContext) -> None:
+    user_id = _require_user_id(message)
+    if user_id not in settings.admin_telegram_ids:
+        await message.answer("⛔ Команда доступна только администраторам.")
+        return
+    await state.set_state(UploadForm.document)
+    await message.answer("Отправь PDF для загрузки в базу знаний", reply_markup=cancel_keyboard())
+
+
+@router.message(UploadForm.document, F.document)
+async def upload_document_handler(message: Message, state: FSMContext) -> None:
+    user_id = _require_user_id(message)
+    if user_id not in settings.admin_telegram_ids:
+        await state.clear()
+        await message.answer("⛔ Команда доступна только администраторам.")
+        return
+
+    document = message.document
+    if document is None:
+        await message.answer("Отправь документ в формате PDF.")
+        return
+
+    if document.file_size and document.file_size > MAX_PDF_SIZE_BYTES:
+        await message.answer("Файл слишком большой (макс. 20 МБ)")
+        return
+
+    file_name = document.file_name or "document.pdf"
+    if document.mime_type != "application/pdf" and not file_name.lower().endswith(".pdf"):
+        await message.answer("Поддерживаются только PDF-документы.")
+        return
+
+    bot = message.bot
+    if bot is None:
+        await message.answer("Bot не инициализирован.")
+        return
+
+    file_bytes = BytesIO()
+    await bot.download(document, destination=file_bytes)
+    file_bytes.seek(0)
+
+    try:
+        result = await _ingest_rag_pdf(file_name, file_bytes.getvalue())
+    except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+        await message.answer(f"Ошибка загрузки в базу знаний: {exc}")
+        return
+
+    chunks_added = int(result.get("chunks_added", 0))
+    source = str(result.get("source", file_name))
+    await state.clear()
+    await message.answer(
+        f"✅ Загружено {chunks_added} chunks из документа {source}",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+
+
 # ── Отмена и текстовый fallback ───────────────────────────────────────────────
 
 
@@ -544,6 +610,21 @@ async def _analyze_tender_pdf(filename: str, content: bytes) -> dict:
         response = await client.post(
             f"{settings.core_api_url.rstrip('/')}/api/analyze/tender",
             files={"file": (filename, content, "application/pdf")},
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def _ingest_rag_pdf(filename: str, content: bytes) -> dict:
+    headers = {"X-API-Key": _get_admin_api_key()}
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{settings.core_api_url.rstrip('/')}/api/rag/ingest",
+            files={
+                "file": (filename, content, "application/pdf"),
+                "source_name": (None, filename),
+            },
             headers=headers,
         )
         response.raise_for_status()

--- a/telegram/states.py
+++ b/telegram/states.py
@@ -39,3 +39,9 @@ class AnalyzeForm(StatesGroup):
     """Состояние загрузки документа для анализа."""
 
     document = State()
+
+
+class UploadForm(StatesGroup):
+    """Состояние загрузки документа в базу знаний."""
+
+    document = State()

--- a/tests/test_rag_routes.py
+++ b/tests/test_rag_routes.py
@@ -1,0 +1,104 @@
+"""Tests for RAG management endpoints."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import rag as rag_routes
+from config.settings import settings
+
+
+class _DummyCollection:
+    def __init__(self, metadatas: list[dict]):
+        self._metadatas = metadatas
+
+    def get(self, include: list[str] | None = None) -> dict:
+        return {"metadatas": self._metadatas}
+
+
+class _DummyRAGEngine:
+    def __init__(self):
+        self.collection = _DummyCollection(
+            [
+                {"source": "sp_48.pdf"},
+                {"source": "sp_48.pdf"},
+                {"source": "gost_21.pdf"},
+            ]
+        )
+
+    def ingest_pdf(self, filepath: str, source_name: str, metadata: dict | None = None) -> int:
+        assert filepath.endswith(".pdf")
+        assert source_name == "sp_48.pdf"
+        return 7
+
+
+def test_rag_ingest_pdf_success(monkeypatch):
+    old_api_keys = settings.api_keys
+    old_admin_keys = settings.admin_api_keys
+    settings.api_keys = ["admin-key"]
+    settings.admin_api_keys = ["admin-key"]
+
+    monkeypatch.setattr(rag_routes, "get_rag_engine", lambda: _DummyRAGEngine())
+
+    parse_called = {"ok": False}
+
+    def _fake_parse(file_bytes: bytes, filename: str):
+        parse_called["ok"] = True
+        assert filename == "sp_48.pdf"
+        assert file_bytes.startswith(b"%PDF")
+        return object()
+
+    monkeypatch.setattr(rag_routes.pdf_parser, "parse", _fake_parse)
+
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/api/rag/ingest",
+            files={
+                "file": ("sp_48.pdf", b"%PDF-1.4 fake", "application/pdf"),
+                "source_name": (None, "sp_48.pdf"),
+            },
+            headers={"X-API-Key": "admin-key"},
+        )
+    finally:
+        settings.api_keys = old_api_keys
+        settings.admin_api_keys = old_admin_keys
+
+    assert response.status_code == 200
+    assert response.json() == {"chunks_added": 7, "source": "sp_48.pdf"}
+    assert parse_called["ok"] is True
+
+
+def test_rag_sources_requires_admin_and_returns_counts(monkeypatch):
+    old_api_keys = settings.api_keys
+    old_admin_keys = settings.admin_api_keys
+    settings.api_keys = ["valid-key", "admin-key"]
+    settings.admin_api_keys = ["admin-key"]
+
+    monkeypatch.setattr(rag_routes, "get_rag_engine", lambda: _DummyRAGEngine())
+
+    try:
+        client = TestClient(app)
+        forbidden = client.get(
+            "/api/rag/sources",
+            headers={"X-API-Key": "valid-key"},
+        )
+        ok = client.get(
+            "/api/rag/sources",
+            headers={"X-API-Key": "admin-key"},
+        )
+    finally:
+        settings.api_keys = old_api_keys
+        settings.admin_api_keys = old_admin_keys
+
+    assert forbidden.status_code == 403
+    assert forbidden.json() == {"detail": "Admin role required"}
+
+    assert ok.status_code == 200
+    assert ok.json() == {
+        "sources": [
+            {"source": "gost_21.pdf", "chunks": 1},
+            {"source": "sp_48.pdf", "chunks": 2},
+        ]
+    }


### PR DESCRIPTION
### Motivation
- Добавить возможность администраторам загружать PDF-нормативы в RAG через Telegram-бота и HTTP API для наполнения базы знаний. 

### Description
- Добавлен Telegram-поток `/upload` с FSM `UploadForm.document`, проверкой `settings.admin_telegram_ids`, валидацией PDF (тип и max 20MB) и отправкой файла на `POST /api/rag/ingest` через multipart с admin API key. 
- В `api/routes/rag.py` добавлен `POST /ingest` принимающий `UploadFile` и `source_name`, который парсит файл через `PDFParser.parse`, сохраняет во временный файл и вызывает `RAGEngine.ingest_pdf()` и возвращает `{"chunks_added": N, "source": source_name}`. 
- В `api/routes/rag.py` добавлен `GET /sources` для получения списка источников с количеством чанков, и вынесена проверка прав в `_require_admin` (требует `settings.admin_api_keys`). 
- Добавлено поле настроек `admin_telegram_ids: list[int] = []` и помощник для получения admin API key; добавлены тесты в `tests/test_rag_routes.py`.

### Testing
- Запущен `pytest -q tests/test_rag_routes.py` и оба теста прошли успешно (`2 passed`).
- Первичная прогонка `pytest -q tests/test_rag_routes.py tests/test_middleware.py` завершилась с ошибками из-за отсутствия плагина для async-тестов в окружении, после чего тесты RAG были адаптированы для `TestClient` и выполнены успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4556b080832fadfdf7babe55e6b6)