### PR TITLE
Добавить пакетную подпись документов, Handover batch UI и Telegram /sign_all

### DIFF
--- a/api/routes/sign.py
+++ b/api/routes/sign.py
@@ -26,6 +26,14 @@ class SignDocumentRequest(BaseModel):
     user_id: str
 
 
+class BatchSignRequest(BaseModel):
+    """Запрос пакетной подписи документов."""
+
+    doc_ids: list[str]
+    doc_type: str
+    user_id: str
+
+
 _ALLOWED_DOC_TYPES = {"aosr", "ks2", "ks3"}
 
 
@@ -189,21 +197,20 @@ def _resolve_download_url(locator: str) -> str:
     return _presign_object_key(locator)
 
 
-@router.post("/sign/document")
-async def sign_document(
-    payload: SignDocumentRequest,
-    request: Request,
+async def sign_document_inner(
+    doc_id: str,
+    doc_type: str,
+    user_id: str,
     background_tasks: BackgroundTasks,
-):
-    """Подписать PDF документа через КриптоПро REST API."""
-    _ = request
-    if payload.doc_type not in _ALLOWED_DOC_TYPES:
+) -> dict:
+    """Внутренняя логика подписи документа."""
+    if doc_type not in _ALLOWED_DOC_TYPES:
         raise HTTPException(status_code=422, detail="doc_type must be one of: aosr, ks2, ks3")
 
     doc = await asyncio.to_thread(
         _fetch_exec_doc_for_sign,
-        payload.doc_id,
-        payload.doc_type,
+        doc_id,
+        doc_type,
     )
     if not doc:
         raise HTTPException(status_code=404, detail="Document not found")
