### PR TITLE
fix: update Tauri Rust crates to match NPM package versions

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -6,13 +6,13 @@ authors = ["Construction AI"]
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "2.0.0", features = [] }
+tauri-build = { version = "2", features = [] }
 
 [dependencies]
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-tauri = { version = "2.0.0", features = [] }
-tauri-plugin-store = "2.0.0"
+tauri = { version = "2", features = [] }
+tauri-plugin-store = "2"
 thiserror = "2"
 rfd = "0.15"
 dirs = "6"


### PR DESCRIPTION
The Tauri build was failing due to version mismatches between Rust crates (pinned to 2.0.0) and NPM packages (resolving to latest 2.x via ^2.0). Using "2" as the version spec lets Cargo resolve to latest 2.x, keeping both sides in sync.

## Что сделано
- [ ] 

## Тесты
- [ ] Добавлены/обновлены тесты
- [ ] pytest проходит локально

## Checklist
- [ ] ruff check прошёл
- [ ] Нет print() в коде
