### PR TITLE
Add typed analytics responses and PTO-focused delay notifications

### DIFF
--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
 
 from config.settings import settings
 from core.analytics.schedule_predictor import SchedulePredictor
@@ -17,6 +19,26 @@ router = APIRouter(prefix="/analytics", tags=["analytics"])
 _CACHE_TTL_SECONDS = 6 * 60 * 60
 _cache = RedisCache(settings.redis_url)
 _predictor = SchedulePredictor()
+
+
+class RiskItem(BaseModel):
+    section: str
+    description: str
+    severity: Literal["high", "medium", "low"]
+
+
+class ScheduleAnalyticsResponse(BaseModel):
+    avg_delay_days: float
+    delay_rate: float
+    predicted_completion: str
+    risks: list[RiskItem]
+    recommendations: list[str]
+
+
+class AnalyticsDashboardResponse(BaseModel):
+    project_id: str
+    sections: list[dict]
+    forecast: ScheduleAnalyticsResponse
 
 
 def _require_project_access(request: Request, project_id: str) -> None:
@@ -38,7 +60,7 @@ def _require_project_access(request: Request, project_id: str) -> None:
             raise HTTPException(status_code=403, detail="Access denied")
 
 
-@router.get("/schedule/{project_id}")
+@router.get("/schedule/{project_id}", response_model=ScheduleAnalyticsResponse)
 async def get_schedule_analytics(project_id: str, request: Request) -> dict:
     """Return project delay stats and completion forecast."""
     _require_project_access(request, project_id)
@@ -56,7 +78,7 @@ async def get_schedule_analytics(project_id: str, request: Request) -> dict:
     return prediction
 
 
-@router.get("/dashboard/{project_id}")
+@router.get("/dashboard/{project_id}", response_model=AnalyticsDashboardResponse)
 async def get_analytics_dashboard(project_id: str, request: Request) -> dict:
     """Return dashboard summary by KG sections with schedule forecast."""
     _require_project_access(request, project_id)

--- a/config/settings.py
+++ b/config/settings.py
@@ -69,6 +69,7 @@ class Settings(BaseSettings):
     telegram_bot_token: str = ""
     telegram_webhook_url: str = ""
     admin_telegram_ids: list[int] = []
+    pto_engineer_telegram_ids: list[int] = []
     domain: str = "localhost"
 
     # ── tk-generator ───────────────────────────

--- a/core/analytics/notifications.py
+++ b/core/analytics/notifications.py
@@ -53,7 +53,8 @@ class AnalyticsNotifier:
     async def check_and_notify_projects(self) -> None:
         """Check projects with high delay_rate and send Telegram notifications."""
         project_ids = await self._get_all_project_ids()
-        if not project_ids or not settings.bot_token or not settings.admin_telegram_ids:
+        target_chat_ids = settings.pto_engineer_telegram_ids or settings.admin_telegram_ids
+        if not project_ids or not settings.bot_token or not target_chat_ids:
             return
 
         bot = Bot(token=settings.bot_token)
@@ -75,7 +76,7 @@ class AnalyticsNotifier:
                     f"Прогноз завершения: {prediction.get('predicted_completion')}\n"
                     f"Проверка: {now}"
                 )
-                for chat_id in settings.admin_telegram_ids:
+                for chat_id in target_chat_ids:
                     await bot.send_message(chat_id=chat_id, text=message)
         finally:
             await bot.session.close()


### PR DESCRIPTION
### Motivation
- Сделать контракт API аналитики более строгим и проверяемым на уровне Pydantic/FastAPI, включая явную типизацию рисков по уровню серьёзности.
- Обеспечить адресную рассылку ежедневных уведомлений ПТО-инженерам вместо отправки только администраторам.
- Сохранить существующее поведение прогнозирования и кэширования, добавив минимальные улучшения конфигурации и маршрутов.

### Description
- Добавлены Pydantic-модели `RiskItem`, `ScheduleAnalyticsResponse` и `AnalyticsDashboardResponse` и использованы как `response_model` для эндпоинтов `GET /api/analytics/schedule/{project_id}` и `GET /api/analytics/dashboard/{project_id}`; поле `severity` ограничено `"high" | "medium" | "low"`.
- Сохранено кэширование в Redis с ключом `analytics:schedule:{project_id}` и TTL 6 часов (пересоздание/повторное использование кэша для schedule и dashboard).
- В `core/analytics/notifications.py` изменена логика отправки: сначала используются `pto_engineer_telegram_ids`, при их отсутствии — `admin_telegram_ids`, при этом расписание (09:00 MSK) и порог `delay_rate > 0.3` сохранены.
- Добавлена новая настройка `pto_engineer_telegram_ids` в `config/settings.py` для конфигурации целевых Telegram chat_id ПТО.

### Testing
- Запущены автоматические тесты `pytest -q tests/test_analytics.py` и все тесты успешно прошли (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e151083150832fb18ccc215fb5b2ff)