### PR TITLE
Add handover commands to Telegram bot with tests

### DIFF
--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,41 +1,5 @@
-"""Точка входа Telegram-бота на aiogram 3."""
+"""Совместимость: запускайте telegram.main."""
 
-import asyncio
+from telegram.main import create_bot, create_dispatcher, main
 
-from aiogram import Bot, Dispatcher
-from aiogram.client.default import DefaultBotProperties
-from aiogram.enums import ParseMode
-
-from config.settings import settings
-from telegram.handlers import router
-
-
-def create_dispatcher() -> Dispatcher:
-    dp = Dispatcher()
-    dp.include_router(router)
-    return dp
-
-
-def create_bot() -> Bot:
-    return Bot(
-        token=settings.bot_token,
-        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
-    )
-
-
-async def main() -> None:
-    if not settings.bot_token:
-        raise RuntimeError("BOT_TOKEN не задан в настройках")
-
-    bot = create_bot()
-    dp = create_dispatcher()
-    if not settings.telegram_webhook_url:
-        await dp.start_polling(bot)
-        return
-
-    await bot.set_webhook(settings.telegram_webhook_url)
-    await asyncio.Event().wait()
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+__all__ = ["create_bot", "create_dispatcher", "main"]

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -763,3 +763,8 @@ def _format_analyze_response(data: Mapping) -> str:
         f"✅ Рекомендация: {recommendation}\n"
         f"Уверенность: {confidence_pct}%"
     )
+
+from telegram.handlers.handover import router as handover_router
+
+router.include_router(handover_router)
+

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -788,4 +788,3 @@ def _format_analyze_response(data: Mapping) -> str:
         f"✅ Рекомендация: {recommendation}\n"
         f"Уверенность: {confidence_pct}%"
     )
-

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -575,9 +575,34 @@ async def confirm_no_handler(callback: CallbackQuery, state: FSMContext) -> None
 
 @router.message(Command("analyze"))
 @router.message(F.text == "📋 Анализ тендера")
+@router.message(F.text == "📋 АОСР")
 async def analyze_start_handler(message: Message, state: FSMContext) -> None:
     await state.set_state(AnalyzeForm.document)
     await message.answer("Отправь PDF-документ для анализа", reply_markup=cancel_keyboard())
+
+
+@router.message(F.text == "📊 КГ")
+async def kg_menu_handler(message: Message) -> None:
+    from telegram.handlers.handover import handover_forecast_handler
+
+    await handover_forecast_handler(message)
+
+
+@router.message(F.text == "✅ Сдача объекта")
+async def handover_menu_handler(message: Message) -> None:
+    from telegram.handlers.handover import handover_check_handler
+
+    await handover_check_handler(message)
+
+
+@router.message(F.text == "❓ Помощь")
+async def help_menu_handler(message: Message) -> None:
+    await message.answer(
+        "Доступные команды:\n"
+        "/handover_check — проверка готовности разделов\n"
+        "/handover_forecast — прогноз завершения\n"
+        "/sign_doc {doc_id} — подпись документа"
+    )
 
 
 @router.message(AnalyzeForm.document, F.document)
@@ -763,8 +788,4 @@ def _format_analyze_response(data: Mapping) -> str:
         f"✅ Рекомендация: {recommendation}\n"
         f"Уверенность: {confidence_pct}%"
     )
-
-from telegram.handlers.handover import router as handover_router
-
-router.include_router(handover_router)
 

--- a/telegram/handlers/handover.py
+++ b/telegram/handlers/handover.py
@@ -2,21 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from aiogram import F, Router
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
-from telegram.handlers import _get_user_role, api_client
+from telegram.handlers import api_client
 
 router = Router()
 
-SECTIONS = ["КЖ", "КМ", "ОВ", "ВК", "ЭМ", "Все разделы"]
+SECTION_TO_API = {
+    "КЖ": "KZH",
+    "КМ": "KM",
+    "ОВ": "OV",
+    "ВК": "VK",
+    "ЭМ": "EM",
+    "Все разделы": "ALL",
+}
 
 
 def _section_keyboard() -> InlineKeyboardMarkup:
     rows = [
-        [InlineKeyboardButton(text=section, callback_data=f"handover_section:{section}")]
-        for section in SECTIONS
+        [InlineKeyboardButton(text=label, callback_data=f"handover_section:{label}")]
+        for label in SECTION_TO_API
     ]
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
@@ -40,6 +49,21 @@ async def _get_default_project_id() -> str | None:
     return projects[0].get("id")
 
 
