### PR TITLE
Add KG schedule analytics endpoints with Redis cache and daily Telegram alerts

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -21,14 +21,16 @@ from api.middleware import (
     rate_limit_exceeded_handler,
     setup_rate_limiter,
 )
-from api.routes import auth, chat, generate, health, isup, projects, rag, sign, web
+from api.routes import analytics, auth, chat, generate, health, isup, projects, rag, sign, web
 from api.routes.analyze import router as analyze_router
 from config.settings import settings
+from core.analytics.notifications import AnalyticsNotifier
 from core.database import init_db
 from telegram.bot import create_bot, create_dispatcher
 
 _ = (AGENT_RUNS, PIPELINE_DURATION)
 telegram_router = APIRouter()
+analytics_notifier = AnalyticsNotifier()
 
 
 @asynccontextmanager
@@ -40,12 +42,14 @@ async def lifespan(app: FastAPI):
     app.state.started_at = datetime.now(timezone.utc)  # noqa: UP017
     app.state.telegram_bot = None
     app.state.telegram_dp = None
+    await analytics_notifier.start()
     if settings.telegram_webhook_url and settings.bot_token:
         app.state.telegram_bot = create_bot()
         app.state.telegram_dp = create_dispatcher()
         await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url)
     print("🚀 Construction AI Core запускается...")
     yield
+    await analytics_notifier.stop()
     if app.state.telegram_bot is not None:
         await app.state.telegram_bot.delete_webhook(drop_pending_updates=False)
         await app.state.telegram_bot.session.close()
@@ -95,6 +99,7 @@ app.include_router(isup.router)
 app.include_router(analyze_router, prefix="/api/analyze", tags=["analyze"])
 app.include_router(rag.router, prefix="/api/rag", tags=["rag"])
 app.include_router(projects.router, prefix="/api", tags=["projects"])
+app.include_router(analytics.router, prefix="/api", tags=["analytics"])
 app.include_router(web.router, tags=["web"])
 app.mount("/web", StaticFiles(directory="web", html=True), name="web")
 setup_rate_limiter(app.routes)

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -1,0 +1,57 @@
+"""Analytics API routes for schedule prediction and dashboard summaries."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter
+
+from config.settings import settings
+from core.analytics.schedule_predictor import SchedulePredictor
+from core.cache import RedisCache
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+_CACHE_TTL_SECONDS = 6 * 60 * 60
+_cache = RedisCache(settings.redis_url)
+_predictor = SchedulePredictor()
+
+
+@router.get("/schedule/{project_id}")
+async def get_schedule_analytics(project_id: str) -> dict:
+    """Return project delay stats and completion forecast."""
+    key = f"analytics:schedule:{project_id}"
+    cached = await _cache.get(key)
+    if cached is not None:
+        return json.loads(cached)
+
+    prediction = await _predictor.predict_completion(project_id)
+    await _cache.set(
+        key,
+        json.dumps(prediction, ensure_ascii=False),
+        ttl=_CACHE_TTL_SECONDS,
+    )
+    return prediction
+
+
+@router.get("/dashboard/{project_id}")
+async def get_analytics_dashboard(project_id: str) -> dict:
+    """Return dashboard summary by KG sections with schedule forecast."""
+    key = f"analytics:schedule:{project_id}"
+    cached = await _cache.get(key)
+    if cached is not None:
+        forecast = json.loads(cached)
+    else:
+        forecast = await _predictor.predict_completion(project_id)
+        await _cache.set(
+            key,
+            json.dumps(forecast, ensure_ascii=False),
+            ttl=_CACHE_TTL_SECONDS,
+        )
+
+    sections = await _predictor.get_section_summary(project_id)
+    return {
+        "project_id": project_id,
+        "sections": sections,
+        "forecast": forecast,
+    }

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request
 
 from config.settings import settings
 from core.analytics.schedule_predictor import SchedulePredictor
 from core.cache import RedisCache
+from core.projects import Project, get_projects_sessionmaker
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])
 
@@ -17,9 +19,29 @@ _cache = RedisCache(settings.redis_url)
 _predictor = SchedulePredictor()
 
 
+def _require_project_access(request: Request, project_id: str) -> None:
+    username = getattr(request.state, "username", None)
+    if not username:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    session_local = get_projects_sessionmaker(settings.sqlite_db_path)
+    try:
+        project_uuid = UUID(project_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Project not found") from exc
+    with session_local() as session:
+        project = session.get(Project, project_uuid)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        members = project.members or []
+        if username != project.owner_id and username not in members:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.get("/schedule/{project_id}")
-async def get_schedule_analytics(project_id: str) -> dict:
+async def get_schedule_analytics(project_id: str, request: Request) -> dict:
     """Return project delay stats and completion forecast."""
+    _require_project_access(request, project_id)
     key = f"analytics:schedule:{project_id}"
     cached = await _cache.get(key)
     if cached is not None:
@@ -35,8 +57,9 @@ async def get_schedule_analytics(project_id: str) -> dict:
 
 
 @router.get("/dashboard/{project_id}")
-async def get_analytics_dashboard(project_id: str) -> dict:
+async def get_analytics_dashboard(project_id: str, request: Request) -> dict:
     """Return dashboard summary by KG sections with schedule forecast."""
+    _require_project_access(request, project_id)
     key = f"analytics:schedule:{project_id}"
     cached = await _cache.get(key)
     if cached is not None:

--- a/core/analytics/__init__.py
+++ b/core/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics package."""
+
+from core.analytics.schedule_predictor import SchedulePredictor
+
+__all__ = ["SchedulePredictor"]

