### PR TITLE
Add GSN readiness checklist, compliance API and PDF report generation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -21,7 +21,19 @@ from api.middleware import (
     rate_limit_exceeded_handler,
     setup_rate_limiter,
 )
-from api.routes import analytics, auth, chat, compliance, generate, health, isup, projects, rag, sign, web
+from api.routes import (
+    analytics,
+    auth,
+    chat,
+    compliance,
+    generate,
+    health,
+    isup,
+    projects,
+    rag,
+    sign,
+    web,
+)
 from api.routes.analyze import router as analyze_router
 from config.settings import settings
 from core.analytics.notifications import AnalyticsNotifier

--- a/api/main.py
+++ b/api/main.py
@@ -21,7 +21,7 @@ from api.middleware import (
     rate_limit_exceeded_handler,
     setup_rate_limiter,
 )
-from api.routes import analytics, auth, chat, generate, health, isup, projects, rag, sign, web
+from api.routes import analytics, auth, chat, compliance, generate, health, isup, projects, rag, sign, web
 from api.routes.analyze import router as analyze_router
 from config.settings import settings
 from core.analytics.notifications import AnalyticsNotifier
@@ -100,6 +100,7 @@ app.include_router(analyze_router, prefix="/api/analyze", tags=["analyze"])
 app.include_router(rag.router, prefix="/api/rag", tags=["rag"])
 app.include_router(projects.router, prefix="/api", tags=["projects"])
 app.include_router(analytics.router, prefix="/api", tags=["analytics"])
+app.include_router(compliance.router, prefix="/api", tags=["compliance"])
 app.include_router(web.router, tags=["web"])
 app.mount("/web", StaticFiles(directory="web", html=True), name="web")
 setup_rate_limiter(app.routes)

--- a/api/routes/compliance.py
+++ b/api/routes/compliance.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+import datetime as dt
 from pathlib import Path
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response
 
+from config.settings import settings
 from core.compliance.gsn_checklist import GSNReadinessChecker
+from core.projects import Project, get_projects_sessionmaker
 
 router = APIRouter(prefix="/compliance", tags=["compliance"])
 checker = GSNReadinessChecker()
+UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
 
 
 def _build_section_row(section_result: dict) -> str:
@@ -34,9 +38,10 @@ def _build_section_row(section_result: dict) -> str:
 def _render_gsn_report_html(project_id: str, checklist: dict) -> str:
     template = Path("templates/gsn_checklist.html").read_text(encoding="utf-8")
     rows = "\n".join(_build_section_row(item) for item in checklist["sections"])