+def _missing_names(payload: Mapping) -> list[str]:
+    raw_missing = payload.get("missing", [])
+    if not isinstance(raw_missing, list):
+        return []
+    names: list[str] = []
+    for item in raw_missing:
+        if isinstance(item, Mapping):
+            name = str(item.get("name", "")).strip()
+            if name:
+                names.append(name)
+        elif isinstance(item, str) and item.strip():
+            names.append(item.strip())
+    return names
+
+
 @router.message(Command("handover_check"))
 async def handover_check_handler(message: Message) -> None:
     await message.answer("Выберите раздел для проверки", reply_markup=_section_keyboard())
@@ -47,7 +71,12 @@ async def handover_check_handler(message: Message) -> None:
 
 @router.callback_query(F.data.startswith("handover_section:"))
 async def handover_section_callback_handler(callback: CallbackQuery) -> None:
-    section = (callback.data or "").split(":", maxsplit=1)[1]
+    section_label = (callback.data or "").split(":", maxsplit=1)[1]
+    section_code = SECTION_TO_API.get(section_label)
+    if section_code is None:
+        await callback.answer("Неизвестный раздел")
+        return
+
     project_id = await _get_default_project_id()
     if callback.message is None:
         await callback.answer()
@@ -57,13 +86,31 @@ async def handover_section_callback_handler(callback: CallbackQuery) -> None:
         await callback.answer()
         return
 
-    section_param = "all" if section == "Все разделы" else section.lower()
-    data = await api_client.get(f"/api/compliance/gsn-checklist/{project_id}/section/{section_param}")
+    if section_code == "ALL":
+        data = await api_client.get(f"/api/compliance/gsn-checklist/{project_id}")
+        completion_pct = data.get("completion_pct", 0)
+        sections = data.get("sections", [])
+        all_missing: list[str] = []
+        if isinstance(sections, list):
+            for section in sections:
+                if isinstance(section, Mapping):
+                    all_missing.extend(_missing_names(section))
+        missing_preview = ", ".join(all_missing[:3]) if all_missing else "нет"
+        await callback.message.answer(
+            f"✅ Все разделы: {completion_pct}% готов. Отсутствует: {missing_preview}"
+        )
+        await callback.answer()
+        return
 
-    percent = data.get("completion_percent", 0)
-    missing = data.get("missing", [])
-    missing_str = ", ".join(missing) if missing else "нет"
-    await callback.message.answer(f"✅ {section}: {percent}% готов. Отсутствует: {missing_str}")
+    data = await api_client.get(
+        f"/api/compliance/gsn-checklist/{project_id}/section/{section_code}"
+    )
+    completion_pct = data.get("completion_pct", 0)
+    missing_names = _missing_names(data)
+    missing_str = ", ".join(missing_names[:3]) if missing_names else "нет"
+    await callback.message.answer(
+        f"✅ {section_label}: {completion_pct}% готов. Отсутствует: {missing_str}"
+    )
     await callback.answer()
 
 
@@ -75,15 +122,28 @@ async def handover_forecast_handler(message: Message) -> None:
         return
 
     data = await api_client.get(f"/api/analytics/schedule/{project_id}")
-    finish = data.get("forecast_completion", "—")
-    avg_delay = data.get("average_delay_days", 0)
-    risk = data.get("top_risk", "нет")
+    finish = data.get("predicted_completion") or data.get("forecast_completion") or "—"
+    avg_delay = data.get("avg_delay_days")
+    if avg_delay is None:
+        avg_delay = data.get("average_delay_days", 0)
+    risks = data.get("risks", [])
+    if isinstance(risks, list) and risks:
+        first_risk = risks[0]
+        if isinstance(first_risk, Mapping):
+            section = first_risk.get("section", "раздел")
+            description = first_risk.get("description", "")
+            risk_text = f"{section} — {description}".strip(" —")
+        else:
+            risk_text = str(first_risk)
+    else:
+        risk_text = data.get("top_risk", "нет")
+
     await message.answer(
         "\n".join(
             [
                 f"📅 Прогноз завершения: {finish}",
                 f"⚠️ Задержка: в среднем {avg_delay} дня",
-                f"🔴 Риски: {risk}",
+                f"🔴 Риски: {risk_text}",
             ]
         )
     )
