### PR TITLE
Add ISUP webhook endpoints and HandoverPage polling/UI

### DIFF
--- a/api/routes/isup.py
+++ b/api/routes/isup.py
@@ -103,15 +103,19 @@ async def list_isup_submissions(project_id: str) -> dict:
     """Список отправок в ИСУП по проекту для polling из фронтенда."""
     engine = create_engine(settings.database_url, future=True)
     with engine.connect() as conn:
-        rows = conn.execute(
-            text(
-                """
+        rows = (
+            conn.execute(
+                text(
+                    """
                 SELECT submission_id, doc_id, status, submitted_at
                 FROM isup_submissions
                 WHERE project_id = :pid
                 ORDER BY submitted_at DESC
                 """
-            ),
-            {"pid": project_id},
-        ).mappings().all()
+                ),
+                {"pid": project_id},
+            )
+            .mappings()
+            .all()
+        )
     return {"submissions": [dict(row) for row in rows]}

--- a/api/routes/isup.py
+++ b/api/routes/isup.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+from sqlalchemy import create_engine, text
 
 from config.settings import settings
 from core.integrations.isup import ISUPClient, _fetch_doc_payload
@@ -25,6 +27,14 @@ class SubmitAlbumRequest(BaseModel):
 
     project_id: str
     section: str
+
+
+class ISUPCallbackPayload(BaseModel):
+    """Payload вебхука обратного статуса из ИСУП."""
+
+    submission_id: str
+    status: str
+    comment: str = ""
 
 
 @router.post("/submit-document")
@@ -65,3 +75,43 @@ async def get_status(submission_id: str, request: Request) -> dict:
 
     result = await ISUPClient().get_submission_status(submission_id)
     return {"ok": True, "result": result}
+
+
+@router.post("/callback")
+async def isup_status_callback(payload: ISUPCallbackPayload) -> dict:
+    """Вебхук от ИСУП: обновить статус отправки."""
+    engine = create_engine(settings.database_url, future=True)
+    query = text(
+        """
+        UPDATE isup_submissions
+        SET status = :status,
+            response_json = json_patch(COALESCE(response_json, '{}'), :patch)
+        WHERE submission_id = :submission_id
+        """
+    )
+    patch_data = json.dumps({"callback_status": payload.status, "comment": payload.comment})
+    with engine.begin() as conn:
+        conn.execute(
+            query,
+            {"submission_id": payload.submission_id, "status": payload.status, "patch": patch_data},
+        )
+    return {"ok": True}
+
+
+@router.get("/submissions/{project_id}")
+async def list_isup_submissions(project_id: str) -> dict:
+    """Список отправок в ИСУП по проекту для polling из фронтенда."""
+    engine = create_engine(settings.database_url, future=True)
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT submission_id, doc_id, status, submitted_at
+                FROM isup_submissions
+                WHERE project_id = :pid
+                ORDER BY submitted_at DESC
+                """
+            ),
+            {"pid": project_id},
+        ).mappings().all()
+    return {"submissions": [dict(row) for row in rows]}

--- a/config/settings.py
+++ b/config/settings.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     isup_client_id: str = ""
     isup_client_secret: str = ""
     isup_enabled: bool = False
+    isup_webhook_secret: str = ""
 
     # ── Telegram ───────────────────────────────
     bot_token: str = ""

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -15,6 +15,13 @@ interface ProjectInfo {
   is_state_contract?: boolean;
 }
 
+interface ISUPSubmission {
+  submission_id: string;
+  doc_id: string;
+  status: string;
+  submitted_at: string;
+}
+
 const sectionOrder = ['AR', 'KZH', 'KM', 'OV', 'VK', 'EM', 'SS', 'APS', 'PS'];
 const signableDocTypes = new Set(['aosr', 'ks2', 'ks3']);
 