+    generated_at = dt.datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
     return (
         template.replace("{{ project_id }}", project_id)
-        .replace("{{ generated_at }}", datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"))
+        .replace("{{ generated_at }}", generated_at)
         .replace("{{ total_completion_pct }}", str(checklist["completion_pct"]))
         .replace("{{ section_rows }}", rows)
     )
@@ -50,23 +55,42 @@ def _render_pdf_from_html(html: str) -> bytes:
     return HTML(string=html, base_url=str(Path.cwd())).write_pdf()
 
 
+def _require_project_member(request: Request, project_id: UUID) -> None:
+    username = getattr(request.state, "username", None)
+    if not username:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    session_local = get_projects_sessionmaker(settings.sqlite_db_path)
+    with session_local() as session:
+        project = session.get(Project, project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+
+        members = project.members or []
+        if username != project.owner_id and username not in members:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.get("/gsn-checklist/{project_id}")
-async def get_gsn_checklist(project_id: str) -> dict:
-    return await checker.check_full_project(project_id=project_id)
+async def get_gsn_checklist(project_id: UUID, request: Request) -> dict:
+    _require_project_member(request=request, project_id=project_id)
+    return await checker.check_full_project(project_id=str(project_id))
 
 
 @router.get("/gsn-checklist/{project_id}/section/{section}")
-async def get_gsn_checklist_section(project_id: str, section: str) -> dict:
+async def get_gsn_checklist_section(project_id: UUID, section: str, request: Request) -> dict:
+    _require_project_member(request=request, project_id=project_id)
     try:
-        return await checker.check_section(project_id=project_id, section=section)
+        return await checker.check_section(project_id=str(project_id), section=section)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post("/gsn-report/{project_id}")
-async def generate_gsn_report(project_id: str) -> Response:
-    checklist = await checker.check_full_project(project_id=project_id)
-    html = _render_gsn_report_html(project_id=project_id, checklist=checklist)
+async def generate_gsn_report(project_id: UUID, request: Request) -> Response:
+    _require_project_member(request=request, project_id=project_id)
+    checklist = await checker.check_full_project(project_id=str(project_id))
+    html = _render_gsn_report_html(project_id=str(project_id), checklist=checklist)
     try:
         pdf_bytes = await asyncio.to_thread(_render_pdf_from_html, html)
     except RuntimeError as exc:

--- a/api/routes/compliance.py
+++ b/api/routes/compliance.py
@@ -1,0 +1,79 @@
+"""Compliance API routes for GSN checklist and PDF reporting."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+
+from core.compliance.gsn_checklist import GSNReadinessChecker
+
+router = APIRouter(prefix="/compliance", tags=["compliance"])
+checker = GSNReadinessChecker()
+
+
+def _build_section_row(section_result: dict) -> str:
+    required = len(section_result["present"]) + len(section_result["missing"])
+    present = len(section_result["present"])
+    missing = len(section_result["missing"])
+    completion_pct = section_result["completion_pct"]
+    return (
+        "<tr>"
+        f"<td>{section_result['section']}</td>"
+        f"<td>{required}</td>"
+        f"<td>{present}</td>"
+        f"<td>{missing}</td>"
+        f"<td>{completion_pct}%</td>"
+        "</tr>"
+    )
+
+
+def _render_gsn_report_html(project_id: str, checklist: dict) -> str:
+    template = Path("templates/gsn_checklist.html").read_text(encoding="utf-8")
+    rows = "\n".join(_build_section_row(item) for item in checklist["sections"])
+    return (
+        template.replace("{{ project_id }}", project_id)
+        .replace("{{ generated_at }}", datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"))
+        .replace("{{ total_completion_pct }}", str(checklist["completion_pct"]))
+        .replace("{{ section_rows }}", rows)
+    )
+
+
+def _render_pdf_from_html(html: str) -> bytes:
+    try:
+        from weasyprint import HTML
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("weasyprint is required for gsn PDF report generation") from exc
+    return HTML(string=html, base_url=str(Path.cwd())).write_pdf()
+
+
+@router.get("/gsn-checklist/{project_id}")
+async def get_gsn_checklist(project_id: str) -> dict:
+    return await checker.check_full_project(project_id=project_id)
+
+
+@router.get("/gsn-checklist/{project_id}/section/{section}")
+async def get_gsn_checklist_section(project_id: str, section: str) -> dict:
+    try:
+        return await checker.check_section(project_id=project_id, section=section)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/gsn-report/{project_id}")
+async def generate_gsn_report(project_id: str) -> Response:
+    checklist = await checker.check_full_project(project_id=project_id)
+    html = _render_gsn_report_html(project_id=project_id, checklist=checklist)
+    try:
+        pdf_bytes = await asyncio.to_thread(_render_pdf_from_html, html)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="gsn_checklist_{project_id}.pdf"'},
+    )

--- a/core/compliance/__init__.py
+++ b/core/compliance/__init__.py
@@ -1,0 +1,5 @@
+"""Compliance checks and report helpers."""
+
+from core.compliance.gsn_checklist import GSNReadinessChecker, GSN_REQUIREMENTS
+
+__all__ = ["GSNReadinessChecker", "GSN_REQUIREMENTS"]

--- a/core/compliance/__init__.py
+++ b/core/compliance/__init__.py
@@ -1,5 +1,5 @@
 """Compliance checks and report helpers."""
 
-from core.compliance.gsn_checklist import GSNReadinessChecker, GSN_REQUIREMENTS
+from core.compliance.gsn_checklist import GSN_REQUIREMENTS, GSNReadinessChecker
 
 __all__ = ["GSNReadinessChecker", "GSN_REQUIREMENTS"]

--- a/core/compliance/gsn_checklist.py
+++ b/core/compliance/gsn_checklist.py
@@ -126,9 +126,13 @@ class GSNReadinessChecker:
     def _ensure_project_exists(self, project_id: str) -> None:
         project_uuid = UUID(project_id)
         with self._sessionmaker() as session:
-            project_exists = session.query(ProjectDocument.project_id).filter(
-                ProjectDocument.project_id == project_uuid,
-            ).first()
+            project_exists = (
+                session.query(ProjectDocument.project_id)
+                .filter(
+                    ProjectDocument.project_id == project_uuid,
+                )
+                .first()
+            )
             if project_exists is not None:
                 return
 

--- a/core/compliance/gsn_checklist.py
+++ b/core/compliance/gsn_checklist.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from config.settings import settings
-from core.projects import ProjectDocument, get_projects_sessionmaker
+from core.projects import Project, ProjectDocument, get_projects_sessionmaker
 
 # Требования Приказа №522-пр по каждому разделу
 GSN_REQUIREMENTS = {
@@ -81,13 +81,15 @@ class GSNReadinessChecker:
     """Check project document readiness for GSN handover checklist."""
 
     def __init__(self) -> None:
-        self._sessionmaker = get_projects_sessionmaker(settings.sqlite_db_path)
+        self.db_path = settings.sqlite_db_path
+        self._sessionmaker = get_projects_sessionmaker(self.db_path)
 
     def _list_section_documents(self, project_id: str, section: str) -> list[ProjectDocument]:
+        project_uuid = UUID(project_id)
         with self._sessionmaker() as session:
             project_docs = (
                 session.query(ProjectDocument)
-                .filter(ProjectDocument.project_id == UUID(project_id))
+                .filter(ProjectDocument.project_id == project_uuid)
                 .order_by(ProjectDocument.created_at.asc())
                 .all()
             )
@@ -121,6 +123,19 @@ class GSNReadinessChecker:
         ready_count = len(list(present))
         return round((ready_count / total_required) * 100, 2)
 
+    def _ensure_project_exists(self, project_id: str) -> None:
+        project_uuid = UUID(project_id)
+        with self._sessionmaker() as session:
+            project_exists = session.query(ProjectDocument.project_id).filter(
+                ProjectDocument.project_id == project_uuid,
+            ).first()
+            if project_exists is not None:
+                return
+
+            project = session.get(Project, project_uuid)
+            if project is None:
+                raise LookupError("Project not found")
+
     async def check_section(self, project_id: str, section: str) -> dict:
         """
         Сверить наличие АОСР, журналов, исп. схем, паспортов с GSN_REQUIREMENTS.
@@ -130,6 +145,7 @@ class GSNReadinessChecker:
         if requirements is None:
             raise ValueError(f"Unsupported section: {section}")
 
+        self._ensure_project_exists(project_id=project_id)
         docs = self._list_section_documents(project_id=project_id, section=normalized_section)
 
         missing: list[dict[str, str]] = []

--- a/core/compliance/gsn_checklist.py
+++ b/core/compliance/gsn_checklist.py
@@ -1,0 +1,165 @@
+"""GSN readiness checks against Rostechnadzor order №522-pr requirements."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from config.settings import settings
+from core.projects import ProjectDocument, get_projects_sessionmaker
+
+# Требования Приказа №522-пр по каждому разделу
+GSN_REQUIREMENTS = {
+    "KZH": {
+        "required_acts": ["армирование", "опалубка", "бетонирование"],
+        "required_journals": ["журнал бетонных работ", "журнал замоноличивания"],
+        "required_schemes": ["схемы армирования", "геодезические схемы"],
+        "required_passports": ["арматура", "бетон", "протоколы кубиков"],
+    },
+    "OV": {
+        "required_acts": ["монтаж воздуховодов", "монтаж оборудования", "пусконаладка"],
+        "required_journals": ["журнал монтажа систем вентиляции", "журнал испытаний ОВ"],
+        "required_schemes": ["исполнительные схемы трасс ОВ", "аксонометрические схемы"],
+        "required_passports": ["вентиляционное оборудование", "воздуховоды", "протоколы испытаний"],
+    },
+    "VK": {
+        "required_acts": ["монтаж трубопроводов", "опрессовка", "гидравлические испытания"],
+        "required_journals": ["журнал сварочных работ", "журнал испытаний ВК"],
+        "required_schemes": ["исполнительные схемы сетей ВК", "геодезические схемы"],
+        "required_passports": ["трубная продукция", "запорная арматура", "протоколы испытаний"],
+    },
+    "EM": {
+        "required_acts": ["прокладка кабельных линий", "монтаж щитов", "пусконаладка"],
+        "required_journals": ["журнал электромонтажных работ", "журнал испытаний ЭМ"],
+        "required_schemes": ["исполнительные схемы кабельных трасс", "однолинейные схемы"],
+        "required_passports": ["кабельная продукция", "щитовое оборудование", "протоколы измерений"],
+    },
+    "AR": {
+        "required_acts": ["кирпичная кладка", "монтаж перегородок", "отделочные работы"],
+        "required_journals": ["общий журнал работ", "журнал отделочных работ"],
+        "required_schemes": ["исполнительные схемы этажей", "планы фактических отметок"],
+        "required_passports": ["строительные смеси", "листовые материалы", "сертификаты соответствия"],
+    },
+    "SS": {
+        "required_acts": ["монтаж кабельных линий", "монтаж оборудования", "пусконаладка"],
+        "required_journals": ["журнал монтажа СС", "журнал испытаний СС"],
+        "required_schemes": ["исполнительные схемы СС", "структурные схемы"],
+        "required_passports": ["кабели связи", "оборудование СС", "протоколы тестирования"],
+    },
+    "APS": {
+        "required_acts": ["монтаж извещателей", "монтаж шлейфов", "пусконаладка"],
+        "required_journals": ["журнал монтажа АПС", "журнал испытаний АПС"],
+        "required_schemes": ["исполнительные схемы АПС", "планы размещения извещателей"],
+        "required_passports": ["извещатели", "приборы ППК", "протоколы испытаний"],
+    },
+    "PS": {
+        "required_acts": ["монтаж спринклерных линий", "монтаж насосной станции", "опрессовка"],
+        "required_journals": ["журнал монтажа ПС", "журнал испытаний ПС"],
+        "required_schemes": ["исполнительные схемы ПС", "гидравлические схемы"],
+        "required_passports": ["трубопроводы", "пожарная арматура", "протоколы испытаний"],
+    },
+}
+
+
+_REQUIREMENT_KEYS = (
+    ("required_acts", "act"),
+    ("required_journals", "journal"),
+    ("required_schemes", "scheme"),
+    ("required_passports", "passport"),
+)
+
+
+class GSNReadinessChecker:
+    """Check project document readiness for GSN handover checklist."""
+
+    def __init__(self) -> None:
+        self._sessionmaker = get_projects_sessionmaker(settings.sqlite_db_path)
+
+    def _list_section_documents(self, project_id: str, section: str) -> list[ProjectDocument]:
+        with self._sessionmaker() as session:
+            project_docs = (
+                session.query(ProjectDocument)
+                .filter(ProjectDocument.project_id == UUID(project_id))
+                .order_by(ProjectDocument.created_at.asc())
+                .all()
+            )
+
+        section_lower = section.lower()
+        filtered = [
+            doc
+            for doc in project_docs
+            if section_lower in (doc.document_type or "").lower()
+            or section_lower in (doc.title or "").lower()
+        ]
+        return filtered
+
+    @staticmethod
+    def _matches_requirement(doc: ProjectDocument, requirement_name: str) -> bool:
+        haystack = f"{doc.document_type} {doc.title}".lower()
+        return requirement_name.lower() in haystack
+
+    @staticmethod
+    def _serialize_present(doc_type: str, name: str, doc_id: str) -> dict[str, str]:
+        return {"type": doc_type, "name": name, "doc_id": doc_id}
+
+    @staticmethod
+    def _serialize_missing(doc_type: str, name: str) -> dict[str, str]:
+        return {"type": doc_type, "name": name}
+
+    @staticmethod
+    def _completion_pct(present: Iterable[dict], total_required: int) -> float:
+        if total_required <= 0:
+            return 100.0
+        ready_count = len(list(present))
+        return round((ready_count / total_required) * 100, 2)
+
+    async def check_section(self, project_id: str, section: str) -> dict:
+        """
+        Сверить наличие АОСР, журналов, исп. схем, паспортов с GSN_REQUIREMENTS.
+        """
+        normalized_section = section.upper()
+        requirements = GSN_REQUIREMENTS.get(normalized_section)
+        if requirements is None:
+            raise ValueError(f"Unsupported section: {section}")
+
+        docs = self._list_section_documents(project_id=project_id, section=normalized_section)
+
+        missing: list[dict[str, str]] = []
+        present: list[dict[str, str]] = []
+        for requirement_key, requirement_type in _REQUIREMENT_KEYS:
+            for name in requirements[requirement_key]:
+                matched = next((doc for doc in docs if self._matches_requirement(doc, name)), None)
+                if matched is None:
+                    missing.append(self._serialize_missing(requirement_type, name))
+                else:
+                    present.append(
+                        self._serialize_present(requirement_type, name, str(matched.id)),
+                    )
+
+        total_required = sum(len(requirements[key]) for key, _ in _REQUIREMENT_KEYS)
+        completion_pct = self._completion_pct(present=present, total_required=total_required)
+
+        return {
+            "section": normalized_section,
+            "ready": not missing,
+            "missing": missing,
+            "present": present,
+            "completion_pct": completion_pct,
+        }
+
+    async def check_full_project(self, project_id: str) -> dict:
+        """Проверить все разделы, вернуть сводный чеклист."""
+        sections = []
+        for section in GSN_REQUIREMENTS:
+            sections.append(await self.check_section(project_id=project_id, section=section))
+
+        avg_completion = 0.0
+        if sections:
+            avg_completion = round(sum(item["completion_pct"] for item in sections) / len(sections), 2)
+
+        return {
+            "project_id": project_id,
+            "ready": all(item["ready"] for item in sections),
+            "completion_pct": avg_completion,
+            "sections": sections,
+        }

--- a/core/compliance/gsn_checklist.py
+++ b/core/compliance/gsn_checklist.py
@@ -32,13 +32,21 @@ GSN_REQUIREMENTS = {
         "required_acts": ["прокладка кабельных линий", "монтаж щитов", "пусконаладка"],
         "required_journals": ["журнал электромонтажных работ", "журнал испытаний ЭМ"],
         "required_schemes": ["исполнительные схемы кабельных трасс", "однолинейные схемы"],
-        "required_passports": ["кабельная продукция", "щитовое оборудование", "протоколы измерений"],
+        "required_passports": [
+            "кабельная продукция",
+            "щитовое оборудование",
+            "протоколы измерений",
+        ],
     },
     "AR": {
         "required_acts": ["кирпичная кладка", "монтаж перегородок", "отделочные работы"],
         "required_journals": ["общий журнал работ", "журнал отделочных работ"],
         "required_schemes": ["исполнительные схемы этажей", "планы фактических отметок"],
-        "required_passports": ["строительные смеси", "листовые материалы", "сертификаты соответствия"],
+        "required_passports": [
+            "строительные смеси",
+            "листовые материалы",
+            "сертификаты соответствия",
+        ],
     },
     "SS": {
         "required_acts": ["монтаж кабельных линий", "монтаж оборудования", "пусконаладка"],
@@ -155,7 +163,10 @@ class GSNReadinessChecker:
 
         avg_completion = 0.0
         if sections:
-            avg_completion = round(sum(item["completion_pct"] for item in sections) / len(sections), 2)
+            avg_completion = round(
+                sum(item["completion_pct"] for item in sections) / len(sections),
+                2,
+            )
 
         return {
             "project_id": project_id,

--- a/templates/gsn_checklist.html
+++ b/templates/gsn_checklist.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <title>Чеклист готовности ГСН</title>
+  <style>
+    @page { size: A4; margin: 20mm; }
+    body {
+      font-family: "Times New Roman", serif;
+      color: #000;
+      font-size: 12pt;
+      line-height: 1.3;
+    }
+    h1, h2 { text-align: center; margin: 0; }
+    h1 { font-size: 16pt; margin-bottom: 8px; }
+    h2 { font-size: 13pt; margin-bottom: 20px; font-weight: normal; }
+    .meta { margin-bottom: 16px; }
+    .meta p { margin: 2px 0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid #000;
+      padding: 6px;
+      vertical-align: middle;
+      text-align: center;
+    }
+    th { font-weight: bold; }
+    .summary {
+      margin-top: 16px;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <h1>Пакет исполнительной документации для сдачи ГСН</h1>
+  <h2>Чеклист соответствия Приказу Ростехнадзора №522-пр</h2>
+
+  <div class="meta">
+    <p><strong>Проект:</strong> {{ project_id }}</p>
+    <p><strong>Дата формирования:</strong> {{ generated_at }}</p>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Раздел</th>
+        <th>Требуется</th>
+        <th>Есть</th>
+        <th>Отсутствует</th>
+        <th>% готовности</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ section_rows }}
+    </tbody>
+  </table>
+
+  <p class="summary">Итоговая готовность проекта: {{ total_completion_pct }}%</p>
+</body>
+</html>

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,0 +1,116 @@
+"""Tests for GSN compliance checklist and report API."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import compliance
+from config.settings import settings
+from core.compliance.gsn_checklist import GSNReadinessChecker, GSN_REQUIREMENTS
+from core.projects import Project, ProjectDocument, get_projects_sessionmaker
+
+
+def _seed_project_docs(sqlite_path: str, section: str, include_journals: bool = True) -> str:
+    session_local = get_projects_sessionmaker(sqlite_path)
+    project_id = uuid4()
+
+    with session_local() as session:
+        session.add(
+            Project(
+                id=project_id,
+                name="GSN Project",
+                description="",
+                owner_id="tester",
+                members=["tester"],
+            )
+        )
+
+        requirements = GSN_REQUIREMENTS[section]
+        for requirement_key in ("required_acts", "required_schemes", "required_passports"):
+            for requirement in requirements[requirement_key]:
+                session.add(
+                    ProjectDocument(
+                        project_id=project_id,
+                        document_type=f"{section} {requirement_key}",
+                        session_id="sess-1",
+                        created_by="tester",
+                        title=f"{section} {requirement}",
+                        version=1,
+                    )
+                )
+
+        if include_journals:
+            for requirement in requirements["required_journals"]:
+                session.add(
+                    ProjectDocument(
+                        project_id=project_id,
+                        document_type=f"{section} required_journals",
+                        session_id="sess-1",
+                        created_by="tester",
+                        title=f"{section} {requirement}",
+                        version=1,
+                    )
+                )
+
+        session.commit()
+
+    return str(project_id)
+
+
+def test_gsn_checklist_complete(tmp_path):
+    old_db_path = settings.sqlite_db_path
+    settings.sqlite_db_path = str(tmp_path / "compliance_complete.db")
+    try:
+        project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True)
+        checker = GSNReadinessChecker()
+        result = asyncio.run(checker.check_section(project_id=project_id, section="KZH"))
+    finally:
+        settings.sqlite_db_path = old_db_path
+
+    assert result["ready"] is True
+    assert result["missing"] == []
+    assert result["completion_pct"] == 100.0
+
+
+def test_gsn_checklist_missing(tmp_path):
+    old_db_path = settings.sqlite_db_path
+    settings.sqlite_db_path = str(tmp_path / "compliance_missing.db")
+    try:
+        project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=False)
+        checker = GSNReadinessChecker()
+        result = asyncio.run(checker.check_section(project_id=project_id, section="KZH"))
+    finally:
+        settings.sqlite_db_path = old_db_path
+
+    assert result["ready"] is False
+    missing_journal_names = {item["name"] for item in result["missing"] if item["type"] == "journal"}
+    assert missing_journal_names == set(GSN_REQUIREMENTS["KZH"]["required_journals"])
+
+
+def test_gsn_report_pdf(tmp_path, monkeypatch):
+    old_db_path = settings.sqlite_db_path
+    old_keys = settings.api_keys
+    settings.sqlite_db_path = str(tmp_path / "compliance_api.db")
+    settings.api_keys = ["valid-key"]
+
+    project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True)
+
+    monkeypatch.setattr(compliance, "checker", GSNReadinessChecker())
+    monkeypatch.setattr(compliance, "_render_pdf_from_html", lambda _html: b"%PDF-1.4\nmock")
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                f"/api/compliance/gsn-report/{project_id}",
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -3,18 +3,36 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
 from api.main import app
 from api.routes import compliance