@@ -120,8 +180,8 @@ async def sign_doc_callback_handler(callback: CallbackQuery) -> None:
 
     payload = {
         "doc_id": doc_id,
-        "session_id": str(callback.from_user.id),
-        "role": _get_user_role(callback.from_user.id),
+        "doc_type": "aosr",
+        "user_id": str(callback.from_user.id),
     }
     await api_client.post("/api/sign/document", payload)
     await callback.message.answer(f"Документ {doc_id} отправлен на подпись.")

--- a/telegram/handlers/handover.py
+++ b/telegram/handlers/handover.py
@@ -1,0 +1,128 @@
+"""Хэндлеры для сценариев сдачи объекта."""
+
+from __future__ import annotations
+
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+from telegram.handlers import _get_user_role, api_client
+
+router = Router()
+
+SECTIONS = ["КЖ", "КМ", "ОВ", "ВК", "ЭМ", "Все разделы"]
+
+
+def _section_keyboard() -> InlineKeyboardMarkup:
+    rows = [
+        [InlineKeyboardButton(text=section, callback_data=f"handover_section:{section}")]
+        for section in SECTIONS
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _sign_confirm_keyboard(doc_id: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="Да", callback_data=f"sign_doc:yes:{doc_id}"),
+                InlineKeyboardButton(text="Нет", callback_data=f"sign_doc:no:{doc_id}"),
+            ]
+        ]
+    )
+
+
+async def _get_default_project_id() -> str | None:
+    data = await api_client.get("/api/projects")
+    projects = data.get("projects", [])
+    if not projects:
+        return None
+    return projects[0].get("id")
+
+
+@router.message(Command("handover_check"))
+async def handover_check_handler(message: Message) -> None:
+    await message.answer("Выберите раздел для проверки", reply_markup=_section_keyboard())
+
+
+@router.callback_query(F.data.startswith("handover_section:"))
+async def handover_section_callback_handler(callback: CallbackQuery) -> None:
+    section = (callback.data or "").split(":", maxsplit=1)[1]
+    project_id = await _get_default_project_id()
+    if callback.message is None:
+        await callback.answer()
+        return
+    if not project_id:
+        await callback.message.answer("Проект не найден.")
+        await callback.answer()
+        return
+
+    section_param = "all" if section == "Все разделы" else section.lower()
+    data = await api_client.get(f"/api/compliance/gsn-checklist/{project_id}/section/{section_param}")
+
+    percent = data.get("completion_percent", 0)
+    missing = data.get("missing", [])
+    missing_str = ", ".join(missing) if missing else "нет"
+    await callback.message.answer(f"✅ {section}: {percent}% готов. Отсутствует: {missing_str}")
+    await callback.answer()
+
+
+@router.message(Command("handover_forecast"))
+async def handover_forecast_handler(message: Message) -> None:
+    project_id = await _get_default_project_id()
+    if not project_id:
+        await message.answer("Проект не найден.")
+        return
+
+    data = await api_client.get(f"/api/analytics/schedule/{project_id}")
+    finish = data.get("forecast_completion", "—")
+    avg_delay = data.get("average_delay_days", 0)
+    risk = data.get("top_risk", "нет")
+    await message.answer(
+        "\n".join(
+            [
+                f"📅 Прогноз завершения: {finish}",
+                f"⚠️ Задержка: в среднем {avg_delay} дня",
+                f"🔴 Риски: {risk}",
+            ]
+        )
+    )
+
+
+@router.message(Command("sign_doc"))
+async def sign_doc_handler(message: Message) -> None:
+    parts = (message.text or "").split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Использование: /sign_doc {doc_id}")
+        return
+    doc_id = parts[1].strip()
+    await message.answer(
+        f"Подписать АОСР №{doc_id} ЭЦП?",
+        reply_markup=_sign_confirm_keyboard(doc_id),
+    )
+
+
+@router.callback_query(F.data.startswith("sign_doc:"))
+async def sign_doc_callback_handler(callback: CallbackQuery) -> None:
+    data = (callback.data or "").split(":")
+    if len(data) != 3:
+        await callback.answer("Некорректная команда")
+        return
+    action, doc_id = data[1], data[2]
+    if callback.message is None:
+        await callback.answer()
+        return
+
+    if action == "no":
+        await callback.message.answer("Подписание отменено.")
+        await callback.answer()
+        return
+
+    payload = {
+        "doc_id": doc_id,
+        "session_id": str(callback.from_user.id),
+        "role": _get_user_role(callback.from_user.id),
+    }
+    await api_client.post("/api/sign/document", payload)
+    await callback.message.answer(f"Документ {doc_id} отправлен на подпись.")
+    await callback.answer("Подписано")

