### PR TITLE
Fix generated_docs migration safety and tenant-scoped KS2 1C export

### DIFF
--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -1050,9 +1050,10 @@ async def export_ks2_1c_xml(
     org_id: str | None = Depends(get_tenant_id),
 ):
     """Экспорт КС-2 в XML-формат для импорта в 1С."""
-    _ = (request, org_id)
+    _ = request
+    tenant = org_id or "default"
     try:
-        xml_bytes = await onec_exporter.export_ks2_to_xml(doc_id=doc_id)
+        xml_bytes = await onec_exporter.export_ks2_to_xml(doc_id=doc_id, org_id=tenant)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/core/export/onec_exporter.py
+++ b/core/export/onec_exporter.py
@@ -103,10 +103,14 @@ class OneCExporter:
         )
         engine = create_engine(settings.database_url, future=True)
         with engine.connect() as conn:
-            row = conn.execute(
-                query,
-                {"doc_id": doc_id, "doc_type": doc_type, "org_id": org_id},
-            ).mappings().first()
+            row = (
+                conn.execute(
+                    query,
+                    {"doc_id": doc_id, "doc_type": doc_type, "org_id": org_id},
+                )
+                .mappings()
+                .first()
+            )
         if row is None:
             return None
         payload = row.get("payload")

--- a/core/export/onec_exporter.py
+++ b/core/export/onec_exporter.py
@@ -14,11 +14,11 @@ from config.settings import settings
 class OneCExporter:
     """Экспортёр КС-2 и М-29 в XML, совместимый с 1С."""
 
-    async def export_ks2_to_xml(self, doc_id: str) -> bytes:
+    async def export_ks2_to_xml(self, doc_id: str, org_id: str = "default") -> bytes:
         """Выгрузить КС-2 из generated_docs в XML-формат 1С."""
-        document = await self._fetch_generated_doc(doc_id=doc_id, doc_type="ks2")
+        document = await self._fetch_generated_doc(doc_id=doc_id, doc_type="ks2", org_id=org_id)
         if document is None:
-            raise ValueError(f"KS2 document not found for doc_id={doc_id}")
+            raise ValueError(f"KS2 document not found for doc_id={doc_id} and org_id={org_id}")
 
         root = ET.Element("КС2")
         ET.SubElement(root, "Номер").text = str(document.get("number") or doc_id)
@@ -90,19 +90,23 @@ class OneCExporter:
         ET.SubElement(root, "Итого").text = self._decimal_to_str(total_amount)
         return self._to_xml_bytes(root)
 
-    async def _fetch_generated_doc(self, doc_id: str, doc_type: str) -> dict | None:
+    async def _fetch_generated_doc(self, doc_id: str, doc_type: str, org_id: str) -> dict | None:
         query = text(
             """
             SELECT payload
             FROM generated_docs
             WHERE id = :doc_id
               AND type = :doc_type
+              AND org_id = :org_id
             LIMIT 1
             """
         )
         engine = create_engine(settings.database_url, future=True)
         with engine.connect() as conn:
-            row = conn.execute(query, {"doc_id": doc_id, "doc_type": doc_type}).mappings().first()
+            row = conn.execute(
+                query,
+                {"doc_id": doc_id, "doc_type": doc_type, "org_id": org_id},
+            ).mappings().first()
         if row is None:
             return None
         payload = row.get("payload")

--- a/migrations/versions/20260417_add_org_id.py
+++ b/migrations/versions/20260417_add_org_id.py
@@ -40,6 +40,9 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if "generated_docs" in inspector.get_table_names():
+        generated_docs_columns = {
+            column["name"] for column in inspector.get_columns("generated_docs")
+        }
         op.execute(
             """
             CREATE TABLE generated_docs_new (
@@ -53,19 +56,34 @@ def upgrade() -> None:
             )
             """
         )
-        op.execute(
-            """
-            INSERT INTO generated_docs_new (id, type, org_id, payload, created_at, updated_at)
-            SELECT
-                id,
-                type,
-                COALESCE(org_id, 'default') AS org_id,
-                payload,
-                created_at,
-                updated_at
-            FROM generated_docs
-            """
-        )
+        if "org_id" in generated_docs_columns:
+            op.execute(
+                """
+                INSERT INTO generated_docs_new (id, type, org_id, payload, created_at, updated_at)
+                SELECT
+                    id,
+                    type,
+                    COALESCE(org_id, 'default') AS org_id,
+                    payload,
+                    created_at,
+                    updated_at
+                FROM generated_docs
+                """
+            )
+        else:
+            op.execute(
+                """
+                INSERT INTO generated_docs_new (id, type, org_id, payload, created_at, updated_at)
+                SELECT
+                    id,
+                    type,
+                    'default' AS org_id,
+                    payload,
+                    created_at,
+                    updated_at
+                FROM generated_docs
+                """
+            )
         op.drop_table("generated_docs")
         op.rename_table("generated_docs_new", "generated_docs")
         op.create_index("ix_generated_docs_org_id", "generated_docs", ["org_id"], unique=False)
