### PR TITLE
Add Helm chart for Kubernetes deployment with HPA and health probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,16 @@ jobs:
         with:
           name: test-results
           path: .pytest_cache/
+
+  helm:
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Helm lint
+        run: helm lint helm/construction-ai/
+      - name: Helm template validation
+        run: helm template helm/construction-ai/ > /dev/null

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,26 @@
+name: Helm Lint
+
+on:
+  push:
+    paths:
+      - 'helm/construction-ai/**'
+      - '.github/workflows/helm-lint.yml'
+  pull_request:
+    paths:
+      - 'helm/construction-ai/**'
+      - '.github/workflows/helm-lint.yml'
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm lint
+        run: helm lint helm/construction-ai/
+
+      - name: Helm template validation
+        run: helm template helm/construction-ai/ > /dev/null

--- a/helm/construction-ai/Chart.yaml
+++ b/helm/construction-ai/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: construction-ai
+description: Construction AI Core — ИИ-помощник для строительной отрасли
+version: 0.1.0
+appVersion: "4.2"

--- a/helm/construction-ai/templates/configmap.yaml
+++ b/helm/construction-ai/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: construction-ai-config
+  labels:
+    app.kubernetes.io/name: construction-ai
+data:
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/helm/construction-ai/templates/deployment-api.yaml
+++ b/helm/construction-ai/templates/deployment-api.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: construction-ai-api
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: construction-ai
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: construction-ai
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: construction-ai-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: sqlite-storage
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: sqlite-storage
+          persistentVolumeClaim:
+            claimName: construction-ai-sqlite
+      {{- end }}

--- a/helm/construction-ai/templates/deployment-bot.yaml
+++ b/helm/construction-ai/templates/deployment-bot.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.bot.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: construction-ai-bot
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: bot
+spec:
+  replicas: {{ .Values.bot.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: construction-ai
+      app.kubernetes.io/component: bot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: construction-ai
+        app.kubernetes.io/component: bot
+    spec:
+      containers:
+        - name: bot
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "telegram.main"]
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: construction-ai-secrets
+          resources:
+            {{- toYaml .Values.bot.resources | nindent 12 }}
+{{- end }}

--- a/helm/construction-ai/templates/hpa-api.yaml
+++ b/helm/construction-ai/templates/hpa-api.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: construction-ai-api
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: construction-ai-api
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/helm/construction-ai/templates/ingress.yaml
+++ b/helm/construction-ai/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: construction-ai-api
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: api
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: construction-ai-api
+                port:
+                  number: {{ .Values.api.port }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+  {{- end }}
+{{- end }}

--- a/helm/construction-ai/templates/pvc-sqlite.yaml
+++ b/helm/construction-ai/templates/pvc-sqlite.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: construction-ai-sqlite
+  labels:
+    app.kubernetes.io/name: construction-ai
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/helm/construction-ai/templates/redis.yaml
+++ b/helm/construction-ai/templates/redis.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: construction-ai-redis
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: construction-ai
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: construction-ai
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: {{ .Values.redis.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: construction-ai-redis
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port }}
+      targetPort: {{ .Values.redis.port }}
+{{- end }}

--- a/helm/construction-ai/templates/secret.yaml
+++ b/helm/construction-ai/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: construction-ai-secrets
+  labels:
+    app.kubernetes.io/name: construction-ai
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/helm/construction-ai/templates/service-api.yaml
+++ b/helm/construction-ai/templates/service-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: construction-ai-api
+  labels:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: construction-ai
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      port: {{ .Values.api.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm/construction-ai/values.yaml
+++ b/helm/construction-ai/values.yaml
@@ -1,0 +1,63 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/ivanpetrov19960407-afk/construction-ai-core
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+api:
+  port: 8000
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+
+bot:
+  enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+service:
+  type: ClusterIP
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+ingress:
+  enabled: true
+  className: nginx
+  host: construction-ai.example.com
+  tls: true
+  tlsSecretName: construction-ai-tls
+
+redis:
+  enabled: true
+  image: redis:7-alpine
+  port: 6379
+
+env:
+  LOG_LEVEL: "INFO"
+  DEBUG: "false"
+
+secrets:
+  API_KEY: ""
+  OPENAI_API_KEY: ""
+
+persistence:
+  enabled: false
+  accessMode: ReadWriteOnce
+  size: 5Gi
+  mountPath: /app/data


### PR DESCRIPTION
### Motivation
- Provide a reusable Helm chart to deploy Construction AI Core to Kubernetes with sane defaults for replicas, resources and image configuration.
- Enable autoscaling and resilience by adding an HPA and liveness/readiness probes for the API.
- Add CI validation to ensure chart quality via `helm lint` and `helm template` on push/PR.

### Description
- Added a new chart under `helm/construction-ai` with `Chart.yaml`, `values.yaml` and templates for `deployment-api.yaml`, `deployment-bot.yaml`, `service-api.yaml`, `ingress.yaml`, `hpa-api.yaml`, `configmap.yaml`, `secret.yaml`, `pvc-sqlite.yaml`, and `redis.yaml`.
- Implemented API `livenessProbe` (`/health`, `initialDelaySeconds: 30`, `periodSeconds: 10`) and `readinessProbe` (`/health`, `initialDelaySeconds: 15`, `periodSeconds: 5`) and wired `envFrom: secretRef: construction-ai-secrets` into the deployment.
- HPA uses `autoscaling/v2` and configures CPU and memory utilization targets from `values.yaml` (`targetCPUUtilizationPercentage` and `targetMemoryUtilizationPercentage`).
- Added a dedicated GitHub Actions workflow `.github/workflows/helm-lint.yml` and extended the existing CI (`.github/workflows/ci.yml`) with a `helm` job that runs `helm lint helm/construction-ai/` and `helm template helm/construction-ai/`.

### Testing
- Attempted to run `helm lint helm/construction-ai/` and `helm template helm/construction-ai/ > /dev/null` locally, but the local environment does not have Helm installed so the commands failed with `helm: command not found`.
- CI now includes a `helm` job and a standalone `Helm Lint` workflow that will run `helm lint` and `helm template` on push and pull requests to validate the chart automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f136960c832f9a0512dc6ea92e20)