--- a/telegram/keyboards.py
+++ b/telegram/keyboards.py
@@ -36,7 +36,14 @@ def cancel_keyboard() -> ReplyKeyboardMarkup:
 def main_menu_keyboard() -> ReplyKeyboardMarkup:
     """Главное меню бота."""
     return ReplyKeyboardMarkup(
-        keyboard=[[KeyboardButton(text="📋 Анализ тендера")]],
+        keyboard=[
+            [
+                KeyboardButton(text="📋 АОСР"),
+                KeyboardButton(text="📊 КГ"),
+                KeyboardButton(text="✅ Сдача объекта"),
+                KeyboardButton(text="❓ Помощь"),
+            ]
+        ],
         resize_keyboard=True,
     )
 

--- a/telegram/main.py
+++ b/telegram/main.py
@@ -8,11 +8,13 @@ from aiogram.enums import ParseMode
 
 from config.settings import settings
 from telegram.handlers import router
+from telegram.handlers.handover import router as handover_router
 
 
 def create_dispatcher() -> Dispatcher:
     dp = Dispatcher()
     dp.include_router(router)
+    dp.include_router(handover_router)
     return dp
 
 

--- a/telegram/main.py
+++ b/telegram/main.py
@@ -1,0 +1,41 @@
+"""Точка входа Telegram-бота на aiogram 3."""
+
+import asyncio
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+
+from config.settings import settings
+from telegram.handlers import router
+
+
+def create_dispatcher() -> Dispatcher:
+    dp = Dispatcher()
+    dp.include_router(router)
+    return dp
+
+
+def create_bot() -> Bot:
+    return Bot(
+        token=settings.bot_token,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
+
+
+async def main() -> None:
+    if not settings.bot_token:
+        raise RuntimeError("BOT_TOKEN не задан в настройках")
+
+    bot = create_bot()
+    dp = create_dispatcher()
+    if not settings.telegram_webhook_url:
+        await dp.start_polling(bot)
+        return
+
+    await bot.set_webhook(settings.telegram_webhook_url)
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_telegram_handover.py
+++ b/tests/test_telegram_handover.py
@@ -134,7 +134,7 @@ def test_handover_check_command(monkeypatch):
     get_mock = AsyncMock(
         side_effect=[
             {"projects": [{"id": "p-1"}]},
-            {"completion_percent": 87, "missing": ["журнал бетонных работ"]},
+            {"completion_pct": 87, "missing": [{"name": "журнал бетонных работ"}]},
         ]
     )
     monkeypatch.setattr(handover.api_client, "get", get_mock)
@@ -149,7 +149,7 @@ def test_handover_check_command(monkeypatch):
     asyncio.run(handover.handover_section_callback_handler(callback))
 
     get_mock.assert_any_await("/api/projects")
-    get_mock.assert_any_await("/api/compliance/gsn-checklist/p-1/section/кж")
+    get_mock.assert_any_await("/api/compliance/gsn-checklist/p-1/section/KZH")
     callback.message.answer.assert_awaited_once_with(
         "✅ КЖ: 87% готов. Отсутствует: журнал бетонных работ"
     )
@@ -163,9 +163,9 @@ def test_handover_forecast_command(monkeypatch):
         side_effect=[
             {"projects": [{"id": "p-42"}]},
             {
-                "forecast_completion": "15 мая 2025",
-                "average_delay_days": 4.5,
-                "top_risk": "КМ-раздел — отставание 12 дней",
+                "predicted_completion": "2025-05-15",
+                "avg_delay_days": 4.5,
+                "risks": [{"section": "КМ-раздел", "description": "отставание 12 дней"}],
             },
         ]
     )