@@ -90,8 +108,22 @@ def downgrade() -> None:
         op.execute(
             """
             INSERT INTO generated_docs_old (id, type, payload, created_at, updated_at)
+            WITH ranked AS (
+                SELECT
+                    id,
+                    type,
+                    payload,
+                    created_at,
+                    updated_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY id, type
+                        ORDER BY updated_at DESC, created_at DESC, org_id ASC
+                    ) AS rn
+                FROM generated_docs
+            )
             SELECT id, type, payload, created_at, updated_at
-            FROM generated_docs
+            FROM ranked
+            WHERE rn = 1
             """
         )
         op.drop_table("generated_docs")

--- a/migrations/versions/20260417_add_org_id.py
+++ b/migrations/versions/20260417_add_org_id.py
@@ -19,7 +19,6 @@ _TABLES = (
     "projects",
     "executive_docs",
     "kg_entries",
-    "generated_docs",
     "isup_submissions",
 )
 
@@ -38,8 +37,66 @@ def upgrade() -> None:
     )
     op.create_index("ix_users_org_id", "users", ["org_id"], unique=False)
 
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "generated_docs" in inspector.get_table_names():
+        op.execute(
+            """
+            CREATE TABLE generated_docs_new (
+                id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                org_id TEXT NOT NULL DEFAULT 'default',
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id, type, org_id)
+            )
+            """
+        )
+        op.execute(
+            """
+            INSERT INTO generated_docs_new (id, type, org_id, payload, created_at, updated_at)
+            SELECT
+                id,
+                type,
+                COALESCE(org_id, 'default') AS org_id,
+                payload,
+                created_at,
+                updated_at
+            FROM generated_docs
+            """
+        )
+        op.drop_table("generated_docs")
+        op.rename_table("generated_docs_new", "generated_docs")
+        op.create_index("ix_generated_docs_org_id", "generated_docs", ["org_id"], unique=False)
+
 
 def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "generated_docs" in inspector.get_table_names():
+        op.execute(
+            """
+            CREATE TABLE generated_docs_old (
+                id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id, type)
+            )
+            """
+        )
+        op.execute(
+            """
+            INSERT INTO generated_docs_old (id, type, payload, created_at, updated_at)
+            SELECT id, type, payload, created_at, updated_at
+            FROM generated_docs
+            """
+        )
+        op.drop_table("generated_docs")
+        op.rename_table("generated_docs_old", "generated_docs")
+
     op.drop_index("ix_users_org_id", table_name="users")
     op.drop_column("users", "org_id")
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -11,9 +11,10 @@ from core.export.onec_exporter import OneCExporter
 def test_ks2_xml_structure(monkeypatch):
     """КС-2 экспортируется с ключевыми тегами 1С."""
 
-    async def _mock_fetch_generated_doc(doc_id: str, doc_type: str) -> dict:
+    async def _mock_fetch_generated_doc(doc_id: str, doc_type: str, org_id: str) -> dict:
         assert doc_id == "doc-001"
         assert doc_type == "ks2"
+        assert org_id == "default"
         return {
             "number": "КС2-77",
             "date": "2026-04-01",
@@ -47,9 +48,10 @@ def test_ks2_xml_structure(monkeypatch):
 def test_ks2_xml_keeps_explicit_zero_amount(monkeypatch):
     """Если amount=0 указан явно, он не должен заменяться quantity*price."""
 
-    async def _mock_fetch_generated_doc(doc_id: str, doc_type: str) -> dict:
+    async def _mock_fetch_generated_doc(doc_id: str, doc_type: str, org_id: str) -> dict:
         assert doc_id == "doc-zero"
         assert doc_type == "ks2"
+        assert org_id == "default"
         return {
             "number": "КС2-0",
             "date": "2026-04-01",


### PR DESCRIPTION
### Motivation
- Prevent Alembic `upgrade()` from failing on environments where `generated_docs` is created lazily by application code rather than by migrations. 
- Ensure the `generated_docs` schema migrates safely from a `(id, type)` PK to a tenant-aware `(id, type, org_id)` PK without leaving inconsistent constraints that break `ON CONFLICT` upserts. 
- Prevent cross-tenant data leaks by making KS2 1C export queries tenant-scoped so a `doc_id` cannot return another organization's document.

### Description
- Removed `generated_docs` from the unconditional `_TABLES` loop and added runtime table-existence checks in the migration to avoid altering a missing table. 
- Added migration logic in `migrations/versions/20260417_add_org_id.py` to rebuild `generated_docs` into `generated_docs_new` with `org_id` and primary key `(id, type, org_id)` on upgrade, and to restore the original `(id, type)` table shape on downgrade. 
- Updated `OneCExporter.export_ks2_to_xml` to accept `org_id` (defaulting to `"default"`) and changed `_fetch_generated_doc` to include `org_id` in the SQL `WHERE` clause. 
- Propagated tenant context in the route by passing `org_id` from `api/routes/generate.py` into `onec_exporter`, and adapted `tests/test_export.py` mocks to the new `_fetch_generated_doc(doc_id, doc_type, org_id)` signature.

### Testing
- Ran `pytest -q tests/test_export.py` and all tests passed (`3 passed`). 
- Ran `python -m py_compile migrations/versions/20260417_add_org_id.py api/routes/generate.py core/export/onec_exporter.py tests/test_export.py` and compilation succeeded. 
- Sanity-checked diffs and local commit; no automated failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e167791f74832f9c01173eb21ecd4d)