+from api.security import encode_jwt
 from config.settings import settings
 from core.compliance.gsn_checklist import GSN_REQUIREMENTS, GSNReadinessChecker
 from core.projects import Project, ProjectDocument, get_projects_sessionmaker
 
+UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
 
-def _seed_project_docs(sqlite_path: str, section: str, include_journals: bool = True) -> str:
+
+def _make_bearer(username: str, role: str = "pto_engineer") -> str:
+    payload = {
+        "sub": username,
+        "role": role,
+        "exp": int((dt.datetime.now(UTC) + dt.timedelta(hours=1)).timestamp()),
+    }
+    return encode_jwt(payload, settings.jwt_secret, algorithm="HS256")
+
+
+def _seed_project_docs(
+    sqlite_path: str,
+    section: str,
+    include_journals: bool = True,
+    owner: str = "tester",
+) -> str:
     session_local = get_projects_sessionmaker(sqlite_path)
     project_id = uuid4()
 
@@ -24,8 +42,8 @@ def _seed_project_docs(sqlite_path: str, section: str, include_journals: bool = 
                 id=project_id,
                 name="GSN Project",
                 description="",
-                owner_id="tester",
-                members=["tester"],
+                owner_id=owner,
+                members=[owner],
             )
         )
 
@@ -37,7 +55,7 @@ def _seed_project_docs(sqlite_path: str, section: str, include_journals: bool = 
                         project_id=project_id,
                         document_type=f"{section} {requirement_key}",
                         session_id="sess-1",
-                        created_by="tester",
+                        created_by=owner,
                         title=f"{section} {requirement}",
                         version=1,
                     )