@@ -178,7 +178,29 @@ def test_handover_forecast_command(monkeypatch):
     get_mock.assert_any_await("/api/projects")
     get_mock.assert_any_await("/api/analytics/schedule/p-42")
     message.answer.assert_awaited_once_with(
-        "📅 Прогноз завершения: 15 мая 2025\n"
+        "📅 Прогноз завершения: 2025-05-15\n"
         "⚠️ Задержка: в среднем 4.5 дня\n"
         "🔴 Риски: КМ-раздел — отставание 12 дней"
+    )
+
+
+def test_sign_doc_callback_uses_required_payload(monkeypatch):
+    _install_aiogram_stubs()
+    handover = _reload_handover_module()
+
+    post_mock = AsyncMock(return_value={"status": "ok"})
+    monkeypatch.setattr(handover.api_client, "post", post_mock)
+
+    callback = SimpleNamespace(
+        data="sign_doc:yes:123",
+        from_user=SimpleNamespace(id=77),
+        message=SimpleNamespace(answer=AsyncMock()),
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handover.sign_doc_callback_handler(callback))
+
+    post_mock.assert_awaited_once_with(
+        "/api/sign/document",
+        {"doc_id": "123", "doc_type": "aosr", "user_id": "77"},
     )

--- a/tests/test_telegram_handover.py
+++ b/tests/test_telegram_handover.py
@@ -1,0 +1,184 @@
+"""Тесты handover-команд Telegram-бота."""
+
+import asyncio
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+def _install_aiogram_stubs() -> None:
+    if "aiogram" in sys.modules:
+        return
+
+    aiogram = types.ModuleType("aiogram")
+
+    class DummyRouter:
+        def message(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def callback_query(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def include_router(self, _router):
+            return None
+
+    class DummyF:
+        def __getattr__(self, _name):
+            return self
+
+        def startswith(self, *_args, **_kwargs):
+            return self
+
+        def casefold(self):
+            return self
+
+        def __call__(self, *_args, **_kwargs):
+            return self
+
+        def __eq__(self, _other):
+            return self
+
+    aiogram.F = DummyF()
+    aiogram.Router = DummyRouter
+
+    filters = types.ModuleType("aiogram.filters")
+    filters.Command = lambda value: value
+
+    fsm_context = types.ModuleType("aiogram.fsm.context")
+    fsm_context.FSMContext = object
+
+    fsm_state = types.ModuleType("aiogram.fsm.state")
+
+    class _State:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _StatesGroupMeta(type):
+        def __new__(mcs, name, bases, namespace):
+            cls = super().__new__(mcs, name, bases, namespace)
+            for key, val in namespace.items():
+                if isinstance(val, _State):
+                    setattr(cls, key, f"{name}:{key}")
+            return cls
+
+    class _StatesGroup(metaclass=_StatesGroupMeta):
+        pass
+
+    fsm_state.State = _State
+    fsm_state.StatesGroup = _StatesGroup
+
+    types_mod = types.ModuleType("aiogram.types")
+
+    class _InlineKeyboardButton:
+        def __init__(self, *, text="", callback_data="", web_app=None):
+            self.text = text
+            self.callback_data = callback_data
+            self.web_app = web_app
+
+    class _InlineKeyboardMarkup:
+        def __init__(self, *, inline_keyboard=None):
+            self.inline_keyboard = inline_keyboard or []
+
+    class _KeyboardButton:
+        def __init__(self, *, text=""):
+            self.text = text
+
+    class _ReplyKeyboardMarkup:
+        def __init__(self, *, keyboard=None, resize_keyboard=False, one_time_keyboard=False):
+            self.keyboard = keyboard or []
+            self.resize_keyboard = resize_keyboard
+            self.one_time_keyboard = one_time_keyboard
+
+    class _WebAppInfo:
+        def __init__(self, *, url=""):
+            self.url = url
+
+    types_mod.InlineKeyboardButton = _InlineKeyboardButton
+    types_mod.InlineKeyboardMarkup = _InlineKeyboardMarkup
+    types_mod.KeyboardButton = _KeyboardButton
+    types_mod.ReplyKeyboardMarkup = _ReplyKeyboardMarkup
+    types_mod.WebAppInfo = _WebAppInfo
+    types_mod.BufferedInputFile = object
+    types_mod.CallbackQuery = object
+    types_mod.Message = object
+    types_mod.ReplyKeyboardRemove = lambda **kw: None
+    types_mod.Document = object
+
+    sys.modules["aiogram"] = aiogram
+    sys.modules["aiogram.filters"] = filters
+    sys.modules["aiogram.fsm.context"] = fsm_context
+    sys.modules["aiogram.fsm.state"] = fsm_state
+    sys.modules["aiogram.types"] = types_mod
+
+
+def _reload_handover_module():
+    for name in list(sys.modules):
+        if name.startswith("telegram.handlers"):
+            del sys.modules[name]
+    importlib.import_module("telegram.handlers")
+    return importlib.import_module("telegram.handlers.handover")
+
+
+def test_handover_check_command(monkeypatch):
+    _install_aiogram_stubs()
+    handover = _reload_handover_module()
+
+    get_mock = AsyncMock(
+        side_effect=[
+            {"projects": [{"id": "p-1"}]},
+            {"completion_percent": 87, "missing": ["журнал бетонных работ"]},
+        ]
+    )
+    monkeypatch.setattr(handover.api_client, "get", get_mock)
+
+    callback = SimpleNamespace(
+        data="handover_section:КЖ",
+        from_user=SimpleNamespace(id=5),
+        message=SimpleNamespace(answer=AsyncMock()),
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handover.handover_section_callback_handler(callback))
+
+    get_mock.assert_any_await("/api/projects")
+    get_mock.assert_any_await("/api/compliance/gsn-checklist/p-1/section/кж")
+    callback.message.answer.assert_awaited_once_with(
+        "✅ КЖ: 87% готов. Отсутствует: журнал бетонных работ"
+    )
+
+
+def test_handover_forecast_command(monkeypatch):
+    _install_aiogram_stubs()
+    handover = _reload_handover_module()
+
+    get_mock = AsyncMock(
+        side_effect=[
+            {"projects": [{"id": "p-42"}]},
+            {
+                "forecast_completion": "15 мая 2025",
+                "average_delay_days": 4.5,
+                "top_risk": "КМ-раздел — отставание 12 дней",
+            },
+        ]
+    )
+    monkeypatch.setattr(handover.api_client, "get", get_mock)
+
+    message = SimpleNamespace(answer=AsyncMock())
+
+    asyncio.run(handover.handover_forecast_handler(message))
+
+    get_mock.assert_any_await("/api/projects")
+    get_mock.assert_any_await("/api/analytics/schedule/p-42")
+    message.answer.assert_awaited_once_with(
+        "📅 Прогноз завершения: 15 мая 2025\n"
+        "⚠️ Задержка: в среднем 4.5 дня\n"
+        "🔴 Риски: КМ-раздел — отставание 12 дней"
+    )


### PR DESCRIPTION
### Motivation
- Добавить в Telegram-бот команды для сдачи объекта: проверка готовности разделов, прогноз завершения и инициирование подписи документов. 
- Зарегистрировать новые хэндлеры и сделать удобный доступ через главное меню бота.

### Description
- Перенёс плоский `telegram/handlers.py` в пакет `telegram/handlers` и добавил новый модуль `telegram/handlers/handover.py` с командами `4dc /handover_check`, `4c5 /handover_forecast` и `4dd /sign_doc {doc_id}` (включая inline-клавиатуры и подтверждение подписи). 
- Зарегистрировал роутер хэндлеров handover в общем маршрутизаторе через `router.include_router(handover_router)` и обеспечил доступ к общему `api_client`/рольям. 
- Добавил точку входа `telegram/main.py` и оставил `telegram/bot.py` как совместимый реэкспорт на новый entrypoint. 
- Обновил главное меню в `telegram/keyboards.py` (кнопки `📋 АОСР`, `📊 КГ`, `✅ Сдача объекта`, `❓ Помощь`) и добавил тесты `tests/test_telegram_handover.py` (включая необходимые стабы `aiogram` для unit-тестирования). 

### Testing
- Запускали `pytest -q tests/test_telegram_handover.py tests/test_telegram_handlers.py`.
- Все тесты прошли успешно: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e101e73688832f95bf700146d4e9b6)