### PR TITLE
Add org-based white-label branding (API, templates, web & desktop)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,7 @@ from api.routes import (
     analytics,
     auth,
     billing,
+    branding,
     chat,
     compliance,
     generate,
@@ -105,6 +106,7 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
 app.include_router(health.router, tags=["health"])
 app.include_router(auth.router, tags=["auth"])
 app.include_router(billing.router, prefix="/api", tags=["billing"])
+app.include_router(branding.router, prefix="/api", tags=["branding"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
 # generate.router содержит /api/generate/* включая /api/generate/exec-album
 app.include_router(generate.router, prefix="/api", tags=["generate"])

--- a/api/routes/branding.py
+++ b/api/routes/branding.py
@@ -1,0 +1,36 @@
+"""Branding API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from core.branding import BrandingConfig, get_branding, upsert_branding
+from core.multitenancy import get_tenant_id
+
+router = APIRouter(prefix="/branding", tags=["branding"])
+
+
+@router.get("", response_model=BrandingConfig)
+async def read_branding(org_id: str | None = Depends(get_tenant_id)) -> BrandingConfig:
+    """Return branding config for current org_id."""
+    return await get_branding(org_id or "default")
+
+
+@router.put("", response_model=BrandingConfig)
+async def update_branding(
+    payload: BrandingConfig,
+    request: Request,
+    org_id: str | None = Depends(get_tenant_id),
+) -> BrandingConfig:
+    """Update branding config for current org (admin only)."""
+    role = getattr(request.state, "user_role", None)
+    if role is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    current_org = org_id or "default"
+    if payload.org_id != current_org:
+        raise HTTPException(status_code=400, detail="org_id mismatch")
+
+    return await upsert_branding(payload)

--- a/api/routes/compliance.py
+++ b/api/routes/compliance.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
 from config.settings import settings
+from core.branding import BrandingConfig, get_branding
 from core.compliance.gsn_checklist import GSNReadinessChecker
 from core.multitenancy import get_tenant_id
 from core.projects import Project, get_projects_sessionmaker
@@ -36,7 +37,7 @@ def _build_section_row(section_result: dict) -> str:
     )
 
 
-def _render_gsn_report_html(project_id: str, checklist: dict) -> str:
+def _render_gsn_report_html(project_id: str, checklist: dict, branding: BrandingConfig) -> str:
     template = Path("templates/gsn_checklist.html").read_text(encoding="utf-8")
     rows = "\n".join(_build_section_row(item) for item in checklist["sections"])
     generated_at = dt.datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
@@ -44,6 +45,8 @@ def _render_gsn_report_html(project_id: str, checklist: dict) -> str:
         template.replace("{{ project_id }}", project_id)
         .replace("{{ generated_at }}", generated_at)
         .replace("{{ total_completion_pct }}", str(checklist["completion_pct"]))
+        .replace("{{ company_name }}", branding.company_name)
+        .replace("{{ logo_url }}", branding.logo_url)
         .replace("{{ section_rows }}", rows)
     )
 
@@ -104,7 +107,12 @@ async def generate_gsn_report(
 ) -> Response:
     _require_project_member(request=request, project_id=project_id, org_id=org_id or "default")
     checklist = await checker.check_full_project(project_id=str(project_id))
-    html = _render_gsn_report_html(project_id=str(project_id), checklist=checklist)
+    branding = await get_branding(org_id or "default")
+    html = _render_gsn_report_html(
+        project_id=str(project_id),
+        checklist=checklist,
+        branding=branding,
+    )
     try:
         pdf_bytes = await asyncio.to_thread(_render_pdf_from_html, html)
     except RuntimeError as exc:

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -368,21 +368,13 @@ async def generate_exec_album(
         raise HTTPException(status_code=404, detail="Approved executive docs not found")
 
     branding = await get_branding(tenant)
-    try:
-        pdf_bytes = await asyncio.to_thread(
-            _render_exec_album_pdf,
-            project_id=payload.project_id,
-            section=payload.section,
-            docs=docs,
-            branding=branding,
-        )
-    except TypeError:
-        pdf_bytes = await asyncio.to_thread(
-            _render_exec_album_pdf,
-            project_id=payload.project_id,
-            section=payload.section,
-            docs=docs,
-        )
+    pdf_bytes = await asyncio.to_thread(
+        _render_exec_album_pdf,
+        project_id=payload.project_id,
+        section=payload.section,
+        docs=docs,
+        branding=branding,
+    )
     presigned_url = await asyncio.to_thread(
         _upload_album_bytes,
         project_id=payload.project_id,

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -19,6 +19,7 @@ from sqlalchemy import create_engine, text
 from agents.calculator import CalculatorAgent
 from config.settings import settings
 from core.billing import require_quota
+from core.branding import BrandingConfig, get_branding
 from core.cache import RedisCache
 from core.export.onec_exporter import OneCExporter
 from core.llm_router import LLMRouter
@@ -222,7 +223,12 @@ def _fetch_approved_exec_docs(project_id: str, section: str, org_id: str = "defa
     return [dict(row) for row in rows]
 
 
-def _render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> bytes:
+def _render_exec_album_pdf(
+    project_id: str,
+    section: str,
+    docs: list[dict],
+    branding: BrandingConfig,
+) -> bytes:
     """Сформировать PDF альбома через WeasyPrint."""
     from weasyprint import HTML
 
@@ -243,6 +249,8 @@ def _render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> b
         .replace("{{ generated_at }}", generated_at)
         .replace("{{ doc_count }}", str(len(docs)))
         .replace("{{ docs_list }}", docs_html)
+        .replace("{{ company_name }}", branding.company_name)
+        .replace("{{ logo_url }}", branding.logo_url)
     )
     return HTML(string=html, base_url=str(Path.cwd())).write_pdf()
 
@@ -359,12 +367,22 @@ async def generate_exec_album(
     if not docs:
         raise HTTPException(status_code=404, detail="Approved executive docs not found")
 
-    pdf_bytes = await asyncio.to_thread(
-        _render_exec_album_pdf,
-        project_id=payload.project_id,
-        section=payload.section,
-        docs=docs,
-    )
+    branding = await get_branding(tenant)
+    try:
+        pdf_bytes = await asyncio.to_thread(
+            _render_exec_album_pdf,
+            project_id=payload.project_id,
+            section=payload.section,
+            docs=docs,
+            branding=branding,
+        )
+    except TypeError:
+        pdf_bytes = await asyncio.to_thread(
+            _render_exec_album_pdf,
+            project_id=payload.project_id,
+            section=payload.section,
+            docs=docs,
+        )
     presigned_url = await asyncio.to_thread(
         _upload_album_bytes,
         project_id=payload.project_id,

--- a/core/branding.py
+++ b/core/branding.py
@@ -1,0 +1,123 @@
+"""White-label branding configuration helpers."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from pydantic import BaseModel
+
+from config.settings import settings
+from core.cache import RedisCache
+
+
+class BrandingConfig(BaseModel):
+    org_id: str
+    company_name: str = "Construction AI"
+    logo_url: str = ""
+    primary_color: str = "#2563eb"
+    accent_color: str = "#1d4ed8"
+    favicon_url: str = ""
+    support_email: str = ""
+    custom_domain: str = ""
+
+
+redis_cache = RedisCache(settings.redis_url)
+
+
+def _load_from_db(org_id: str) -> BrandingConfig:
+    default = BrandingConfig(org_id=org_id)
+    try:
+        with sqlite3.connect(settings.sqlite_db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT org_id, company_name, logo_url, primary_color, accent_color,
+                       favicon_url, custom_domain, support_email
+                FROM org_branding
+                WHERE org_id = ?
+                """,
+                (org_id,),
+            )
+            row = cursor.fetchone()
+    except sqlite3.Error:
+        return default
+
+    if row is None:
+        return default
+
+    return BrandingConfig(
+        org_id=str(row[0]),
+        company_name=str(row[1] or default.company_name),
+        logo_url=str(row[2] or ""),
+        primary_color=str(row[3] or default.primary_color),
+        accent_color=str(row[4] or default.accent_color),
+        favicon_url=str(row[5] or ""),
+        custom_domain=str(row[6] or ""),
+        support_email=str(row[7] or ""),
+    )
+
+
+async def get_branding(org_id: str) -> BrandingConfig:
+    """Получить конфигурацию брендинга из Redis (TTL 1ч) или БД."""
+    normalized_org_id = org_id or "default"
+    cache_key = f"branding:{normalized_org_id}"
+
+    cached = await redis_cache.get(cache_key)
+    if cached:
+        try:
+            return BrandingConfig.model_validate_json(cached)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    branding = _load_from_db(normalized_org_id)
+    await redis_cache.set(cache_key, branding.model_dump_json(), ttl=3600)
+    return branding
+
+
+async def upsert_branding(branding: BrandingConfig) -> BrandingConfig:
+    """Create or update branding config in DB and refresh cache."""
+    with sqlite3.connect(settings.sqlite_db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS org_branding (
+              org_id TEXT PRIMARY KEY,
+              company_name TEXT NOT NULL,
+              logo_url TEXT NOT NULL DEFAULT '',
+              primary_color TEXT NOT NULL DEFAULT '#2563eb',
+              accent_color TEXT NOT NULL DEFAULT '#1d4ed8',
+              favicon_url TEXT NOT NULL DEFAULT '',
+              custom_domain TEXT NOT NULL DEFAULT '',
+              support_email TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO org_branding (
+              org_id, company_name, logo_url, primary_color, accent_color,
+              favicon_url, custom_domain, support_email
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(org_id) DO UPDATE SET
+              company_name = excluded.company_name,
+              logo_url = excluded.logo_url,
+              primary_color = excluded.primary_color,
+              accent_color = excluded.accent_color,
+              favicon_url = excluded.favicon_url,
+              custom_domain = excluded.custom_domain,
+              support_email = excluded.support_email
+            """,
+            (
+                branding.org_id,
+                branding.company_name,
+                branding.logo_url,
+                branding.primary_color,
+                branding.accent_color,
+                branding.favicon_url,
+                branding.custom_domain,
+                branding.support_email,
+            ),
+        )
+        conn.commit()
+
+    await redis_cache.set(f"branding:{branding.org_id}", branding.model_dump_json(), ttl=3600)
+    return branding

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,17 +1,53 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { getApiConfig } from './api/coreClient';
 import Sidebar from './components/Sidebar';
 import { resolveRoute } from './router';
+import type { BrandingConfig } from './store/brandingStore';
+import { useBrandingStore } from './store/brandingStore';
 
 const normalizePath = (path: string) => path.replace(/\/$/, '') || '/';
 
 export default function App() {
   const [currentPath, setCurrentPath] = useState(() => normalizePath(window.location.pathname));
+  const branding = useBrandingStore((state) => state.branding);
+  const setBranding = useBrandingStore((state) => state.setBranding);
 
   useEffect(() => {
     const onPopState = () => setCurrentPath(normalizePath(window.location.pathname));
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadBranding(): Promise<void> {
+      try {
+        const { apiUrl, apiKey } = await getApiConfig();
+        const response = await fetch(`${apiUrl.replace(/\/$/, '')}/api/branding`, {
+          method: 'GET',
+          headers: {
+            'X-API-Key': apiKey
+          }
+        });
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as BrandingConfig;
+        if (isMounted) {
+          setBranding(data);
+        }
+      } catch (_error) {
+        // fallback to default UI theme
+      }
+    }
+
+    void loadBranding();
+    return () => {
+      isMounted = false;
+    };
+  }, [setBranding]);
 
   const navigate = (path: string) => {
     const nextPath = normalizePath(path);
@@ -23,16 +59,20 @@ export default function App() {
     setCurrentPath(nextPath);
   };
 
+  const appTheme = useMemo(
+    () => ({
+      minHeight: '100vh',
+      padding: 16,
+      fontFamily: 'Inter, Arial, sans-serif',
+      display: 'flex',
+      gap: 16,
+      borderTop: `4px solid ${branding?.primary_color ?? '#2563eb'}`
+    }),
+    [branding?.primary_color]
+  );
+
   return (
-    <main
-      style={{
-        minHeight: '100vh',
-        padding: 16,
-        fontFamily: 'Inter, Arial, sans-serif',
-        display: 'flex',
-        gap: 16
-      }}
-    >
+    <main style={appTheme}>
       <Sidebar currentPath={currentPath} onNavigate={navigate} />
       <section style={{ flex: 1 }}>{resolveRoute(currentPath, () => navigate('/'))}</section>
     </main>

--- a/desktop/src/store/brandingStore.ts
+++ b/desktop/src/store/brandingStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+export interface BrandingConfig {
+  org_id: string;
+  company_name: string;
+  logo_url: string;
+  primary_color: string;
+  accent_color: string;
+  favicon_url: string;
+  support_email: string;
+  custom_domain: string;
+}
+
+interface BrandingState {
+  branding: BrandingConfig | null;
+  setBranding: (branding: BrandingConfig) => void;
+}
+
+export const useBrandingStore = create<BrandingState>((set) => ({
+  branding: null,
+  setBranding: (branding) => set({ branding })
+}));

--- a/migrations/versions/20260417_add_org_branding.py
+++ b/migrations/versions/20260417_add_org_branding.py
@@ -1,0 +1,34 @@
+"""create org_branding table
+
+Revision ID: 20260417_add_org_branding
+Revises: 20260417_add_org_subscriptions
+Create Date: 2026-04-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260417_add_org_branding"
+down_revision = "20260417_add_org_subscriptions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_branding",
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("company_name", sa.Text(), nullable=False, server_default="Construction AI"),
+        sa.Column("logo_url", sa.Text(), nullable=False, server_default=""),
+        sa.Column("primary_color", sa.Text(), nullable=False, server_default="#2563eb"),
+        sa.Column("accent_color", sa.Text(), nullable=False, server_default="#1d4ed8"),
+        sa.Column("favicon_url", sa.Text(), nullable=False, server_default=""),
+        sa.Column("custom_domain", sa.Text(), nullable=False, server_default=""),
+        sa.Column("support_email", sa.Text(), nullable=False, server_default=""),
+        sa.PrimaryKeyConstraint("org_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("org_branding")

--- a/templates/exec_album_cover.html
+++ b/templates/exec_album_cover.html
@@ -13,6 +13,10 @@
     </style>
   </head>
   <body>
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+      <div><strong>{{ company_name }}</strong></div>
+      <img src="{{ logo_url }}" alt="logo" style="max-height:40px;" />
+    </div>
     <h1>Исполнительный альбом</h1>
     <div class="meta">
       <p><strong>Проект:</strong> {{ project_id }}</p>

--- a/templates/gsn_checklist.html
+++ b/templates/gsn_checklist.html
@@ -35,6 +35,10 @@
   </style>
 </head>
 <body>
+  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+    <div><strong>{{ company_name }}</strong></div>
+    <img src="{{ logo_url }}" alt="logo" style="max-height:36px;" />
+  </div>
   <h1>Пакет исполнительной документации для сдачи ГСН</h1>
   <h2>Чеклист соответствия Приказу Ростехнадзора №522-пр</h2>
 

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -1,0 +1,116 @@
+"""Tests for white-label branding API and template integration."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import compliance
+from api.security import encode_jwt
+from config.settings import settings
+from core.branding import BrandingConfig, get_branding
+
+UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
+
+
+def _make_bearer(username: str, role: str, org_id: str = "default") -> str:
+    payload = {
+        "sub": username,
+        "role": role,
+        "org_id": org_id,
+        "exp": int((dt.datetime.now(UTC) + dt.timedelta(hours=1)).timestamp()),
+    }
+    return encode_jwt(payload, settings.jwt_secret, algorithm="HS256")
+
+
+def test_get_default_branding(tmp_path):
+    old_db_path = settings.sqlite_db_path
+    settings.sqlite_db_path = str(tmp_path / "branding_default.db")
+
+    try:
+        branding = asyncio.run(get_branding("acme"))
+    finally:
+        settings.sqlite_db_path = old_db_path
+
+    assert branding.org_id == "acme"
+    assert branding.company_name == "Construction AI"
+    assert branding.primary_color == "#2563eb"
+
+
+def test_update_branding_admin_only(tmp_path):
+    old_db_path = settings.sqlite_db_path
+    old_keys = settings.api_keys
+    old_secret = settings.jwt_secret
+    settings.sqlite_db_path = str(tmp_path / "branding_api.db")
+    settings.api_keys = ["valid-key"]
+    settings.jwt_secret = "z" * 32
+
+    payload = {
+        "org_id": "org-alpha",
+        "company_name": "Alpha Build",
+        "logo_url": "https://cdn.example/logo.png",
+        "primary_color": "#111111",
+        "accent_color": "#222222",
+        "favicon_url": "",
+        "support_email": "support@alpha.example",
+        "custom_domain": "alpha.example",
+    }
+
+    try:
+        with TestClient(app) as client:
+            forbidden = client.put(
+                "/api/branding",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {_make_bearer('user', 'pto_engineer', 'org-alpha')}"
+                },
+            )
+            allowed = client.put(
+                "/api/branding",
+                json=payload,
+                headers={"Authorization": f"Bearer {_make_bearer('admin', 'admin', 'org-alpha')}"},
+            )
+            fetched = client.get(
+                "/api/branding",
+                headers={"Authorization": f"Bearer {_make_bearer('admin', 'admin', 'org-alpha')}"},
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        settings.api_keys = old_keys
+        settings.jwt_secret = old_secret
+
+    assert forbidden.status_code == 403
+    assert allowed.status_code == 200
+    assert fetched.status_code == 200
+    assert fetched.json()["company_name"] == "Alpha Build"
+
+
+def test_branding_in_pdf_template():
+    checklist = {
+        "sections": [
+            {
+                "section": "KZH",
+                "present": [1, 2],
+                "missing": [3],
+                "completion_pct": 66.7,
+            }
+        ],
+        "completion_pct": 66.7,
+    }
+    branding = BrandingConfig(
+        org_id="org-x",
+        company_name="ООО Альфа Строй",
+        logo_url="https://cdn.example/alpha.svg",
+    )
+
+    html = compliance._render_gsn_report_html(
+        project_id="project-42",
+        checklist=checklist,
+        branding=branding,
+    )
+
+    assert "ООО Альфа Строй" in html
+    assert "https://cdn.example/alpha.svg" in html

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -28,10 +28,16 @@ def test_exec_album_endpoint(monkeypatch):
             },
         ]
 
-    def _mock_render_exec_album_pdf(project_id: str, section: str, docs: list[dict]) -> bytes:
+    def _mock_render_exec_album_pdf(
+        project_id: str,
+        section: str,
+        docs: list[dict],
+        branding,
+    ) -> bytes:
         assert project_id == "project-1"
         assert section == "AR"
         assert len(docs) == 2
+        assert branding.org_id == "default"
         return b"%PDF-1.4\nmock"
 
     def _mock_upload_album_bytes(project_id: str, section: str, pdf_bytes: bytes) -> str:

--- a/web/app.js
+++ b/web/app.js
@@ -32,6 +32,30 @@ if ("serviceWorker" in navigator) {
   });
 }
 
+async function initBranding() {
+  try {
+    const response = await fetch("/api/branding", {
+      method: "GET",
+      headers: buildAuthHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const branding = await response.json();
+    document.documentElement.style.setProperty("--color-primary", branding.primary_color);
+    document.documentElement.style.setProperty("--color-accent", branding.accent_color);
+
+    const titleNode = document.getElementById("app-title");
+    if (titleNode) {
+      titleNode.textContent = branding.company_name || "Construction AI";
+    }
+    document.title = branding.company_name || "Construction AI";
+  } catch (error) {
+    console.warn("Branding fetch failed", error);
+  }
+}
+
 async function initChatProbe() {
   try {
     await fetch("/api/chat", {
@@ -43,6 +67,7 @@ async function initChatProbe() {
   }
 }
 
+initBranding();
 initChatProbe();
 
 const tabButtons = document.querySelectorAll(".tab-btn");

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="app-header">
-      <h1>Construction AI</h1>
+      <h1 id="app-title">Construction AI</h1>
       <p id="theme-indicator">Тема: light</p>
     </header>
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -2,6 +2,8 @@
   --bg: #ffffff;
   --fg: #171717;
   --accent: #0f6fff;
+  --color-primary: #2563eb;
+  --color-accent: #1d4ed8;
 }
 
 :root[data-theme="dark"] {
@@ -38,7 +40,7 @@ main {
 }
 
 .tab-btn {
-  border: 1px solid var(--accent);
+  border: 1px solid var(--color-primary);
   background: transparent;
   color: var(--fg);
   padding: 10px;
@@ -46,7 +48,7 @@ main {
 }
 
 .tab-btn.active {
-  background: var(--accent);
+  background: var(--color-primary);
   color: #fff;
 }
 
@@ -71,7 +73,7 @@ input {
 
 button[type="submit"] {
   border: none;
-  background: var(--accent);
+  background: var(--color-accent);
   color: #fff;
   padding: 10px 14px;
   border-radius: 10px;


### PR DESCRIPTION
### Motivation
- Provide per-organization white-label customization (company name, logo, colors, favicon, domain, support email) selectable by `org_id`.
- Cache branding in Redis for fast reads with a DB fallback and support updates persisted to SQLite.
- Surface branding in generated artifacts (GSN checklist and exec-album PDFs) and in web/desktop UI so interfaces can be customized per tenant.

### Description
- Added a new module `core/branding.py` with `BrandingConfig`, `get_branding` (Redis read-through cache, TTL 1h) and `upsert_branding` (DB upsert + cache refresh).
- Added branding API router `api/routes/branding.py` exposing `GET /api/branding` and `PUT /api/branding` (admin-only) and registered it in `api/main.py`.
- Created Alembic migration `migrations/versions/20260417_add_org_branding.py` to create the `org_branding` table with the requested columns and `org_id` PK.
- Wired branding into server flows and templates: `compliance` GSN report and `generate` exec-album now fetch `BrandingConfig` and inject `{{ company_name }}` / `{{ logo_url }}` into `templates/gsn_checklist.html` and `templates/exec_album_cover.html`.
- Updated web PWA (`web/app.js`, `web/index.html`, `web/styles.css`) to fetch `/api/branding` on load, apply CSS custom properties `--color-primary` / `--color-accent`, and set the app title to `company_name`.
- Added desktop support: `desktop/src/store/brandingStore.ts` (Zustand store) and `desktop/src/App.tsx` now fetch branding at startup and apply `branding.primary_color` to the app theme.
- Added tests `tests/test_branding.py` covering default fallback, admin-only update via API, and presence of branding in rendered PDF HTML.

### Testing
- Run linter: `ruff check core/branding.py api/routes/branding.py tests/test_branding.py` — all checks passed.
- Unit tests: `pytest -q tests/test_branding.py` — `3 passed`.
- The branding integration into PDF rendering was exercised by `test_branding_in_pdf_template` which asserts `company_name` and `logo_url` are present in rendered HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f2d9c3ac832f8ef98dd5ddbccb5a)