### PR TITLE
Add handover page with readiness, signing and forecast tabs

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useState } from 'react';
 import Sidebar from './components/Sidebar';
-import ChatPage from './pages/ChatPage';
-import GenerateKSPage from './pages/GenerateKSPage';
-import GenerateLetterPage from './pages/GenerateLetterPage';
-import GenerateTKPage from './pages/GenerateTKPage';
-import SettingsPage from './pages/SettingsPage';
+import { resolveRoute } from './router';
 
 const normalizePath = (path: string) => path.replace(/\/$/, '') || '/';
 
@@ -27,28 +23,6 @@ export default function App() {
     setCurrentPath(nextPath);
   };
 
-  const renderPage = () => {
-    switch (currentPath) {
-      case '/':
-        return <ChatPage />;
-      case '/settings':
-        return <SettingsPage />;
-      case '/generate/tk':
-        return <GenerateTKPage />;
-      case '/generate/letter':
-        return <GenerateLetterPage />;
-      case '/generate/ks':
-        return <GenerateKSPage />;
-      default:
-        return (
-          <section>
-            <h2>Страница не найдена</h2>
-            <button onClick={() => navigate('/')}>На главную</button>
-          </section>
-        );
-    }
-  };
-
   return (
     <main
       style={{
@@ -60,7 +34,7 @@ export default function App() {
       }}
     >
       <Sidebar currentPath={currentPath} onNavigate={navigate} />
-      <section style={{ flex: 1 }}>{renderPage()}</section>
+      <section style={{ flex: 1 }}>{resolveRoute(currentPath, () => navigate('/'))}</section>
     </main>
   );
 }

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -1,8 +1,10 @@
+import { type ReactNode } from 'react';
 import { useChatStore } from '../store/chatStore';
 
 interface NavItem {
   path: string;
   label: string;
+  icon?: ReactNode;
 }
 
 interface SidebarProps {
@@ -10,12 +12,33 @@ interface SidebarProps {
   onNavigate: (path: string) => void;
 }
 
+function CheckBadgeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      style={{ width: 18, height: 18 }}
+      aria-hidden
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-3.75-7.5a2.25 2.25 0 0 0-2.25-2.25h-6a2.25 2.25 0 0 0-2.25 2.25v.372a2.25 2.25 0 0 1-.659 1.591l-.264.264a2.25 2.25 0 0 0 0 3.182l.264.264c.422.422.659.995.659 1.591v.372a2.25 2.25 0 0 0 2.25 2.25h6a2.25 2.25 0 0 0 2.25-2.25v-.372c0-.597.237-1.169.659-1.591l.264-.264a2.25 2.25 0 0 0 0-3.182l-.264-.264a2.25 2.25 0 0 1-.659-1.591v-.372Z"
+      />
+    </svg>
+  );
+}
+
 const navItems: NavItem[] = [
   { path: '/', label: 'Чат' },
   { path: '/settings', label: 'Настройки' },
   { path: '/generate/tk', label: 'Генерация ТК' },
   { path: '/generate/letter', label: 'Генерация письма' },
-  { path: '/generate/ks', label: 'Генерация КС' }
+  { path: '/generate/ks', label: 'Генерация КС' },
+  { path: '/handover', label: 'Сдача объекта', icon: <CheckBadgeIcon /> }
 ];
 
 export default function Sidebar({ currentPath, onNavigate }: SidebarProps) {
@@ -32,9 +55,13 @@ export default function Sidebar({ currentPath, onNavigate }: SidebarProps) {
             onClick={() => onNavigate(item.path)}
             style={{
               textAlign: 'left',
-              fontWeight: currentPath === item.path ? 700 : 400
+              fontWeight: currentPath === item.path ? 700 : 400,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8
             }}
           >
+            {item.icon}
             {item.label}
           </button>
         ))}

