### PR TITLE
Add exec-album generation endpoint with S3/MinIO upload and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN pip install --no-cache-dir --prefix=/install \
     "slowapi>=0.1.9" \
     "structlog>=24.0.0" \
     "tqdm>=4.66.0" \
-    "prometheus-fastapi-instrumentator>=7.0.0"
+    "prometheus-fastapi-instrumentator>=7.0.0" \
+    "boto3>=1.34.0"
 
 # Stage 2: runtime
 FROM python:3.11-slim

--- a/api/main.py
+++ b/api/main.py
@@ -88,6 +88,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 app.include_router(health.router, tags=["health"])
 app.include_router(auth.router, tags=["auth"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
+# generate.router содержит /api/generate/* включая /api/generate/exec-album
 app.include_router(generate.router, prefix="/api", tags=["generate"])
 app.include_router(analyze_router, prefix="/api/analyze", tags=["analyze"])
 app.include_router(rag.router, prefix="/api/rag", tags=["rag"])

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 import tempfile
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Literal
@@ -30,6 +30,8 @@ pdf_parser = PDFParser()
 pdf_exporter = PDFExporter()
 redis_cache = RedisCache(settings.redis_url)
 logger = structlog.get_logger("api.generate")
+
+UTC = getattr(datetime, "UTC", timezone(timedelta(0)))
 
 ALLOWED_UNITS = ["м³", "м²", "пог.м.", "шт.", "т", "кг"]
 MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024
@@ -213,7 +215,7 @@ def _render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> b
 
     template_path = Path("templates/exec_album_cover.html")
     cover_template = template_path.read_text(encoding="utf-8")
-    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    generated_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
     docs_html = "\n".join(
         (
             f"<li><strong>Документ #{index}</strong>: "
@@ -237,9 +239,12 @@ def _upload_album_bytes(project_id: str, section: str, pdf_bytes: bytes) -> str:
     try:
         import boto3
     except ImportError as exc:  # pragma: no cover - runtime dependency
-        raise HTTPException(status_code=500, detail="boto3 is required for S3/MinIO upload") from exc
+        raise HTTPException(
+            status_code=500,
+            detail="boto3 is required for S3/MinIO upload",
+        ) from exc
 
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     object_key = f"{project_id}/{section}_{timestamp}.pdf"
 
     client = boto3.client(

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -4,6 +4,7 @@ import asyncio
 import re
 import tempfile
 import uuid
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Literal
@@ -12,6 +13,7 @@ import structlog
 from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import create_engine, text
 
 from agents.calculator import CalculatorAgent
 from config.settings import settings
@@ -32,6 +34,7 @@ logger = structlog.get_logger("api.generate")
 ALLOWED_UNITS = ["м³", "м²", "пог.м.", "шт.", "т", "кг"]
 MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024
 ANALYZE_TIMEOUT_SECONDS = 120
+EXEC_ALBUM_SECTIONS = ("AR", "KZH", "KM", "KMD", "OV", "VK", "EM", "TX", "GP")
 
 
 class TKRequest(BaseModel):
@@ -177,6 +180,121 @@ class PPRRequest(BaseModel):
     session_id: str | None = None
     export_format: Literal["docx", "pdf"] = "docx"
     norms: list[str] = []
+
+
+class AlbumRequest(BaseModel):
+    """Запрос на сборку исполнительного альбома."""
+
+    project_id: str
+    section: Literal["AR", "KZH", "KM", "KMD", "OV", "VK", "EM", "TX", "GP"]
+
+
+def _fetch_approved_exec_docs(project_id: str, section: str) -> list[dict]:
+    """Получить утвержденные АОСР по проекту и разделу."""
+    engine = create_engine(settings.database_url, future=True)
+    query = text(
+        """
+        SELECT id, pdf_url, created_at
+        FROM executive_docs
+        WHERE project_id = :project_id
+          AND discipline_section = :section
+          AND status = 'approved'
+        ORDER BY created_at ASC
+        """
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(query, {"project_id": project_id, "section": section}).mappings().all()
+    return [dict(row) for row in rows]
+
+
+def _render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> bytes:
+    """Сформировать PDF альбома через WeasyPrint."""
+    from weasyprint import HTML
+
+    template_path = Path("templates/exec_album_cover.html")
+    cover_template = template_path.read_text(encoding="utf-8")
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    docs_html = "\n".join(
+        (
+            f"<li><strong>Документ #{index}</strong>: "
+            f"<a href=\"{doc['pdf_url']}\">{doc['pdf_url']}</a>"
+            f" <span>(created_at: {doc.get('created_at', '-')})</span></li>"
+        )
+        for index, doc in enumerate(docs, start=1)
+    )
+    html = (
+        cover_template.replace("{{ project_id }}", project_id)
+        .replace("{{ section }}", section)
+        .replace("{{ generated_at }}", generated_at)
+        .replace("{{ doc_count }}", str(len(docs)))
+        .replace("{{ docs_list }}", docs_html)
+    )
+    return HTML(string=html, base_url=str(Path.cwd())).write_pdf()
+
+
+def _upload_album_bytes(project_id: str, section: str, pdf_bytes: bytes) -> str:
+    """Загрузить PDF альбома в S3/MinIO и вернуть presigned URL."""
+    try:
+        import boto3
+    except ImportError as exc:  # pragma: no cover - runtime dependency
+        raise HTTPException(status_code=500, detail="boto3 is required for S3/MinIO upload") from exc
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    object_key = f"{project_id}/{section}_{timestamp}.pdf"
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint_url or None,
+        aws_access_key_id=settings.s3_access_key or None,
+        aws_secret_access_key=settings.s3_secret_key or None,
+        region_name=settings.s3_region,
+        use_ssl=settings.s3_use_ssl,
+    )
+    client.put_object(
+        Bucket=settings.s3_bucket_albums,
+        Key=object_key,
+        Body=pdf_bytes,
+        ContentType="application/pdf",
+    )
+    return str(
+        client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": settings.s3_bucket_albums, "Key": object_key},
+            ExpiresIn=3600,
+        )
+    )
+
+
+@router.post(
+    "/generate/exec-album",
+    summary="Сборка исполнительного альбома",
+    description="Собирает PDF-альбом по утвержденным АОСР выбранного раздела.",
+)
+async def generate_exec_album(payload: AlbumRequest, request: Request):
+    """Собрать исполнительный альбом по проекту и разделу."""
+    _ = request
+    if payload.section not in EXEC_ALBUM_SECTIONS:
+        raise HTTPException(status_code=422, detail="Invalid section")
+
+    docs = _fetch_approved_exec_docs(project_id=payload.project_id, section=payload.section)
+    if not docs:
+        raise HTTPException(status_code=404, detail="Approved executive docs not found")
+
+    pdf_bytes = _render_exec_album_pdf(
+        project_id=payload.project_id,
+        section=payload.section,
+        docs=docs,
+    )
+    presigned_url = _upload_album_bytes(
+        project_id=payload.project_id,
+        section=payload.section,
+        pdf_bytes=pdf_bytes,
+    )
+    return {
+        "url": presigned_url,
+        "doc_count": len(docs),
+        "section": payload.section,
+    }
 
 
 @router.post(

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -219,7 +219,7 @@ def _render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> b
     docs_html = "\n".join(
         (
             f"<li><strong>Документ #{index}</strong>: "
-            f"<a href=\"{doc['pdf_url']}\">{doc['pdf_url']}</a>"
+            f'<a href="{doc["pdf_url"]}">{doc["pdf_url"]}</a>'
             f" <span>(created_at: {doc.get('created_at', '-')})</span></li>"
         )
         for index, doc in enumerate(docs, start=1)
@@ -281,16 +281,22 @@ async def generate_exec_album(payload: AlbumRequest, request: Request):
     if payload.section not in EXEC_ALBUM_SECTIONS:
         raise HTTPException(status_code=422, detail="Invalid section")
 
-    docs = _fetch_approved_exec_docs(project_id=payload.project_id, section=payload.section)
+    docs = await asyncio.to_thread(
+        _fetch_approved_exec_docs,
+        project_id=payload.project_id,
+        section=payload.section,
+    )
     if not docs:
         raise HTTPException(status_code=404, detail="Approved executive docs not found")
 
-    pdf_bytes = _render_exec_album_pdf(
+    pdf_bytes = await asyncio.to_thread(
+        _render_exec_album_pdf,
         project_id=payload.project_id,
         section=payload.section,
         docs=docs,
     )
-    presigned_url = _upload_album_bytes(
+    presigned_url = await asyncio.to_thread(
+        _upload_album_bytes,
         project_id=payload.project_id,
         section=payload.section,
         pdf_bytes=pdf_bytes,

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,6 +43,14 @@ class Settings(BaseSettings):
     # ── Redis (серверный деплой) ────────────────
     redis_url: str = "redis://redis:6379"
 
+    # ── S3 / MinIO ─────────────────────────────
+    s3_endpoint_url: str = ""
+    s3_access_key: str = ""
+    s3_secret_key: str = ""
+    s3_region: str = "us-east-1"
+    s3_bucket_albums: str = "albums"
+    s3_use_ssl: bool = False
+
     # ── Telegram ───────────────────────────────
     bot_token: str = ""
     core_api_url: str = "http://api:8000"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "bcrypt>=4.1.0",
     "redis[hiredis]>=5.0",
     "sqlalchemy>=2.0.0",
+    "boto3>=1.34.0",
 ]
 
 [project.optional-dependencies]

--- a/templates/exec_album_cover.html
+++ b/templates/exec_album_cover.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>Исполнительный альбом</title>
+    <style>
+      @page { size: A4; margin: 20mm; }
+      body { font-family: Arial, sans-serif; color: #111; font-size: 12pt; }
+      h1, h2 { margin: 0 0 12px; }
+      .meta { margin-bottom: 16px; }
+      .meta p { margin: 4px 0; }
+      .docs li { margin-bottom: 8px; line-height: 1.4; }
+    </style>
+  </head>
+  <body>
+    <h1>Исполнительный альбом</h1>
+    <div class="meta">
+      <p><strong>Проект:</strong> {{ project_id }}</p>
+      <p><strong>Раздел:</strong> {{ section }}</p>
+      <p><strong>Дата сборки:</strong> {{ generated_at }}</p>
+      <p><strong>Количество АОСР:</strong> {{ doc_count }}</p>
+    </div>
+
+    <h2>Состав альбома</h2>
+    <ol class="docs">
+      {{ docs_list }}
+    </ol>
+  </body>
+</html>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,61 @@
+"""Тесты для /api/generate/exec-album."""
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import generate
+from config.settings import settings
+
+
+def test_exec_album_endpoint(monkeypatch):
+    """POST /api/generate/exec-album возвращает URL собранного альбома."""
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+
+    def _mock_fetch_approved_exec_docs(project_id: str, section: str) -> list[dict]:
+        assert project_id == "project-1"
+        assert section == "AR"
+        return [
+            {
+                "id": "doc-1",
+                "pdf_url": "https://storage.local/doc-1.pdf",
+                "created_at": "2026-01-10T10:00:00Z",
+            },
+            {
+                "id": "doc-2",
+                "pdf_url": "https://storage.local/doc-2.pdf",
+                "created_at": "2026-01-11T10:00:00Z",
+            },
+        ]
+
+    def _mock_render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> bytes:
+        assert project_id == "project-1"
+        assert section == "AR"
+        assert len(docs) == 2
+        return b"%PDF-1.4\nmock"
+
+    def _mock_upload_album_bytes(project_id: str, section: str, pdf_bytes: bytes) -> str:
+        assert project_id == "project-1"
+        assert section == "AR"
+        assert pdf_bytes.startswith(b"%PDF")
+        return "https://storage.local/presigned/project-1/AR_latest.pdf"
+
+    monkeypatch.setattr(generate, "_fetch_approved_exec_docs", _mock_fetch_approved_exec_docs)
+    monkeypatch.setattr(generate, "_render_exec_album_pdf", _mock_render_exec_album_pdf)
+    monkeypatch.setattr(generate, "_upload_album_bytes", _mock_upload_album_bytes)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/generate/exec-album",
+                json={"project_id": "project-1", "section": "AR"},
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "url" in data
+    assert data["section"] == "AR"
+    assert data["doc_count"] == 2


### PR DESCRIPTION
### Motivation
- Нужен API-эндпоинт для сборки единого исполнительного альбома (PDF) из утверждённых АОСР по проекту и разделу и публикации результата в S3/MinIO.

### Description
- Добавлен маршрут `POST /api/generate/exec-album` в `api/routes/generate.py` и Pydantic-схема `AlbumRequest` с жёсткой валидацией `section` на значения `"AR","KZH","KM","KMD","OV","VK","EM","TX","GP"`.
- Реализованы вспомогательные функции: `_fetch_approved_exec_docs` (SQL-запрос к таблице `executive_docs` через `sqlalchemy.text`), `_render_exec_album_pdf` (рендер титульной страницы через `templates/exec_album_cover.html` и генерация PDF с `weasyprint`) и `_upload_album_bytes` (загрузка в S3/MinIO через `boto3` и выдача presigned URL). 
- Добавлены настройки S3/MinIO в `config/settings.py` (`s3_endpoint_url`, `s3_access_key`, `s3_secret_key`, `s3_region`, `s3_bucket_albums`, `s3_use_ssl`) и сам шаблон титульной страницы `templates/exec_album_cover.html`.
- Добавлен тест `tests/test_generate.py::test_exec_album_endpoint` который мокает выборку из БД и загрузку в хранилище и проверяет ответ `{ "url", "doc_count", "section" }`, а также небольшой комментарий в `api/main.py` по подключению роутера.

### Testing
- Запущен тест `pytest -q tests/test_generate.py::test_exec_album_endpoint` и он успешно прошёл (`1 passed`).
- Тест использует `monkeypatch` для моков `_fetch_approved_exec_docs`, `_render_exec_album_pdf` и `_upload_album_bytes` и проверяет корректность HTTP-ответа (статус `200` и присутствие поля `url`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b4d45084832fbf74387bc2f1537d)