### PR TITLE
Normalize LLM schedule prediction and support LLM-provided completion date

### DIFF
--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -232,8 +232,19 @@ class SchedulePredictor:
             parsed = self._parse_json_object(response.text)
             if parsed is None:
                 return fallback
-            raw_risks = parsed.get("risks", fallback["risks"])
-            normalized_risks: list[dict] = []
+            fallback_risks_candidate = fallback.get("risks")
+            fallback_risks_raw = (
+                fallback_risks_candidate
+                if isinstance(fallback_risks_candidate, list)
+                else []
+            )
+            fallback_risks: list[dict[str, str]] = [
+                risk
+                for risk in fallback_risks_raw
+                if isinstance(risk, dict)
+            ]
+            raw_risks = parsed.get("risks", fallback_risks)
+            normalized_risks: list[dict[str, str]] = []
             for risk in raw_risks if isinstance(raw_risks, list) else []:
                 if not isinstance(risk, dict):
                     continue
@@ -248,7 +259,7 @@ class SchedulePredictor:
                     },
                 )
             if not normalized_risks:
-                normalized_risks = fallback["risks"]
+                normalized_risks = fallback_risks
             return {
                 "predicted_completion": parsed.get("predicted_completion"),
                 "risks": normalized_risks,

--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -234,14 +234,10 @@ class SchedulePredictor:
                 return fallback
             fallback_risks_candidate = fallback.get("risks")
             fallback_risks_raw = (
-                fallback_risks_candidate
-                if isinstance(fallback_risks_candidate, list)
-                else []
+                fallback_risks_candidate if isinstance(fallback_risks_candidate, list) else []
             )
             fallback_risks: list[dict[str, str]] = [
-                risk
-                for risk in fallback_risks_raw
-                if isinstance(risk, dict)
+                risk for risk in fallback_risks_raw if isinstance(risk, dict)
             ]
             raw_risks = parsed.get("risks", fallback_risks)
             normalized_risks: list[dict[str, str]] = []

--- a/core/analytics/schedule_predictor.py
+++ b/core/analytics/schedule_predictor.py
@@ -145,12 +145,14 @@ class SchedulePredictor:
         llm_result = (
             await self._llm_assessment(project_name, stats, adjusted_tasks)
             if include_llm
-            else {"risks": [], "recommendations": []}
+            else {"risks": [], "recommendations": [], "predicted_completion": None}
         )
+        llm_predicted_completion = self._parse_date(llm_result.get("predicted_completion"))
+        final_predicted_completion = llm_predicted_completion or predicted_completion
         return {
             "avg_delay_days": float(stats["avg_delay_days"]),
             "delay_rate": float(stats["delay_rate"]),
-            "predicted_completion": predicted_completion.isoformat(),
+            "predicted_completion": final_predicted_completion.isoformat(),
             "risks": llm_result.get("risks", []),
             "recommendations": llm_result.get("recommendations", []),
             "critical_sections": stats["critical_sections"],
@@ -206,6 +208,7 @@ class SchedulePredictor:
             "Дай прогноз завершения, топ-3 риска, рекомендации. Ответ JSON."
         )
         fallback = {
+            "predicted_completion": None,
             "risks": [
                 {
                     "section": "general",
@@ -229,8 +232,26 @@ class SchedulePredictor:
             parsed = self._parse_json_object(response.text)
             if parsed is None:
                 return fallback
+            raw_risks = parsed.get("risks", fallback["risks"])
+            normalized_risks: list[dict] = []
+            for risk in raw_risks if isinstance(raw_risks, list) else []:
+                if not isinstance(risk, dict):
+                    continue
+                severity = str(risk.get("severity", "medium")).lower()
+                if severity not in {"high", "medium", "low"}:
+                    severity = "medium"
+                normalized_risks.append(
+                    {
+                        "section": str(risk.get("section", "general")),
+                        "description": str(risk.get("description", "")),
+                        "severity": severity,
+                    },
+                )
+            if not normalized_risks:
+                normalized_risks = fallback["risks"]
             return {
-                "risks": parsed.get("risks", fallback["risks"]),
+                "predicted_completion": parsed.get("predicted_completion"),
+                "risks": normalized_risks,
                 "recommendations": parsed.get("recommendations", fallback["recommendations"]),
             }
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
### Motivation
- Сделать выход `SchedulePredictor` более предсказуемым при использовании LLM, обеспечив стабильную форму ответа даже при ошибках модели. 
- Разрешить LLM опционально задавать итоговую дату завершения проекта при наличии валидного значения, при этом сохранять детерминированный расчёт как надёжный fallback.

### Description
- В `core/analytics/schedule_predictor.py` расширен fallback-ответ LLM, добавлен ключ `predicted_completion` для консистентной формы ответа (`fallback` теперь содержит `predicted_completion: None`).
- Добавлена логика, которая парсит `predicted_completion` из ответа LLM и использует его вместо детерминированного `predicted_completion`, если значение валидно (`final_predicted_completion = llm_predicted_completion or predicted_completion`).
- Реализована нормализация списка рисков из LLM: фильтрация некорректных элементов и приведение `severity` к набору значений `high|medium|low` с дефолтом `medium`, а также стабилизация структуры объектов риска (`section`, `description`, `severity`).
- Сохранена существующая структура возвращаемого словаря с полями `avg_delay_days`, `delay_rate`, `predicted_completion`, `risks`, `recommendations`, `critical_sections` и без изменений в API-роутах.

### Testing
- Запущены автоматические тесты `pytest -q tests/test_analytics.py` и все тесты успешно прошли (`3 passed`).
- Тестовый набор включает проверки без задержек, с задержками и поведение кеша (`test_predict_no_delays`, `test_predict_with_delays`, `test_cache_hit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e1e28b48832f859f63236de457ad)