--- a/desktop/src/components/TabLayout.tsx
+++ b/desktop/src/components/TabLayout.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from 'react';
+
+export interface TabItem {
+  key: string;
+  title: string;
+  content: ReactNode;
+}
+
+interface TabLayoutProps {
+  tabs: TabItem[];
+  activeTab: string;
+  onChange: (tabKey: string) => void;
+}
+
+export default function TabLayout({ tabs, activeTab, onChange }: TabLayoutProps) {
+  return (
+    <section style={{ display: 'grid', gap: 12 }}>
+      <nav style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeTab;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onChange(tab.key)}
+              style={{
+                borderRadius: 10,
+                border: '1px solid #cbd5e1',
+                padding: '8px 12px',
+                background: isActive ? '#2563eb' : 'transparent',
+                color: isActive ? '#fff' : 'inherit',
+                fontWeight: isActive ? 700 : 500
+              }}
+            >
+              {tab.title}
+            </button>
+          );
+        })}
+      </nav>
+      <div>{tabs.find((tab) => tab.key === activeTab)?.content}</div>
+    </section>
+  );
+}

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useMemo, useState } from 'react';
+import TabLayout from '../components/TabLayout';
+import { getApiConfig } from '../api/coreClient';
+import type { GSNChecklist, GSNSectionStatus, ScheduleForecast, SignStatus } from '../types/handover';
+
+interface ProjectDocument {
+  id: string;
+  title: string;
+  document_type: string;
+  status?: SignStatus;
+}
+
+interface ProjectInfo {
+  id: string;
+  is_state_contract?: boolean;
+}
+
+const sectionOrder = ['AR', 'KZH', 'KM', 'OV', 'VK', 'EM'];
+
+function normalizeForecast(payload: Partial<ScheduleForecast>): ScheduleForecast {
+  return {
+    predicted_completion: String(payload.predicted_completion ?? '—'),
+    avg_delay_days: Number(payload.avg_delay_days ?? 0),
+    delay_rate: Number(payload.delay_rate ?? 0),
+    risks: Array.isArray(payload.risks) ? payload.risks : [],
+    recommendations: Array.isArray(payload.recommendations) ? payload.recommendations : []
+  };
+}
+
+export default function HandoverPage() {
+  const [activeTab, setActiveTab] = useState('readiness');
+  const [projectId, setProjectId] = useState('');
+  const [userId, setUserId] = useState('');
+  const [checklist, setChecklist] = useState<GSNChecklist | null>(null);
+  const [forecast, setForecast] = useState<ScheduleForecast | null>(null);
+  const [project, setProject] = useState<ProjectInfo | null>(null);
+  const [documents, setDocuments] = useState<ProjectDocument[]>([]);
+  const [signedDocIds, setSignedDocIds] = useState<string[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const savedProjectId = window.localStorage.getItem('handover_project_id') ?? '';
+    const savedUserId = window.localStorage.getItem('handover_user_id') ?? '';
+    setProjectId(savedProjectId);
+    setUserId(savedUserId);
+  }, []);
+
+  const fetchJson = async <T,>(endpoint: string, init?: RequestInit): Promise<T> => {
+    const { apiUrl, apiKey } = await getApiConfig();
+    const response = await fetch(`${apiUrl.replace(/\/$/, '')}${endpoint}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+        ...(init?.headers ?? {})
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return (await response.json()) as T;
+  };
+
+  const loadReadiness = async () => {
+    const data = await fetchJson<GSNChecklist>(`/api/compliance/gsn-checklist/${encodeURIComponent(projectId)}`);
+    setChecklist(data);
+  };
+
+  const loadSigning = async () => {
+    const [projectResponse, docsResponse] = await Promise.all([
+      fetchJson<ProjectInfo>(`/api/projects/${encodeURIComponent(projectId)}`),
+      fetchJson<{ documents: ProjectDocument[] }>(`/api/projects/${encodeURIComponent(projectId)}/documents`)
+    ]);
+    setProject(projectResponse);
+    setDocuments((docsResponse.documents || []).filter((doc) => (doc.status ?? 'approved') === 'approved'));
+  };
+
+  const loadForecast = async () => {
+    const data = await fetchJson<Partial<ScheduleForecast>>(
+      `/api/analytics/schedule/${encodeURIComponent(projectId)}`
+    );
+    setForecast(normalizeForecast(data));
+  };
+
+  const loadAll = async () => {
+    if (!projectId.trim()) {
+      setError('Укажите projectId');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+    window.localStorage.setItem('handover_project_id', projectId);
+    window.localStorage.setItem('handover_user_id', userId);
+
+    try {
+      await Promise.all([loadReadiness(), loadSigning(), loadForecast()]);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Ошибка загрузки данных');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleGenerateReport = async () => {
+    if (!projectId.trim()) {
+      setError('Укажите projectId');
+      return;
+    }
+
+    setError('');
+    try {
+      const { apiUrl, apiKey } = await getApiConfig();
+      const response = await fetch(
+        `${apiUrl.replace(/\/$/, '')}/api/compliance/gsn-report/${encodeURIComponent(projectId)}`,
+        {
+          method: 'POST',
+          headers: { 'X-API-Key': apiKey }
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Report API error: ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `gsn_checklist_${projectId}.pdf`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (reportError) {
+      setError(reportError instanceof Error ? reportError.message : 'Ошибка формирования отчёта');
+    }
+  };
+
+  const handleSign = async (doc: ProjectDocument) => {
+    if (!userId.trim()) {
+      setError('Укажите userId для ЭЦП');
+      return;
+    }
+
+    setError('');
+    try {
+      await fetchJson('/api/sign/document', {
+        method: 'POST',
+        body: JSON.stringify({
+          doc_id: doc.id,
+          doc_type: doc.document_type,
+          user_id: userId
+        })
+      });
+      setSignedDocIds((prev) => [...new Set([...prev, doc.id])]);
+    } catch (signError) {
+      setError(signError instanceof Error ? signError.message : 'Ошибка подписи');
+    }
+  };
+
+  const handleIsupSubmit = async (docId: string) => {
+    setError('');
+    try {
+      await fetchJson('/api/isup/submit-document', {
+        method: 'POST',
+        body: JSON.stringify({ project_id: projectId, doc_id: docId })
+      });
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Ошибка передачи в ИСУП');
+    }
+  };
+
+  const checklistSections = useMemo<GSNSectionStatus[]>(() => {
+    if (!checklist) {
+      return [];
+    }
+    return [...(checklist.sections ?? [])].sort(
+      (a, b) => sectionOrder.indexOf(a.section) - sectionOrder.indexOf(b.section)
+    );
+  }, [checklist]);
+
+  const riskLabel = (level: string) => {
+    if (level === 'high') return { text: 'высокий', color: '#dc2626' };
+    if (level === 'medium') return { text: 'средний', color: '#d97706' };
+    return { text: 'низкий', color: '#16a34a' };
+  };
+
+  return (
+    <section style={{ display: 'grid', gap: 12 }}>
+      <h2>Сдача объекта</h2>
+
+      <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+        <label style={{ display: 'grid', gap: 4 }}>
+          <span>Project ID</span>
+          <input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="UUID проекта" />
+        </label>
+        <label style={{ display: 'grid', gap: 4 }}>
+          <span>User ID для ЭЦП</span>
+          <input value={userId} onChange={(event) => setUserId(event.target.value)} placeholder="Идентификатор пользователя" />
+        </label>
+      </div>
+      <button type="button" onClick={loadAll} disabled={loading}>
+        {loading ? 'Загрузка...' : 'Загрузить данные'}
+      </button>
+      {error && <p style={{ color: 'crimson', margin: 0 }}>{error}</p>}
+
+      <TabLayout
+        tabs={[
+          {
+            key: 'readiness',
+            title: 'Готовность ИД',
+            content: (
+              <section style={{ display: 'grid', gap: 12 }}>
+                <button type="button" onClick={handleGenerateReport}>
+                  Сформировать отчёт
+                </button>
+                <div style={{ display: 'grid', gap: 10 }}>
+                  {checklistSections.map((section) => (
+                    <article
+                      key={section.section}
+                      style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12, display: 'grid', gap: 8 }}
+                    >
+                      <strong>{section.section}</strong>
+                      <div style={{ width: '100%', height: 10, borderRadius: 8, background: '#33415533' }}>
+                        <div
+                          style={{
+                            width: `${Math.max(0, Math.min(100, section.completion_pct))}%`,
+                            height: '100%',
+                            borderRadius: 8,
+                            background: '#2563eb'
+                          }}
+                        />
+                      </div>
+                      <small>Готовность: {section.completion_pct}%</small>
+                      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                        <div>
+                          <strong style={{ color: '#dc2626' }}>Отсутствует</strong>
+                          <ul>
+                            {section.missing.map((item) => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                        <div>
+                          <strong style={{ color: '#16a34a' }}>В наличии</strong>
+                          <ul>
+                            {section.present.map((item) => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            )
+          },
+          {
+            key: 'signing',
+            title: 'Подписание документов',
+            content: (
+              <section style={{ display: 'grid', gap: 10 }}>
+                {documents.map((doc) => {
+                  const status: SignStatus = signedDocIds.includes(doc.id) ? 'signed' : doc.status ?? 'approved';
+                  const icon = status === 'signed' ? '✅' : status === 'approved' ? '🟡' : '📝';
+                  const title = status === 'signed' ? 'подписан' : status === 'approved' ? 'утверждён' : 'черновик';
+
+                  return (
+                    <article
+                      key={doc.id}
+                      style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12, display: 'grid', gap: 8 }}
+                    >
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+                        <strong>{doc.title}</strong>
+                        <span>
+                          {icon} {title}
+                        </span>
+                      </div>
+                      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                        <button type="button" onClick={() => handleSign(doc)} disabled={status === 'signed'}>
+                          Подписать ЭЦП
+                        </button>
+                        {project?.is_state_contract && status === 'signed' && (
+                          <button type="button" onClick={() => handleIsupSubmit(doc.id)}>
+                            Передать в ИСУП
+                          </button>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
+                {!documents.length && <p>Нет документов со статусом «утверждён».</p>}
+              </section>
+            )
+          },
+          {
+            key: 'forecast',
+            title: 'Прогноз завершения',
+            content: (
+              <section style={{ display: 'grid', gap: 10 }}>
+                <article style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12 }}>
+                  <strong>Ожидаемая дата завершения: {forecast?.predicted_completion ?? '—'}</strong>
+                  <p style={{ marginBottom: 6 }}>Средняя задержка: {forecast?.avg_delay_days ?? 0} дн.</p>
+                  <p style={{ marginTop: 0 }}>Вероятность задержки: {((forecast?.delay_rate ?? 0) * 100).toFixed(1)}%</p>
+                </article>
+                <article style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12 }}>
+                  <strong>Риски</strong>
+                  <ul>
+                    {(forecast?.risks ?? []).map((risk) => {
+                      const badge = riskLabel(risk.level);
+                      return (
+                        <li key={`${risk.title}-${risk.level}`}>
+                          <span
+                            style={{
+                              padding: '2px 8px',
+                              borderRadius: 999,
+                              marginRight: 8,
+                              background: `${badge.color}22`,
+                              color: badge.color
+                            }}
+                          >
+                            {badge.text}
+                          </span>
+                          <strong>{risk.title}</strong>
+                          {risk.details ? ` — ${risk.details}` : ''}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </article>
+                <article style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12 }}>
+                  <strong>Рекомендации ИИ</strong>
+                  <ul>
+                    {(forecast?.recommendations ?? []).map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </article>
+              </section>
+            )
+          }
+        ]}
+        activeTab={activeTab}
+        onChange={setActiveTab}
+      />
+    </section>
+  );
+}

--- a/desktop/src/router.tsx
+++ b/desktop/src/router.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+import ChatPage from './pages/ChatPage';
+import GenerateKSPage from './pages/GenerateKSPage';
+import GenerateLetterPage from './pages/GenerateLetterPage';
+import GenerateTKPage from './pages/GenerateTKPage';
+import HandoverPage from './pages/HandoverPage';
+import SettingsPage from './pages/SettingsPage';
+
+export function resolveRoute(path: string, onNavigateHome: () => void): ReactNode {
+  switch (path) {
+    case '/':
+      return <ChatPage />;
+    case '/settings':
+      return <SettingsPage />;
+    case '/generate/tk':
+      return <GenerateTKPage />;
+    case '/generate/letter':
+      return <GenerateLetterPage />;
+    case '/generate/ks':
+      return <GenerateKSPage />;
+    case '/handover':
+      return <HandoverPage />;
+    default:
+      return (
+        <section>
+          <h2>Страница не найдена</h2>
+          <button onClick={onNavigateHome}>На главную</button>
+        </section>
+      );
+  }
+}

--- a/desktop/src/types/handover.ts
+++ b/desktop/src/types/handover.ts
@@ -1,0 +1,30 @@
+export type GSNSectionCode = 'AR' | 'KZH' | 'KM' | 'OV' | 'VK' | 'EM';
+
+export interface GSNSectionStatus {
+  section: GSNSectionCode | string;
+  completion_pct: number;
+  missing: string[];
+  present: string[];
+}
+
+export interface GSNChecklist {
+  project_id?: string;
+  completion_pct: number;
+  sections: GSNSectionStatus[];
+}
+
+export interface ScheduleRisk {
+  title: string;
+  level: 'high' | 'medium' | 'low' | string;
+  details?: string;
+}
+
+export interface ScheduleForecast {
+  predicted_completion: string;
+  avg_delay_days: number;
+  delay_rate: number;
+  risks: ScheduleRisk[];
+  recommendations: string[];
+}
+
+export type SignStatus = 'draft' | 'approved' | 'signed';


### PR DESCRIPTION
### Motivation
- Добавить страницу «Сдача объекта» с тремя логическими вкладками для просмотра готовности исполнительной документации, подписания документов и прогноза завершения проекта. 
- Интегрировать UI с существующими API-эндпоинтами для чеклиста GSN, подписи документов и прогнозной аналитики.

### Description
- Добавлен компонент страницы `desktop/src/pages/HandoverPage.tsx` с тремя вкладками: `Готовность ИД` (запрос `GET /api/compliance/gsn-checklist/{projectId}` и генерация PDF через `POST /api/compliance/gsn-report/{projectId}`), `Подписание документов` (загрузка документов проекта и вызов `POST /api/sign/document`, кнопка отправки в ИСУП при `project.is_state_contract`), и `Прогноз завершения` (запрос `GET /api/analytics/schedule/{projectId}` и отображение даты, метрик, рисков и рекомендаций).
- Добавлен переиспользуемый компонент вкладок `desktop/src/components/TabLayout.tsx` и типы домена `desktop/src/types/handover.ts` (`GSNChecklist`, `ScheduleForecast`, `SignStatus` и сопутствующие интерфейсы).
- Обновлён `desktop/src/components/Sidebar.tsx` — добавлен пункт навигации `Сдача объекта` с иконкой (inline `CheckBadgeIcon`).
- Добавлена простая маршрутизация через `desktop/src/router.tsx` и подключена в `desktop/src/App.tsx` (роут `/handover`).
- Реализовано взаимодействие с API через конфиг из `getApiConfig()` и локальное сохранение введённых `projectId` / `userId`.
- Реализованы базовые стили/разметка в стиле существующего десктопного интерфейса (инлайновые стили, тёмная тема наследуется через корневую логику приложения).

### Testing
- Собран десктопный фронтенд командой `cd desktop && npm run build` (включает `tsc` и `vite build`) — сборка выполнена успешно.
- Нет дополнительных автоматических юнит-тестов, изменённый UI покрытие не запускалось в CI в рамках этого PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f58a0470832fb019077531925b06)