@@ -36,6 +43,7 @@ export default function HandoverPage() {
   const [forecast, setForecast] = useState<ScheduleForecast | null>(null);
   const [project, setProject] = useState<ProjectInfo | null>(null);
   const [documents, setDocuments] = useState<ProjectDocument[]>([]);
+  const [isupSubmissions, setIsupSubmissions] = useState<ISUPSubmission[]>([]);
   const [signedDocIds, setSignedDocIds] = useState<string[]>([]);
   const [ks2DocId, setKs2DocId] = useState('');
   const [m29Period, setM29Period] = useState('');
@@ -74,13 +82,14 @@ export default function HandoverPage() {
     setChecklist(data);
   };
 
-  const loadSigning = async () => {
+  const loadSigning = async (): Promise<ProjectInfo> => {
     const [projectResponse, docsResponse] = await Promise.all([
       fetchJson<ProjectInfo>(`/api/projects/${encodeURIComponent(projectId)}`),
       fetchJson<{ documents: ProjectDocument[] }>(`/api/projects/${encodeURIComponent(projectId)}/documents`)
     ]);
     setProject(projectResponse);
     setDocuments((docsResponse.documents || []).filter((doc) => (doc.status ?? 'approved') === 'approved'));
+    return projectResponse;
   };
 
   const loadForecast = async () => {
@@ -88,6 +97,17 @@ export default function HandoverPage() {
       `/api/analytics/schedule/${encodeURIComponent(projectId)}`
     );
     setForecast(normalizeForecast(data));
+  };
+
+  const loadIsupStatus = async (projectInfo?: ProjectInfo | null) => {
+    if (!projectId.trim() || !projectInfo?.is_state_contract) {
+      setIsupSubmissions([]);
+      return;
+    }
+    const data = await fetchJson<{ submissions: ISUPSubmission[] }>(
+      `/api/isup/submissions/${encodeURIComponent(projectId)}`
+    );
+    setIsupSubmissions(data.submissions);
   };
 
   const loadAll = async () => {
@@ -102,7 +122,8 @@ export default function HandoverPage() {
     window.localStorage.setItem('handover_user_id', userId);
 
     try {
-      await Promise.all([loadReadiness(), loadSigning(), loadForecast()]);
+      const [, loadedProject] = await Promise.all([loadReadiness(), loadSigning(), loadForecast()]);
+      await loadIsupStatus(loadedProject);
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : 'Ошибка загрузки данных');
     } finally {
@@ -424,6 +445,60 @@ export default function HandoverPage() {
                   );
                 })}
                 {!documents.length && <p>Нет документов со статусом «утверждён».</p>}
+
+                {project?.is_state_contract && (
+                  <section style={{ display: 'grid', gap: 8 }}>
+                    <h4 style={{ margin: '8px 0 0' }}>Статус ИСУП</h4>
+                    {isupSubmissions.length > 0 ? (
+                      <div style={{ overflowX: 'auto' }}>
+                        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                          <thead>
+                            <tr>
+                              <th style={{ textAlign: 'left', borderBottom: '1px solid #33415555', padding: '6px 4px' }}>
+                                Submission ID
+                              </th>
+                              <th style={{ textAlign: 'left', borderBottom: '1px solid #33415555', padding: '6px 4px' }}>
+                                Документ
+                              </th>
+                              <th style={{ textAlign: 'left', borderBottom: '1px solid #33415555', padding: '6px 4px' }}>
+                                Статус
+                              </th>
+                              <th style={{ textAlign: 'left', borderBottom: '1px solid #33415555', padding: '6px 4px' }}>
+                                Отправлено
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {isupSubmissions.map((submission) => {
+                              const statusIcon =
+                                submission.status === 'accepted'
+                                  ? '✅'
+                                  : submission.status === 'rejected'
+                                    ? '❌'
+                                    : '⏳';
+                              return (
+                                <tr key={submission.submission_id}>
+                                  <td style={{ borderBottom: '1px solid #33415522', padding: '6px 4px' }}>
+                                    {submission.submission_id}
+                                  </td>
+                                  <td style={{ borderBottom: '1px solid #33415522', padding: '6px 4px' }}>{submission.doc_id}</td>
+                                  <td style={{ borderBottom: '1px solid #33415522', padding: '6px 4px' }}>
+                                    {statusIcon} {submission.status}
+                                  </td>
+                                  <td style={{ borderBottom: '1px solid #33415522', padding: '6px 4px' }}>
+                                    {new Date(submission.submitted_at).toLocaleString()}
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <p style={{ margin: 0 }}>Отправки в ИСУП пока отсутствуют.</p>
+                    )}
+                  </section>
+                )}
               </section>
             )
           },

--- a/tests/test_isup_callback.py
+++ b/tests/test_isup_callback.py
@@ -1,0 +1,135 @@
+"""Tests for ISUP callback and submissions polling routes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import isup as isup_routes
+from config.settings import settings
+
+
+class _FakeBeginConn:
+    def __init__(self):
+        self.executed: list[dict[str, object]] = []
+
+    def execute(self, query, params):
+        self.executed.append({"query": str(query), "params": params})
+
+
+class _FakeBeginContext:
+    def __init__(self, conn: _FakeBeginConn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self._conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+class _FakeMappingsResult:
+    def __init__(self, rows: list[dict[str, object]]):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSelectResult:
+    def __init__(self, rows: list[dict[str, object]]):
+        self._rows = rows
+
+    def mappings(self):
+        return _FakeMappingsResult(self._rows)
+
+
+class _FakeConnectConn:
+    def __init__(self, rows: list[dict[str, object]]):
+        self._rows = rows
+
+    def execute(self, query, params):
+        _ = (query, params)
+        return _FakeSelectResult(self._rows)
+
+
+class _FakeConnectContext:
+    def __init__(self, conn: _FakeConnectConn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self._conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+class _FakeEngine:
+    def __init__(self, rows: list[dict[str, object]] | None = None):
+        self.begin_conn = _FakeBeginConn()
+        self.connect_conn = _FakeConnectConn(rows or [])
+
+    def begin(self):
+        return _FakeBeginContext(self.begin_conn)
+
+    def connect(self):
+        return _FakeConnectContext(self.connect_conn)
+
+
+def test_callback_updates_status(monkeypatch):
+    old_keys = settings.api_keys
+    settings.api_keys = ["test-key"]
+    engine = _FakeEngine()
+    monkeypatch.setattr(isup_routes, "create_engine", lambda *args, **kwargs: engine)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/isup/callback",
+                json={"submission_id": "sub-123", "status": "accepted", "comment": "ok"},
+                headers={"X-API-Key": "test-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert len(engine.begin_conn.executed) == 1
+    params = engine.begin_conn.executed[0]["params"]
+    assert params["submission_id"] == "sub-123"
+    assert params["status"] == "accepted"
+    assert '"callback_status": "accepted"' in params["patch"]
+    assert '"comment": "ok"' in params["patch"]
+
+
+def test_list_submissions(monkeypatch):
+    old_keys = settings.api_keys
+    settings.api_keys = ["test-key"]
+    rows = [
+        {
+            "submission_id": "sub-1",
+            "doc_id": "doc-1",
+            "status": "processing",
+            "submitted_at": "2026-04-16T10:00:00Z",
+        },
+        {
+            "submission_id": "sub-2",
+            "doc_id": "doc-2",
+            "status": "accepted",
+            "submitted_at": "2026-04-16T09:00:00Z",
+        },
+    ]
+    engine = _FakeEngine(rows=rows)
+    monkeypatch.setattr(isup_routes, "create_engine", lambda *args, **kwargs: engine)
+
+    try:
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/isup/submissions/project-1",
+                headers={"X-API-Key": "test-key"},
+            )
+    finally:
+        settings.api_keys = old_keys
+
+    assert response.status_code == 200
+    assert response.json() == {"submissions": rows}


### PR DESCRIPTION
### Motivation
- Add server-side webhook handling so ISUP can push callback status updates into the app's `isup_submissions` table for reliable state tracking. 
- Expose a lightweight polling endpoint so the frontend can show recent ISUP submissions per project. 
- Surface ISUP submission statuses in the Handover UI under the signing tab for state-contract projects. 

### Description
- Added `ISUPCallbackPayload` model and endpoint `POST /api/isup/callback` in `api/routes/isup.py` which writes `status` and a JSON patch (`callback_status` + `comment`) into `isup_submissions` using `sqlalchemy.create_engine` and `text`/`json_patch`.
- Added `GET /api/isup/submissions/{project_id}` in `api/routes/isup.py` to return recent submissions (`submission_id`, `doc_id`, `status`, `submitted_at`) for frontend polling.
- Added `isup_webhook_secret` setting to `config/settings.py` as a placeholder for future HMAC verification of callbacks.
- Updated `desktop/src/pages/HandoverPage.tsx` to fetch submissions via a new `loadIsupStatus` call (invoked from `loadAll`) and render a simple table under the "Подписание документов" tab showing submission id, doc, status (with icons) and sent time; added `ISUPSubmission` type and `isupSubmissions` state.
- Added API tests `tests/test_isup_callback.py` which mock a DB engine to assert the callback update and the submissions listing behavior.

### Testing
- Ran linter: `ruff check api/routes/isup.py tests/test_isup_callback.py` — passed.
- Ran unit tests: `pytest -q tests/test_isup_callback.py` — `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e128cb6f74832fbd70752ab5402ec0)