--- a/core/analytics/notifications.py
+++ b/core/analytics/notifications.py
@@ -60,9 +60,13 @@ class AnalyticsNotifier:
         now = dt.datetime.now(self._utc).strftime("%Y-%m-%d %H:%M UTC")
         try:
             for project_id in project_ids:
-                prediction = await self._predictor.predict_completion(project_id)
-                if float(prediction.get("delay_rate", 0.0)) <= 0.3:
+                quick_prediction = await self._predictor.predict_completion(
+                    project_id,
+                    include_llm=False,
+                )
+                if float(quick_prediction.get("delay_rate", 0.0)) <= 0.3:
                     continue
+                prediction = await self._predictor.predict_completion(project_id, include_llm=True)
 
                 message = (
                     "⚠️ Риск срыва сроков\n"

--- a/core/analytics/notifications.py
+++ b/core/analytics/notifications.py
@@ -1,0 +1,96 @@
+"""Scheduler for daily delay notifications to PTO engineer in Telegram."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+
+import aiosqlite
+import structlog
+from aiogram import Bot
+
+from config.settings import settings
+from core.analytics.schedule_predictor import SchedulePredictor
+
+try:
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.triggers.cron import CronTrigger
+except Exception:  # noqa: BLE001
+    AsyncIOScheduler = None
+    CronTrigger = None
+
+
+class AnalyticsNotifier:
+    """Run daily analytics checks and notify responsible engineers."""
+
+    def __init__(self) -> None:
+        self._logger = structlog.get_logger("core.analytics.notifications")
+        self._predictor = SchedulePredictor()
+        self._scheduler = None
+        self._utc = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
+
+    async def start(self) -> None:
+        """Start APScheduler job if dependency is available."""
+        if AsyncIOScheduler is None or CronTrigger is None:
+            self._logger.warning("apscheduler_unavailable")
+            return
+
+        self._scheduler = AsyncIOScheduler(timezone="Europe/Moscow")
+        self._scheduler.add_job(
+            self.check_and_notify_projects,
+            trigger=CronTrigger(hour=9, minute=0),
+            id="analytics_daily_delay_check",
+            replace_existing=True,
+        )
+        self._scheduler.start()
+
+    async def stop(self) -> None:
+        if self._scheduler is not None:
+            self._scheduler.shutdown(wait=False)
+
+    async def check_and_notify_projects(self) -> None:
+        """Check projects with high delay_rate and send Telegram notifications."""
+        project_ids = await self._get_all_project_ids()
+        if not project_ids or not settings.bot_token or not settings.admin_telegram_ids:
+            return
+
+        bot = Bot(token=settings.bot_token)
+        now = dt.datetime.now(self._utc).strftime("%Y-%m-%d %H:%M UTC")
+        try:
+            for project_id in project_ids:
+                prediction = await self._predictor.predict_completion(project_id)
+                if float(prediction.get("delay_rate", 0.0)) <= 0.3:
+                    continue
+
+                message = (
+                    "⚠️ Риск срыва сроков\n"
+                    f"Проект: {project_id}\n"
+                    f"Delay rate: {prediction['delay_rate']:.0%}\n"
+                    f"Прогноз завершения: {prediction.get('predicted_completion')}\n"
+                    f"Проверка: {now}"
+                )
+                for chat_id in settings.admin_telegram_ids:
+                    await bot.send_message(chat_id=chat_id, text=message)
+        finally:
+            await bot.session.close()
+
+    async def _get_all_project_ids(self) -> list[str]:
+        query = "SELECT id FROM projects"
+        try:
+            async with aiosqlite.connect(settings.sqlite_db_path) as db:
+                rows = await db.execute_fetchall(query)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("projects_list_failed", error=str(exc))
+            return []
+
+        return [str(row[0]) for row in rows]
+
+
+async def run_daily_delay_check() -> None:
+    """Standalone entrypoint for external schedulers/celery beat."""
+    await AnalyticsNotifier().check_and_notify_projects()
+
+
+def run_daily_delay_check_sync() -> None:
+    """Sync wrapper for task queues that require sync callables."""
+    asyncio.run(run_daily_delay_check())

--- a/core/analytics/notifications.py
+++ b/core/analytics/notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+from typing import Any
 
 import aiosqlite
 import structlog
@@ -26,7 +27,7 @@ class AnalyticsNotifier:
     def __init__(self) -> None:
         self._logger = structlog.get_logger("core.analytics.notifications")
         self._predictor = SchedulePredictor()
-        self._scheduler = None
+        self._scheduler: Any | None = None
         self._utc = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
 
     async def start(self) -> None:
@@ -35,14 +36,15 @@ class AnalyticsNotifier:
             self._logger.warning("apscheduler_unavailable")
             return
 
-        self._scheduler = AsyncIOScheduler(timezone="Europe/Moscow")
-        self._scheduler.add_job(
+        scheduler = AsyncIOScheduler(timezone="Europe/Moscow")
+        scheduler.add_job(
             self.check_and_notify_projects,
             trigger=CronTrigger(hour=9, minute=0),
             id="analytics_daily_delay_check",
             replace_existing=True,
         )
-        self._scheduler.start()
+        scheduler.start()
+        self._scheduler = scheduler
 
     async def stop(self) -> None:
         if self._scheduler is not None:

--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -1,0 +1,309 @@
+"""Analytics module for schedule delay prediction based on KG history."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import aiosqlite
+import structlog
+
+from config.settings import settings
+from core.llm_router import LLMProvider, LLMRouter
+
+
+class SchedulePredictor:
+    """Predict project completion date from KG plan/fact history."""
+
+    def __init__(self) -> None:
+        self._logger = structlog.get_logger("core.analytics.schedule_predictor")
+        self._llm_router = LLMRouter()
+        self._utc = getattr(dt, "UTC", dt.timezone.utc)  # noqa: UP017
+
+    async def get_project_history(self, project_id: str) -> list[dict]:
+        """Получить историю план/факт из таблицы kg_entries за 90 дней."""
+        cutoff = (dt.datetime.now(self._utc) - dt.timedelta(days=90)).date().isoformat()
+        query = """
+            SELECT
+                id,
+                project_id,
+                COALESCE(section, '') AS section,
+                COALESCE(task_name, title, 'task') AS task_name,
+                planned_finish,
+                planned_date,
+                actual_finish,
+                actual_date,
+                status,
+                is_closed,
+                created_at,
+                updated_at
+            FROM kg_entries
+            WHERE project_id = ?
+              AND DATE(COALESCE(actual_finish, actual_date, updated_at, created_at)) >= DATE(?)
+            ORDER BY COALESCE(actual_finish, actual_date, updated_at, created_at) DESC
+        """
+
+        try:
+            async with aiosqlite.connect(settings.sqlite_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                rows = await db.execute_fetchall(query, (project_id, cutoff))
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning(
+                "kg_history_unavailable",
+                project_id=project_id,
+                error=str(exc),
+            )
+            return []
+
+        return [dict(row) for row in rows]
+
+    async def calculate_delay_stats(self, history: list) -> dict:
+        """Рассчитать статистику задержек по завершённым задачам."""
+        completed = [row for row in history if self._is_closed(row)]
+        if not completed:
+            return {
+                "avg_delay_days": 0.0,
+                "delay_rate": 0.0,
+                "critical_sections": [],
+                "completed_tasks": 0,
+            }
+
+        delays_by_section: dict[str, list[int]] = {}
+        delayed_count = 0
+        delay_days_list: list[int] = []
+
+        for task in completed:
+            delay_days = self._delay_days(task)
+            delay_days_list.append(delay_days)
+            section = str(task.get("section") or "unknown")
+            delays_by_section.setdefault(section, []).append(delay_days)
+            if delay_days > 0:
+                delayed_count += 1
+
+        avg_delay = sum(delay_days_list) / len(delay_days_list)
+        delay_rate = delayed_count / len(completed)
+
+        critical_sections = sorted(
+            (
+                {
+                    "section": section,
+                    "avg_delay_days": round(sum(values) / len(values), 2),
+                    "delayed_tasks": sum(1 for value in values if value > 0),
+                }
+                for section, values in delays_by_section.items()
+            ),
+            key=lambda item: item["avg_delay_days"],
+            reverse=True,
+        )[:3]
+
+        return {
+            "avg_delay_days": round(avg_delay, 2),
+            "delay_rate": round(delay_rate, 4),
+            "critical_sections": critical_sections,
+            "completed_tasks": len(completed),
+        }
+
+    async def predict_completion(self, project_id: str) -> dict:
+        """Сформировать прогноз завершения проекта и рисков."""
+        history = await self.get_project_history(project_id)
+        stats = await self.calculate_delay_stats(history)
+        open_tasks = await self._get_open_tasks(project_id)
+        project_name = await self._get_project_name(project_id)
+
+        adjusted_tasks = []
+        avg_delay_days = float(stats["avg_delay_days"])
+        for task in open_tasks:
+            planned_finish = self._parse_date(
+                task.get("planned_finish") or task.get("planned_date"),
+            )
+            predicted_finish = None
+            if planned_finish is not None:
+                predicted_finish = planned_finish + dt.timedelta(days=round(avg_delay_days))
+            adjusted_tasks.append(
+                {
+                    **task,
+                    "predicted_finish": predicted_finish.isoformat() if predicted_finish else None,
+                }
+            )
+
+        latest_task_date = max(
+            (
+                self._parse_date(task.get("predicted_finish"))
+                for task in adjusted_tasks
+                if task.get("predicted_finish")
+            ),
+            default=None,
+        )
+        predicted_completion = latest_task_date or dt.date.today()
+
+        llm_result = await self._llm_assessment(project_name, stats, adjusted_tasks)
+        return {
+            "avg_delay_days": float(stats["avg_delay_days"]),
+            "delay_rate": float(stats["delay_rate"]),
+            "predicted_completion": predicted_completion.isoformat(),
+            "risks": llm_result.get("risks", []),
+            "recommendations": llm_result.get("recommendations", []),
+            "critical_sections": stats["critical_sections"],
+        }
+
+    async def get_section_summary(self, project_id: str) -> list[dict]:
+        """Return summary by KG sections for dashboard endpoint."""
+        query = """
+            SELECT
+                COALESCE(section, 'unknown') AS section,
+                COUNT(*) AS total_tasks,
+                SUM(
+                    CASE
+                        WHEN COALESCE(is_closed, 0) = 1 OR status IN ('done', 'closed')
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS closed_tasks,
+                SUM(
+                    CASE
+                        WHEN (COALESCE(is_closed, 0) = 1 OR status IN ('done', 'closed'))
+                            AND DATE(COALESCE(actual_finish, actual_date)) > DATE(
+                                COALESCE(planned_finish, planned_date)
+                            )
+                        THEN 1
+                        ELSE 0
+                    END
+                ) AS delayed_tasks
+            FROM kg_entries
+            WHERE project_id = ?
+            GROUP BY COALESCE(section, 'unknown')
+            ORDER BY section
+        """
+        try:
+            async with aiosqlite.connect(settings.sqlite_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                rows = await db.execute_fetchall(query, (project_id,))
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("kg_sections_unavailable", project_id=project_id, error=str(exc))
+            return []
+
+        return [dict(row) for row in rows]
+
+    async def _llm_assessment(
+        self,
+        project_name: str,
+        stats: dict,
+        tasks: list[dict],
+    ) -> dict:
+        prompt = (
+            f"Проект {project_name}. Статистика: {json.dumps(stats, ensure_ascii=False)}. "
+            f"Открытые задачи: {json.dumps(tasks, ensure_ascii=False)}. "
+            "Дай прогноз завершения, топ-3 риска, рекомендации. Ответ JSON."
+        )
+        fallback = {
+            "risks": [
+                {
+                    "section": "general",
+                    "description": "Недостаточно данных для точной оценки рисков",
+                    "severity": "medium",
+                }
+            ],
+            "recommendations": [
+                "Актуализировать план-факт данные КГ минимум раз в неделю",
+                "Проверить критические разделы и перераспределить ресурсы",
+            ],
+        }
+        try:
+            response = await self._llm_router.query(
+                prompt,
+                provider=LLMProvider.OPENAI,
+                model="gpt-4o-mini",
+                temperature=0.2,
+                max_tokens=1200,
+            )
+            parsed = self._parse_json_object(response.text)
+            if parsed is None:
+                return fallback
+            return {
+                "risks": parsed.get("risks", fallback["risks"]),
+                "recommendations": parsed.get("recommendations", fallback["recommendations"]),
+            }
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("llm_schedule_prediction_failed", error=str(exc))
+            return fallback
+
+    async def _get_open_tasks(self, project_id: str) -> list[dict]:
+        query = """
+            SELECT
+                id,
+                project_id,
+                COALESCE(section, '') AS section,
+                COALESCE(task_name, title, 'task') AS task_name,
+                planned_finish,
+                planned_date,
+                status,
+                is_closed
+            FROM kg_entries
+            WHERE project_id = ?
+              AND NOT (COALESCE(is_closed, 0) = 1 OR status IN ('done', 'closed'))
+            ORDER BY COALESCE(planned_finish, planned_date) ASC
+        """
+        try:
+            async with aiosqlite.connect(settings.sqlite_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                rows = await db.execute_fetchall(query, (project_id,))
+        except Exception:
+            return []
+        return [dict(row) for row in rows]
+
+    async def _get_project_name(self, project_id: str) -> str:
+        query = "SELECT name FROM projects WHERE id = ? LIMIT 1"
+        try:
+            async with aiosqlite.connect(settings.sqlite_db_path) as db:
+                cursor = await db.execute(query, (project_id,))
+                row = await cursor.fetchone()
+                if row is None:
+                    return project_id
+                return str(row[0])
+        except Exception:
+            return project_id
+
+    def _is_closed(self, task: dict) -> bool:
+        status = str(task.get("status") or "").lower()
+        return bool(task.get("is_closed")) or status in {"done", "closed"}
+
+    def _delay_days(self, task: dict) -> int:
+        planned = self._parse_date(task.get("planned_finish") or task.get("planned_date"))
+        actual = self._parse_date(task.get("actual_finish") or task.get("actual_date"))
+        if planned is None or actual is None:
+            return 0
+        return (actual - planned).days
+
+    def _parse_date(self, value: object) -> dt.date | None:
+        if value is None:
+            return None
+        if isinstance(value, dt.datetime):
+            return value.date()
+        if isinstance(value, dt.date):
+            return value
+        text = str(value)
+        if not text:
+            return None
+        candidates = [text, text.replace("Z", "+00:00")]
+        for candidate in candidates:
+            try:
+                return dt.datetime.fromisoformat(candidate).date()
+            except ValueError:
+                continue
+        try:
+            return dt.date.fromisoformat(text[:10])
+        except ValueError:
+            return None
+
+    def _parse_json_object(self, content: str) -> dict | None:
+        text = content.strip()
+        if text.startswith("```"):
+            text = text.strip("`")
+            text = text.removeprefix("json").strip()
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+            return None
+        except json.JSONDecodeError:
+            return None

--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -60,6 +60,7 @@ class SchedulePredictor:
 
     async def calculate_delay_stats(self, history: list) -> dict:
         """Рассчитать статистику задержек по завершённым задачам."""
+
         class CriticalSection(TypedDict):
             section: str
             avg_delay_days: float
@@ -110,7 +111,7 @@ class SchedulePredictor:
             "completed_tasks": len(completed),
         }
 
-    async def predict_completion(self, project_id: str) -> dict:
+    async def predict_completion(self, project_id: str, *, include_llm: bool = True) -> dict:
         """Сформировать прогноз завершения проекта и рисков."""
         history = await self.get_project_history(project_id)
         stats = await self.calculate_delay_stats(history)
@@ -141,7 +142,11 @@ class SchedulePredictor:
         latest_task_date = max(predicted_dates, default=None)
         predicted_completion = latest_task_date or dt.date.today()
 
-        llm_result = await self._llm_assessment(project_name, stats, adjusted_tasks)
+        llm_result = (
+            await self._llm_assessment(project_name, stats, adjusted_tasks)
+            if include_llm
+            else {"risks": [], "recommendations": []}
+        )
         return {
             "avg_delay_days": float(stats["avg_delay_days"]),
             "delay_rate": float(stats["delay_rate"]),

--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+from typing import TypedDict
 
 import aiosqlite
 import structlog
@@ -59,6 +60,11 @@ class SchedulePredictor:
 
     async def calculate_delay_stats(self, history: list) -> dict:
         """Рассчитать статистику задержек по завершённым задачам."""
+        class CriticalSection(TypedDict):
+            section: str
+            avg_delay_days: float
+            delayed_tasks: int
+
         completed = [row for row in history if self._is_closed(row)]
         if not completed:
             return {
@@ -83,15 +89,16 @@ class SchedulePredictor:
         avg_delay = sum(delay_days_list) / len(delay_days_list)
         delay_rate = delayed_count / len(completed)
 
+        critical_sections_unsorted: list[CriticalSection] = [
+            {
+                "section": section,
+                "avg_delay_days": round(sum(values) / len(values), 2),
+                "delayed_tasks": sum(1 for value in values if value > 0),
+            }
+            for section, values in delays_by_section.items()
+        ]
         critical_sections = sorted(
-            (
-                {
-                    "section": section,
-                    "avg_delay_days": round(sum(values) / len(values), 2),
-                    "delayed_tasks": sum(1 for value in values if value > 0),
-                }
-                for section, values in delays_by_section.items()
-            ),
+            critical_sections_unsorted,
             key=lambda item: item["avg_delay_days"],
             reverse=True,
         )[:3]
@@ -126,14 +133,12 @@ class SchedulePredictor:
                 }
             )
 
-        latest_task_date = max(
-            (
-                self._parse_date(task.get("predicted_finish"))
-                for task in adjusted_tasks
-                if task.get("predicted_finish")
-            ),
-            default=None,
-        )
+        predicted_dates: list[dt.date] = []
+        for task in adjusted_tasks:
+            parsed = self._parse_date(task.get("predicted_finish"))
+            if parsed is not None:
+                predicted_dates.append(parsed)
+        latest_task_date = max(predicted_dates, default=None)
         predicted_completion = latest_task_date or dt.date.today()
 
         llm_result = await self._llm_assessment(project_name, stats, adjusted_tasks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "redis[hiredis]>=5.0",
     "sqlalchemy>=2.0.0",
     "boto3>=1.34.0",
+    "apscheduler>=3.10.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,116 @@
+"""Tests for analytics schedule prediction API."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import analytics as analytics_routes
+from api.routes.auth import _create_token
+
+
+def _auth_headers(username: str = "analytics-user") -> dict[str, str]:
+    token = _create_token(username, "pto_engineer")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_predict_no_delays(monkeypatch):
+    async def _mock_predict(project_id: str) -> dict:
+        assert project_id == "project-1"
+        return {
+            "avg_delay_days": 0.0,
+            "delay_rate": 0.0,
+            "predicted_completion": "2026-05-20",
+            "risks": [],
+            "recommendations": ["Продолжать текущий темп"],
+        }
+
+    async def _cache_miss(_: str):
+        return None
+
+    async def _cache_set(_: str, __: str, ttl: int = 0):
+        assert ttl == 21600
+
+    monkeypatch.setattr(analytics_routes._predictor, "predict_completion", _mock_predict)
+    monkeypatch.setattr(analytics_routes._cache, "get", _cache_miss)
+    monkeypatch.setattr(analytics_routes._cache, "set", _cache_set)
+
+    with TestClient(app) as client:
+        response = client.get("/api/analytics/schedule/project-1", headers=_auth_headers())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["avg_delay_days"] == 0.0
+    assert data["delay_rate"] == 0.0
+    assert data["risks"] == []
+
+
+def test_predict_with_delays(monkeypatch):
+    async def _mock_predict(_: str) -> dict:
+        return {
+            "avg_delay_days": 4.5,
+            "delay_rate": 0.3,
+            "predicted_completion": "2026-06-10",
+            "risks": [
+                {
+                    "section": "AR",
+                    "description": "Срыв поставки фасадных материалов",
+                    "severity": "high",
+                }
+            ],
+            "recommendations": ["Ускорить закупки по разделу AR"],
+        }
+
+    async def _cache_miss(_: str):
+        return None
+
+    async def _cache_set(_: str, __: str, ttl: int = 0):
+        assert ttl == 21600
+
+    monkeypatch.setattr(analytics_routes._predictor, "predict_completion", _mock_predict)
+    monkeypatch.setattr(analytics_routes._cache, "get", _cache_miss)
+    monkeypatch.setattr(analytics_routes._cache, "set", _cache_set)
+
+    with TestClient(app) as client:
+        response = client.get("/api/analytics/schedule/project-42", headers=_auth_headers())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["delay_rate"] == 0.3
+    assert data["risks"][0]["severity"] == "high"
+
+
+def test_cache_hit(monkeypatch):
+    calls = {"predict": 0}
+
+    async def _mock_predict(_: str) -> dict:
+        calls["predict"] += 1
+        return {
+            "avg_delay_days": 2.0,
+            "delay_rate": 0.2,
+            "predicted_completion": "2026-06-01",
+            "risks": [],
+            "recommendations": [],
+        }
+
+    class FakeCache:
+        def __init__(self):
+            self.data: dict[str, str] = {}
+
+        async def get(self, key: str):
+            return self.data.get(key)
+
+        async def set(self, key: str, value: str, ttl: int = 0):
+            self.data[key] = value
+
+    fake_cache = FakeCache()
+    monkeypatch.setattr(analytics_routes, "_cache", fake_cache)
+    monkeypatch.setattr(analytics_routes._predictor, "predict_completion", _mock_predict)
+
+    with TestClient(app) as client:
+        first = client.get("/api/analytics/schedule/project-cache", headers=_auth_headers())
+        second = client.get("/api/analytics/schedule/project-cache", headers=_auth_headers())
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert calls["predict"] == 1

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 from api.main import app
 from api.routes import analytics as analytics_routes
 from api.routes.auth import _create_token
+from config.settings import settings
+from core import projects as projects_core
 
 
 def _auth_headers(username: str = "analytics-user") -> dict[str, str]:
@@ -14,9 +16,17 @@ def _auth_headers(username: str = "analytics-user") -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_predict_no_delays(monkeypatch):
+def _with_temp_db(tmp_path):
+    old = settings.sqlite_db_path
+    settings.sqlite_db_path = str(tmp_path / "analytics.db")
+    projects_core._ENGINE_CACHE.clear()
+    projects_core._SESSIONMAKER_CACHE.clear()
+    return old
+
+
+def test_predict_no_delays(monkeypatch, tmp_path):
     async def _mock_predict(project_id: str) -> dict:
-        assert project_id == "project-1"
+        assert project_id
         return {
             "avg_delay_days": 0.0,
             "delay_rate": 0.0,
@@ -35,8 +45,23 @@ def test_predict_no_delays(monkeypatch):
     monkeypatch.setattr(analytics_routes._cache, "get", _cache_miss)
     monkeypatch.setattr(analytics_routes._cache, "set", _cache_set)
 
-    with TestClient(app) as client:
-        response = client.get("/api/analytics/schedule/project-1", headers=_auth_headers())
+    old_db_path = _with_temp_db(tmp_path)
+    try:
+        with TestClient(app) as client:
+            created = client.post(
+                "/api/projects",
+                json={"name": "A", "description": "D", "members": []},
+                headers=_auth_headers(),
+            )
+            project_id = created.json()["id"]
+            response = client.get(
+                f"/api/analytics/schedule/{project_id}",
+                headers=_auth_headers(),
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        projects_core._ENGINE_CACHE.clear()
+        projects_core._SESSIONMAKER_CACHE.clear()
 
     assert response.status_code == 200
     data = response.json()
@@ -45,7 +70,7 @@ def test_predict_no_delays(monkeypatch):
     assert data["risks"] == []
 
 
-def test_predict_with_delays(monkeypatch):
+def test_predict_with_delays(monkeypatch, tmp_path):
     async def _mock_predict(_: str) -> dict:
         return {
             "avg_delay_days": 4.5,
@@ -71,8 +96,23 @@ def test_predict_with_delays(monkeypatch):
     monkeypatch.setattr(analytics_routes._cache, "get", _cache_miss)
     monkeypatch.setattr(analytics_routes._cache, "set", _cache_set)
 
-    with TestClient(app) as client:
-        response = client.get("/api/analytics/schedule/project-42", headers=_auth_headers())
+    old_db_path = _with_temp_db(tmp_path)
+    try:
+        with TestClient(app) as client:
+            created = client.post(
+                "/api/projects",
+                json={"name": "B", "description": "D", "members": []},
+                headers=_auth_headers(),
+            )
+            project_id = created.json()["id"]
+            response = client.get(
+                f"/api/analytics/schedule/{project_id}",
+                headers=_auth_headers(),
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        projects_core._ENGINE_CACHE.clear()
+        projects_core._SESSIONMAKER_CACHE.clear()
 
     assert response.status_code == 200
     data = response.json()
@@ -80,7 +120,7 @@ def test_predict_with_delays(monkeypatch):
     assert data["risks"][0]["severity"] == "high"
 
 
-def test_cache_hit(monkeypatch):
+def test_cache_hit(monkeypatch, tmp_path):
     calls = {"predict": 0}
 
     async def _mock_predict(_: str) -> dict:
@@ -107,9 +147,27 @@ def test_cache_hit(monkeypatch):
     monkeypatch.setattr(analytics_routes, "_cache", fake_cache)
     monkeypatch.setattr(analytics_routes._predictor, "predict_completion", _mock_predict)
 
-    with TestClient(app) as client:
-        first = client.get("/api/analytics/schedule/project-cache", headers=_auth_headers())
-        second = client.get("/api/analytics/schedule/project-cache", headers=_auth_headers())
+    old_db_path = _with_temp_db(tmp_path)
+    try:
+        with TestClient(app) as client:
+            created = client.post(
+                "/api/projects",
+                json={"name": "C", "description": "D", "members": []},
+                headers=_auth_headers(),
+            )
+            project_id = created.json()["id"]
+            first = client.get(
+                f"/api/analytics/schedule/{project_id}",
+                headers=_auth_headers(),
+            )
+            second = client.get(
+                f"/api/analytics/schedule/{project_id}",
+                headers=_auth_headers(),
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        projects_core._ENGINE_CACHE.clear()
+        projects_core._SESSIONMAKER_CACHE.clear()
 
     assert first.status_code == 200
     assert second.status_code == 200


### PR DESCRIPTION
### Motivation
- Добавить модуль прогнозирования срывов сроков на основе истории КГ и предоставить API для просмотра статистики и прогноза. 
- Обеспечить кеширование результатов и ежедневные уведомления ответственным через Telegram для оперативного реагирования на высокие риски.

### Description
- Добавлен аналитический предиктор `SchedulePredictor` в `core/analytics/schedule_predictor.py` с загрузкой 90-дневной истории из `kg_entries`, расчётом `avg_delay_days`, `delay_rate`, `critical_sections`, прогнозом завершения по незакрытым задачам и LLM-оценкой рисков/рекомендаций через `gpt-4o-mini` (через `core.llm_router`).
- Добавлен scheduler/нотifier `core/analytics/notifications.py` на базе APScheduler, который запускается в lifecycle приложения и выполняет ежедневную проверку в `09:00 Europe/Moscow`, отправляя Telegram-уведомления для проектов с `delay_rate > 0.3` через существующий бот и `admin_telegram_ids`.
- Добавлены HTTP-роуты `api/routes/analytics.py`: `GET /api/analytics/schedule/{project_id}` и `GET /api/analytics/dashboard/{project_id}`; ответы содержат `avg_delay_days`, `delay_rate`, `predicted_completion`, `risks`, `recommendations` и секции для dashboard.
- Добавлено кеширование в Redis с ключом `analytics:schedule:{project_id}` и TTL 6 часов (`21600` секунд) через существующий `core.cache.RedisCache`, и интегрирован notifier в `api/main.py` (стартап/стоп).
- Добавлена зависимость `apscheduler` в `pyproject.toml` и пакетный экспорт `core/analytics/__init__.py`.

### Testing
- Запуск `pytest -q tests/test_analytics.py` прошёл успешно: `3 passed`.
- Статический анализ `ruff` проверил изменённые файлы и не обнаружил проблем: `ruff check` — все проверки прошли.
- Тесты покрывают сценарии `test_predict_no_delays`, `test_predict_with_delays` и `test_cache_hit` (кеширование в Redis/фейковом кеше).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d0089cf0832f9f02599353bf5f34)