### PR TITLE
fix: обновление версий Tauri крейтов (#48)

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -6,13 +6,13 @@ authors = ["Construction AI"]
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "2.0.0", features = [] }
+tauri-build = { version = "2", features = [] }
 
 [dependencies]
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-tauri = { version = "2.0.0", features = [] }
-tauri-plugin-store = "2.0.0"
+tauri = { version = "2", features = [] }
+tauri-plugin-store = "2"
 thiserror = "2"
 rfd = "0.15"
 dirs = "6"


### PR DESCRIPTION
## Проблема
Desktop Build падает из-за несовпадения версий Tauri пакетов:
- Rust-крейты зафиксированы на 2.0.0
- NPM-пакеты разрешились в 2.10.x / 2.4.x

## Исправление
Версии Rust-крейтов обновлены с жёсткой фиксации `2.0.0` на диапазон `2`, что позволяет Cargo подтягивать последние 2.x версии — аналогично тому, как NPM работает с `^2.0`.