@@ -50,7 +68,7 @@ def _seed_project_docs(sqlite_path: str, section: str, include_journals: bool = 
                         project_id=project_id,
                         document_type=f"{section} required_journals",
                         session_id="sess-1",
-                        created_by="tester",
+                        created_by=owner,
                         title=f"{section} {requirement}",
                         version=1,
                     )
@@ -104,8 +122,10 @@ def test_gsn_checklist_missing(tmp_path):
 def test_gsn_report_pdf(tmp_path, monkeypatch):
     old_db_path = settings.sqlite_db_path
     old_keys = settings.api_keys
+    old_secret = settings.jwt_secret
     settings.sqlite_db_path = str(tmp_path / "compliance_api.db")
     settings.api_keys = ["valid-key"]
+    settings.jwt_secret = "x" * 32
 
     project_id = _seed_project_docs(
         settings.sqlite_db_path,
@@ -120,11 +140,49 @@ def test_gsn_report_pdf(tmp_path, monkeypatch):
         with TestClient(app) as client:
             response = client.post(
                 f"/api/compliance/gsn-report/{project_id}",
-                headers={"X-API-Key": "valid-key"},
+                headers={"Authorization": f"Bearer {_make_bearer('tester')}"},
             )
     finally:
         settings.sqlite_db_path = old_db_path
         settings.api_keys = old_keys
+        settings.jwt_secret = old_secret
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/pdf")
+
+
+def test_gsn_checklist_requires_membership(tmp_path, monkeypatch):
+    old_db_path = settings.sqlite_db_path
+    old_secret = settings.jwt_secret
+    settings.sqlite_db_path = str(tmp_path / "compliance_access.db")
+    settings.jwt_secret = "y" * 32
+
+    project_id = _seed_project_docs(
+        settings.sqlite_db_path,
+        section="KZH",
+        include_journals=True,
+        owner="owner",
+    )
+    monkeypatch.setattr(compliance, "checker", GSNReadinessChecker())
+
+    try:
+        with TestClient(app) as client:
+            forbidden = client.get(
+                f"/api/compliance/gsn-checklist/{project_id}",
+                headers={"Authorization": f"Bearer {_make_bearer('outsider')}"},
+            )
+            missing_project = client.get(
+                f"/api/compliance/gsn-checklist/{uuid4()}",
+                headers={"Authorization": f"Bearer {_make_bearer('owner')}"},
+            )
+            malformed = client.get(
+                "/api/compliance/gsn-checklist/not-a-uuid",
+                headers={"Authorization": f"Bearer {_make_bearer('owner')}"},
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        settings.jwt_secret = old_secret
+
+    assert forbidden.status_code == 403
+    assert missing_project.status_code == 404
+    assert malformed.status_code == 422

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from api.main import app
 from api.routes import compliance
 from config.settings import settings
-from core.compliance.gsn_checklist import GSNReadinessChecker, GSN_REQUIREMENTS
+from core.compliance.gsn_checklist import GSN_REQUIREMENTS, GSNReadinessChecker
 from core.projects import Project, ProjectDocument, get_projects_sessionmaker
 
 
@@ -65,7 +65,11 @@ def test_gsn_checklist_complete(tmp_path):
     old_db_path = settings.sqlite_db_path
     settings.sqlite_db_path = str(tmp_path / "compliance_complete.db")
     try:
-        project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True)
+        project_id = _seed_project_docs(
+            settings.sqlite_db_path,
+            section="KZH",
+            include_journals=True,
+        )
         checker = GSNReadinessChecker()
         result = asyncio.run(checker.check_section(project_id=project_id, section="KZH"))
     finally:
@@ -80,14 +84,20 @@ def test_gsn_checklist_missing(tmp_path):
     old_db_path = settings.sqlite_db_path
     settings.sqlite_db_path = str(tmp_path / "compliance_missing.db")
     try:
-        project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=False)
+        project_id = _seed_project_docs(
+            settings.sqlite_db_path,
+            section="KZH",
+            include_journals=False,
+        )
         checker = GSNReadinessChecker()
         result = asyncio.run(checker.check_section(project_id=project_id, section="KZH"))
     finally:
         settings.sqlite_db_path = old_db_path
 
     assert result["ready"] is False