@@ -214,7 +221,7 @@ async def sign_document(
 
     cert_thumbprint = await asyncio.to_thread(
         _fetch_user_cert_thumbprint,
-        payload.user_id,
+        user_id,
     )
     cert_thumbprint = cert_thumbprint or _cryptopro_cert_thumbprint()
     if not cert_thumbprint:
@@ -250,16 +257,59 @@ async def sign_document(
     )
     await asyncio.to_thread(
         _mark_document_signed,
-        payload.doc_id,
-        payload.user_id,
+        doc_id,
+        user_id,
         sig_key,
     )
-    background_tasks.add_task(submit_document_if_state_contract, payload.doc_id)
+    background_tasks.add_task(submit_document_if_state_contract, doc_id)
 
     signed_url = await asyncio.to_thread(_presign_object_key, signed_key)
     sig_url = await asyncio.to_thread(_presign_object_key, sig_key)
 
-    return {"signed_url": signed_url, "sig_url": sig_url, "status": "signed"}
+    return {"signed_url": signed_url, "sig_url": sig_url}
+
+
+@router.post("/sign/document")
+async def sign_document(
+    payload: SignDocumentRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    """Подписать PDF документа через КриптоПро REST API."""
+    _ = request
+    result = await sign_document_inner(
+        payload.doc_id,
+        payload.doc_type,
+        payload.user_id,
+        background_tasks,
+    )
+    return {"status": "signed", **result}
+
+
+@router.post("/sign/batch")
+async def batch_sign_documents(payload: BatchSignRequest, background_tasks: BackgroundTasks):
+    """Подписать список документов одним запросом. Возвращает список результатов."""
+    if len(payload.doc_ids) > 20:
+        raise HTTPException(status_code=422, detail="Max 20 documents per batch")
+    if payload.doc_type not in _ALLOWED_DOC_TYPES:
+        raise HTTPException(status_code=422, detail="doc_type must be one of: aosr, ks2, ks3")
+
+    results: list[dict] = []
+    for doc_id in payload.doc_ids:
+        try:
+            result = await sign_document_inner(
+                doc_id,
+                payload.doc_type,
+                payload.user_id,
+                background_tasks,
+            )
+            results.append({"doc_id": doc_id, "status": "signed", **result})
+        except HTTPException as exc:
+            results.append({"doc_id": doc_id, "status": "error", "detail": exc.detail})
+    return {
+        "results": results,
+        "signed_count": sum(1 for item in results if item["status"] == "signed"),
+    }
 
 
 @router.get("/sign/verify/{doc_id}")

--- a/api/routes/sign.py
+++ b/api/routes/sign.py
@@ -306,6 +306,9 @@ async def batch_sign_documents(payload: BatchSignRequest, background_tasks: Back
             results.append({"doc_id": doc_id, "status": "signed", **result})
         except HTTPException as exc:
             results.append({"doc_id": doc_id, "status": "error", "detail": exc.detail})
+        except Exception as exc:  # noqa: BLE001
+            detail = str(exc).strip() or "Unexpected signing error"
+            results.append({"doc_id": doc_id, "status": "error", "detail": detail})
     return {
         "results": results,
         "signed_count": sum(1 for item in results if item["status"] == "signed"),

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -16,6 +16,7 @@ interface ProjectInfo {
 }
 
 const sectionOrder = ['AR', 'KZH', 'KM', 'OV', 'VK', 'EM'];
+const signableDocTypes = new Set(['aosr', 'ks2', 'ks3']);
 
 function normalizeForecast(payload: Partial<ScheduleForecast>): ScheduleForecast {
   return {
@@ -190,7 +191,14 @@ export default function HandoverPage() {
       return;
     }
 
-    const docsByType = pendingDocuments.reduce<Record<string, string[]>>((acc, doc) => {
+    const signablePendingDocuments = pendingDocuments.filter((doc) => signableDocTypes.has(doc.document_type));
+    if (!signablePendingDocuments.length) {
+      setBatchProgress({ signed: 0, total: 0 });
+      setError('Нет документов поддерживаемых типов для пакетной подписи (aosr, ks2, ks3)');
+      return;
+    }
+
+    const docsByType = signablePendingDocuments.reduce<Record<string, string[]>>((acc, doc) => {
       const type = doc.document_type;
       if (!acc[type]) acc[type] = [];
       acc[type].push(doc.id);
@@ -199,36 +207,46 @@ export default function HandoverPage() {
 
     setError('');
     setBatchLoading(true);
-    setBatchProgress({ signed: 0, total: pendingDocuments.length });
+    setBatchProgress({ signed: 0, total: signablePendingDocuments.length });
 
+    let signedTotal = 0;
+    const newlySignedIds = new Set<string>();
+    const batchErrors: string[] = [];
     try {
-      let signedTotal = 0;
-      const newlySignedIds = new Set<string>();
       for (const [docType, ids] of Object.entries(docsByType)) {
-        const response = await fetchJson<{ results: { doc_id: string; status: SignStatus }[] }>(
-          '/api/sign/batch',
-          {
-            method: 'POST',
-            body: JSON.stringify({
-              doc_ids: ids,
-              doc_type: docType,
-              user_id: userId
-            })
+        for (let start = 0; start < ids.length; start += 20) {
+          const chunkIds = ids.slice(start, start + 20);
+          try {
+            const response = await fetchJson<{ results: { doc_id: string; status: string; detail?: string }[] }>(
+              '/api/sign/batch',
+              {
+                method: 'POST',
+                body: JSON.stringify({
+                  doc_ids: chunkIds,
+                  doc_type: docType,
+                  user_id: userId
+                })
+              }
+            );
+            for (const result of response.results ?? []) {
+              if (result.status === 'signed') {
+                signedTotal += 1;
+                newlySignedIds.add(result.doc_id);
+              }
+            }
+          } catch (batchError) {
+            const message = batchError instanceof Error ? batchError.message : 'Ошибка пакетной подписи';
+            batchErrors.push(`${docType}: ${message}`);
           }
-        );
-        for (const result of response.results ?? []) {
-          if (result.status === 'signed') {
-            signedTotal += 1;
-            newlySignedIds.add(result.doc_id);
-          }
+          setBatchProgress({ signed: signedTotal, total: signablePendingDocuments.length });
         }
-        setBatchProgress({ signed: signedTotal, total: pendingDocuments.length });
       }
       if (newlySignedIds.size > 0) {
         setSignedDocIds((prev) => [...new Set([...prev, ...Array.from(newlySignedIds)])]);
       }
-    } catch (signError) {
-      setError(signError instanceof Error ? signError.message : 'Ошибка пакетной подписи');
+      if (batchErrors.length > 0) {
+        setError(`Часть документов не подписана: ${batchErrors[0]}`);
+      }
     } finally {
       setBatchLoading(false);
     }

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -36,6 +36,8 @@ export default function HandoverPage() {
   const [project, setProject] = useState<ProjectInfo | null>(null);
   const [documents, setDocuments] = useState<ProjectDocument[]>([]);
   const [signedDocIds, setSignedDocIds] = useState<string[]>([]);
+  const [batchProgress, setBatchProgress] = useState<{ signed: number; total: number } | null>(null);
+  const [batchLoading, setBatchLoading] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -172,6 +174,66 @@ export default function HandoverPage() {
     }
   };
 
+  const handleBatchSign = async () => {
+    if (!userId.trim()) {
+      setError('Укажите userId для ЭЦП');
+      return;
+    }
+
+    const pendingDocuments = documents.filter((doc) => {
+      const status: SignStatus = signedDocIds.includes(doc.id) ? 'signed' : doc.status ?? 'approved';
+      return status !== 'signed';
+    });
+
+    if (!pendingDocuments.length) {
+      setBatchProgress({ signed: 0, total: 0 });
+      return;
+    }
+
+    const docsByType = pendingDocuments.reduce<Record<string, string[]>>((acc, doc) => {
+      const type = doc.document_type;
+      if (!acc[type]) acc[type] = [];
+      acc[type].push(doc.id);
+      return acc;
+    }, {});
+
+    setError('');
+    setBatchLoading(true);
+    setBatchProgress({ signed: 0, total: pendingDocuments.length });
+
+    try {
+      let signedTotal = 0;
+      const newlySignedIds = new Set<string>();
+      for (const [docType, ids] of Object.entries(docsByType)) {
+        const response = await fetchJson<{ results: { doc_id: string; status: SignStatus }[] }>(
+          '/api/sign/batch',
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              doc_ids: ids,
+              doc_type: docType,
+              user_id: userId
+            })
+          }
+        );
+        for (const result of response.results ?? []) {
+          if (result.status === 'signed') {
+            signedTotal += 1;
+            newlySignedIds.add(result.doc_id);
+          }
+        }
+        setBatchProgress({ signed: signedTotal, total: pendingDocuments.length });
+      }
+      if (newlySignedIds.size > 0) {
+        setSignedDocIds((prev) => [...new Set([...prev, ...Array.from(newlySignedIds)])]);
+      }
+    } catch (signError) {
+      setError(signError instanceof Error ? signError.message : 'Ошибка пакетной подписи');
+    } finally {
+      setBatchLoading(false);
+    }
+  };
+
   const checklistSections = useMemo<GSNSectionStatus[]>(() => {
     if (!checklist) {
       return [];
@@ -201,9 +263,14 @@ export default function HandoverPage() {
           <input value={userId} onChange={(event) => setUserId(event.target.value)} placeholder="Идентификатор пользователя" />
         </label>
       </div>
-      <button type="button" onClick={loadAll} disabled={loading}>
-        {loading ? 'Загрузка...' : 'Загрузить данные'}
-      </button>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <button type="button" onClick={loadAll} disabled={loading}>
+          {loading ? 'Загрузка...' : 'Загрузить данные'}
+        </button>
+        <button type="button" onClick={handleBatchSign} disabled={batchLoading || !documents.length}>
+          {batchLoading ? 'Подписание...' : 'Подписать все (batch)'}
+        </button>
+      </div>
       {error && <p style={{ color: 'crimson', margin: 0 }}>{error}</p>}
 
       <TabLayout
@@ -263,6 +330,7 @@ export default function HandoverPage() {
             title: 'Подписание документов',
             content: (
               <section style={{ display: 'grid', gap: 10 }}>
+                {batchProgress && <p style={{ margin: 0 }}>Подписано {batchProgress.signed} / {batchProgress.total}</p>}
                 {documents.map((doc) => {
                   const status: SignStatus = signedDocIds.includes(doc.id) ? 'signed' : doc.status ?? 'approved';
                   const icon = status === 'signed' ? '✅' : status === 'approved' ? '🟡' : '📝';

--- a/telegram/handlers/handover.py
+++ b/telegram/handlers/handover.py
@@ -41,6 +41,25 @@ def _sign_confirm_keyboard(doc_id: str) -> InlineKeyboardMarkup:
     )
 
 
+def _sign_all_keyboard(documents: list[Mapping]) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for doc in documents:
+        doc_id = str(doc.get("id", "")).strip()
+        if not doc_id:
+            continue
+        title = str(doc.get("title", "Документ")).strip()[:30]
+        doc_type = str(doc.get("document_type", "aosr")).strip() or "aosr"
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"Подписать: {title}",
+                    callback_data=f"sign_all:{doc_id}:{doc_type}",
+                )
+            ]
+        )
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
 async def _get_default_project_id() -> str | None:
     data = await api_client.get("/api/projects")
     projects = data.get("projects", [])
@@ -181,6 +200,60 @@ async def sign_doc_callback_handler(callback: CallbackQuery) -> None:
     payload = {
         "doc_id": doc_id,
         "doc_type": "aosr",
+        "user_id": str(callback.from_user.id),
+    }
+    await api_client.post("/api/sign/document", payload)
+    await callback.message.answer(f"Документ {doc_id} отправлен на подпись.")
+    await callback.answer("Подписано")
+
+
+@router.message(Command("sign_all"))
+async def sign_all_handler(message: Message) -> None:
+    project_id = await _get_default_project_id()
+    if not project_id:
+        await message.answer("Проект не найден.")
+        return
+
+    data = await api_client.get(f"/api/projects/{project_id}/documents")
+    raw_docs = data.get("documents", [])
+    if not isinstance(raw_docs, list):
+        await message.answer("Список документов недоступен.")
+        return
+
+    documents: list[Mapping] = []
+    for doc in raw_docs:
+        if not isinstance(doc, Mapping):
+            continue
+        status = str(doc.get("status", "approved")).strip().lower()
+        if status == "signed":
+            continue
+        documents.append(doc)
+
+    if not documents:
+        await message.answer("Нет документов для подписи.")
+        return
+
+    await message.answer(
+        "Выберите документ для подписи:",
+        reply_markup=_sign_all_keyboard(documents),
+    )
+
+
+@router.callback_query(F.data.startswith("sign_all:"))
+async def sign_all_callback_handler(callback: CallbackQuery) -> None:
+    data = (callback.data or "").split(":", maxsplit=2)
+    if len(data) != 3:
+        await callback.answer("Некорректная команда")
+        return
+
+    _, doc_id, doc_type = data
+    if callback.message is None:
+        await callback.answer()
+        return
+
+    payload = {
+        "doc_id": doc_id,
+        "doc_type": doc_type,
         "user_id": str(callback.from_user.id),
     }
     await api_client.post("/api/sign/document", payload)

--- a/tests/test_sign_batch.py
+++ b/tests/test_sign_batch.py
@@ -1,0 +1,151 @@
+"""Тесты пакетной подписи документов."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import sign
+from config.settings import settings
+
+
+class _MockHTTPResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _MockAsyncClient:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    async def post(self, *args, **kwargs):
+        _ = (args, kwargs)
+        return _MockHTTPResponse(self._payload)
+
+
+def test_sign_document_inner(monkeypatch):
+    monkeypatch.setattr(
+        sign,
+        "_fetch_exec_doc_for_sign",
+        lambda doc_id, doc_type: {
+            "id": doc_id,
+            "doc_type": doc_type,
+            "pdf_url": "https://storage.local/path/doc.pdf",
+            "status": "approved",
+        },
+    )
+    monkeypatch.setattr(sign, "_fetch_user_cert_thumbprint", lambda user_id: "USER-THUMB")
+
+    async def _mock_download_binary(_: str) -> bytes:
+        return b"%PDF-1.4 mock"
+
+    monkeypatch.setattr(sign, "_download_binary", _mock_download_binary)
+    monkeypatch.setattr(
+        sign,
+        "_upload_related_signed_files",
+        lambda *_: ("path/doc_signed.pdf", "path/doc.sig"),
+    )
+    monkeypatch.setattr(
+        sign,
+        "_presign_object_key",
+        lambda object_key: f"https://storage.local/{object_key}",
+    )
+
+    updates: list[dict] = []
+
+    def _mock_mark_document_signed(doc_id: str, user_id: str, sig_url: str) -> None:
+        updates.append({"doc_id": doc_id, "user_id": user_id, "sig_url": sig_url})
+
+    monkeypatch.setattr(sign, "_mark_document_signed", _mock_mark_document_signed)
+
+    signed_data = base64.b64encode(b"%PDF signed").decode("utf-8")
+    signature = base64.b64encode(b"SIG").decode("utf-8")
+    monkeypatch.setattr(
+        sign.httpx,
+        "AsyncClient",
+        lambda **kwargs: _MockAsyncClient(
+            {"signed_data_b64": signed_data, "signature_b64": signature}
+        ),
+    )
+
+    background_tasks = sign.BackgroundTasks()
+    result = asyncio.run(sign.sign_document_inner("doc-1", "aosr", "user-1", background_tasks))
+
+    assert result["signed_url"].endswith("doc_signed.pdf")
+    assert result["sig_url"].endswith("doc.sig")
+    assert updates and updates[0]["doc_id"] == "doc-1"
+
+
+def test_batch_sign_success(monkeypatch):
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+
+    async def _mock_sign_document_inner(doc_id: str, doc_type: str, user_id: str, background_tasks):
+        _ = (doc_type, user_id, background_tasks)
+        return {"signed_url": f"https://storage.local/{doc_id}.pdf", "sig_url": f"https://storage.local/{doc_id}.sig"}
+
+    monkeypatch.setattr(sign, "sign_document_inner", _mock_sign_document_inner)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sign/batch",
+                json={"doc_ids": ["doc-1", "doc-2"], "doc_type": "aosr", "user_id": "user-1"},
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["signed_count"] == 2
+    assert all(item["status"] == "signed" for item in payload["results"])
+
+
+def test_batch_sign_partial_error(monkeypatch):
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+
+    async def _mock_sign_document_inner(doc_id: str, doc_type: str, user_id: str, background_tasks):
+        _ = (doc_type, user_id, background_tasks)
+        if doc_id == "doc-2":
+            raise HTTPException(status_code=404, detail="Document not found")
+        return {"signed_url": f"https://storage.local/{doc_id}.pdf", "sig_url": f"https://storage.local/{doc_id}.sig"}
+
+    monkeypatch.setattr(sign, "sign_document_inner", _mock_sign_document_inner)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sign/batch",
+                json={
+                    "doc_ids": ["doc-1", "doc-2", "doc-3"],
+                    "doc_type": "aosr",
+                    "user_id": "user-1",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["signed_count"] == 2
+    assert payload["results"][1]["status"] == "error"
+    assert payload["results"][1]["detail"] == "Document not found"

--- a/tests/test_sign_batch.py
+++ b/tests/test_sign_batch.py
@@ -98,7 +98,10 @@ def test_batch_sign_success(monkeypatch):
 
     async def _mock_sign_document_inner(doc_id: str, doc_type: str, user_id: str, background_tasks):
         _ = (doc_type, user_id, background_tasks)
-        return {"signed_url": f"https://storage.local/{doc_id}.pdf", "sig_url": f"https://storage.local/{doc_id}.sig"}
+        return {
+            "signed_url": f"https://storage.local/{doc_id}.pdf",
+            "sig_url": f"https://storage.local/{doc_id}.sig",
+        }
 
     monkeypatch.setattr(sign, "sign_document_inner", _mock_sign_document_inner)
 
@@ -126,7 +129,10 @@ def test_batch_sign_partial_error(monkeypatch):
         _ = (doc_type, user_id, background_tasks)
         if doc_id == "doc-2":
             raise HTTPException(status_code=404, detail="Document not found")
-        return {"signed_url": f"https://storage.local/{doc_id}.pdf", "sig_url": f"https://storage.local/{doc_id}.sig"}
+        return {
+            "signed_url": f"https://storage.local/{doc_id}.pdf",
+            "sig_url": f"https://storage.local/{doc_id}.sig",
+        }
 
     monkeypatch.setattr(sign, "sign_document_inner", _mock_sign_document_inner)
 
@@ -149,3 +155,39 @@ def test_batch_sign_partial_error(monkeypatch):
     assert payload["signed_count"] == 2
     assert payload["results"][1]["status"] == "error"
     assert payload["results"][1]["detail"] == "Document not found"
+
+
+def test_batch_sign_partial_unexpected_error(monkeypatch):
+    old_keys = settings.api_keys
+    settings.api_keys = ["valid-key"]
+
+    async def _mock_sign_document_inner(doc_id: str, doc_type: str, user_id: str, background_tasks):
+        _ = (doc_type, user_id, background_tasks)
+        if doc_id == "doc-2":
+            raise RuntimeError("storage unavailable")
+        return {
+            "signed_url": f"https://storage.local/{doc_id}.pdf",
+            "sig_url": f"https://storage.local/{doc_id}.sig",
+        }
+
+    monkeypatch.setattr(sign, "sign_document_inner", _mock_sign_document_inner)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/sign/batch",
+                json={
+                    "doc_ids": ["doc-1", "doc-2", "doc-3"],
+                    "doc_type": "aosr",
+                    "user_id": "user-1",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["signed_count"] == 2
+    assert payload["results"][1]["status"] == "error"
+    assert payload["results"][1]["detail"] == "storage unavailable"


### PR DESCRIPTION
### Motivation
- Нужна возможность подписывать сразу несколько документов одним запросом и отобразить прогресс в UI для ускорения рабочего процесса подписания.
- Упростить повторное использование логики подписи внутри API и обеспечить агрегирование результатов при пакетной обработке.

### Description
- В `api/routes/sign.py` вынесена внутренняя логика подписи в `sign_document_inner(doc_id, doc_type, user_id, background_tasks)` и добавлен Pydantic-модель `BatchSignRequest` вместе с новым endpoint `POST /api/sign/batch`, который валидирует максимум 20 документов и возвращает список результатов по каждому документу (`signed`/`error`).
- Обновлён `POST /api/sign/document` чтобы переиспользовать `sign_document_inner` и вернуть унифицированный результат.
- В `desktop/src/pages/HandoverPage.tsx` добавлена кнопка «Подписать все (batch)» рядом с «Загрузить данные», реализация вызова `/api/sign/batch` для всех неподписанных документов (группировка по `document_type`) и отображение прогресса в виде «Подписано X / Y». Используется существующий `SignStatus` для определения статуса документов.
- В `telegram/handlers/handover.py` добавлена команда `/sign_all`, которая получает список документов проекта, рендерит inline-клавиатуру с кнопками «Подписать: {title}» и обрабатывает callback для вызова `/api/sign/document` по выбранному документу.
- Добавлен тест `tests/test_sign_batch.py`, который покрывает `sign_document_inner`, успешный batch-кейс и частично-ошибочный batch-кейс.

### Testing
- Запущена статическая проверка: `ruff check api/routes/sign.py tests/test_sign_batch.py` — пройдено успешно.
- Запущены unit-тесты: `pytest -q tests/test_sign_batch.py` — все тесты прошли (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1145b054c832fbce413e8f9e3920a)