-    missing_journal_names = {item["name"] for item in result["missing"] if item["type"] == "journal"}
+    missing_journal_names = {
+        item["name"] for item in result["missing"] if item["type"] == "journal"
+    }
     assert missing_journal_names == set(GSN_REQUIREMENTS["KZH"]["required_journals"])
 
 
@@ -97,7 +107,11 @@ def test_gsn_report_pdf(tmp_path, monkeypatch):
     settings.sqlite_db_path = str(tmp_path / "compliance_api.db")
     settings.api_keys = ["valid-key"]
 
-    project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True)
+    project_id = _seed_project_docs(
+        settings.sqlite_db_path,
+        section="KZH",
+        include_journals=True,
+    )
 
     monkeypatch.setattr(compliance, "checker", GSNReadinessChecker())
     monkeypatch.setattr(compliance, "_render_pdf_from_html", lambda _html: b"%PDF-1.4\nmock")


### PR DESCRIPTION
### Motivation
- Implement automated verification of project executive documentation readiness for GSN handover per Rostechnadzor Order №522‑пр. 
- Provide an API to inspect per‑section and full‑project readiness and to produce a printable PDF report for submission.

### Description
- Added `core/compliance/gsn_checklist.py` which defines `GSN_REQUIREMENTS` for 8 sections and a `GSNReadinessChecker` that lists project documents, matches them against required acts/journals/schemes/passports, and computes `ready`, `missing/present` and `completion_pct` for a section or full project.
- Added API router `api/routes/compliance.py` exposing `GET /api/compliance/gsn-checklist/{project_id}`, `GET /api/compliance/gsn-checklist/{project_id}/section/{section}` and `POST /api/compliance/gsn-report/{project_id}` which renders an HTML template and generates a PDF via WeasyPrint (with an ImportError fallback raising a clear error).
- Added printable black-and-white HTML template `templates/gsn_checklist.html` used to render the report and registered the compliance router in `api/main.py`.
- Added unit tests `tests/test_compliance.py` that seed an ephemeral projects DB and cover complete checklist, missing journals, and PDF report generation (WeasyPrint call is mocked in the test).

### Testing
- Ran `pytest -q tests/test_compliance.py` which executed the three new tests and all passed (`3 passed`).
- Tests cover `check_section` success path (complete), missing items path, and the PDF report endpoint returning `Content-Type: application/pdf`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e8126978832f89e853875ad79d11)