### PR TITLE
Add Web Push delivery and strengthen PWA offline behavior

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -35,6 +35,7 @@ from api.routes import (
     rag,
     sign,
     web,
+    web_push,
 )
 from api.routes.analyze import router as analyze_router
 from config.settings import settings
@@ -117,6 +118,7 @@ app.include_router(rag.router, prefix="/api/rag", tags=["rag"])
 app.include_router(projects.router, prefix="/api", tags=["projects"])
 app.include_router(analytics.router, prefix="/api", tags=["analytics"])
 app.include_router(compliance.router, prefix="/api", tags=["compliance"])
+app.include_router(web_push.router)
 app.include_router(web.router, tags=["web"])
 app.mount("/web", StaticFiles(directory="web", html=True), name="web")
 setup_rate_limiter(app.routes)

--- a/api/routes/web_push.py
+++ b/api/routes/web_push.py
@@ -1,0 +1,179 @@
+"""Web Push subscription and delivery endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy import create_engine, text
+
+from config.settings import settings
+
+try:
+    from pywebpush import WebPushException, webpush
+except ImportError:  # pragma: no cover - validated in runtime/tests by monkeypatch
+    WebPushException = RuntimeError
+    webpush = None
+
+router = APIRouter(prefix="/api/push", tags=["push"])
+
+
+class PushSubscriptionKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+
+class PushSubscriptionBody(BaseModel):
+    endpoint: str
+    keys: PushSubscriptionKeys
+
+
+class PushSubscribeRequest(BaseModel):
+    subscription: PushSubscriptionBody
+    org_id: str = "default"
+
+
+class PushSendRequest(BaseModel):
+    org_id: str
+    title: str = "Construction AI"
+    body: str
+    url: str = "/"
+
+
+@dataclass(slots=True)
+class PushSubscriptionRecord:
+    endpoint: str
+    p256dh: str
+    auth: str
+
+
+def _ensure_push_subscriptions_table() -> None:
+    engine = create_engine(settings.database_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS push_subscriptions (
+                    id TEXT PRIMARY KEY,
+                    org_id TEXT NOT NULL,
+                    endpoint TEXT NOT NULL UNIQUE,
+                    p256dh TEXT NOT NULL,
+                    auth TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+            ),
+        )
+
+
+def _require_admin(request: Request) -> None:
+    if getattr(request.state, "user_role", None) == "admin":
+        return
+    api_key = request.headers.get("X-API-Key", "")
+    if api_key and api_key in settings.admin_api_keys:
+        return
+    raise HTTPException(status_code=403, detail="Admin role required")
+
+
+def _load_org_subscriptions(org_id: str) -> list[PushSubscriptionRecord]:
+    _ensure_push_subscriptions_table()
+    engine = create_engine(settings.database_url, future=True)
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT endpoint, p256dh, auth
+                FROM push_subscriptions
+                WHERE org_id = :org_id
+                ORDER BY created_at DESC
+                """,
+            ),
+            {"org_id": org_id},
+        ).mappings()
+        return [PushSubscriptionRecord(**row) for row in rows]
+
+
+async def send_push_to_org(org_id: str, payload: dict[str, str]) -> int:
+    """Send web push payload to all subscriptions of an org."""
+    if webpush is None:
+        raise HTTPException(status_code=503, detail="pywebpush is not installed")
+
+    subs = _load_org_subscriptions(org_id)
+    if not subs:
+        return 0
+
+    vapid_private_key = settings.vapid_private_key.strip()
+    vapid_public_key = settings.vapid_public_key.strip()
+    if not vapid_private_key or not vapid_public_key:
+        raise HTTPException(status_code=503, detail="VAPID keys are not configured")
+
+    sent = 0
+    engine = create_engine(settings.database_url, future=True)
+    for sub in subs:
+        subscription_info = {
+            "endpoint": sub.endpoint,
+            "keys": {
+                "p256dh": sub.p256dh,
+                "auth": sub.auth,
+            },
+        }
+        try:
+            push_data = PushSendRequest.model_validate({"org_id": org_id, **payload})
+            webpush(
+                subscription_info=subscription_info,
+                data=push_data.model_dump_json(),
+                vapid_private_key=vapid_private_key,
+                vapid_claims={"sub": f"mailto:{settings.vapid_claims_email}"},
+            )
+            sent += 1
+        except WebPushException:
+            with engine.begin() as conn:
+                conn.execute(
+                    text("DELETE FROM push_subscriptions WHERE endpoint = :endpoint"),
+                    {"endpoint": sub.endpoint},
+                )
+    return sent
+
+
+@router.post("/subscribe")
+async def subscribe_push(payload: PushSubscribeRequest) -> dict[str, bool]:
+    _ensure_push_subscriptions_table()
+    engine = create_engine(settings.database_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO push_subscriptions (id, org_id, endpoint, p256dh, auth, created_at)
+                VALUES (:id, :org_id, :endpoint, :p256dh, :auth, CURRENT_TIMESTAMP)
+                ON CONFLICT(endpoint) DO UPDATE SET
+                    org_id = excluded.org_id,
+                    p256dh = excluded.p256dh,
+                    auth = excluded.auth
+                """,
+            ),
+            {
+                "id": str(uuid4()),
+                "org_id": payload.org_id,
+                "endpoint": payload.subscription.endpoint,
+                "p256dh": payload.subscription.keys.p256dh,
+                "auth": payload.subscription.keys.auth,
+            },
+        )
+    return {"ok": True}
+
+
+@router.post("/send")
+async def send_push(payload: PushSendRequest, request: Request) -> dict[str, Any]:
+    _require_admin(request)
+    sent = await send_push_to_org(
+        payload.org_id,
+        {
+            "title": payload.title,
+            "body": payload.body,
+            "url": payload.url,
+        },
+    )
+    return {"ok": True, "sent": sent}

--- a/config/settings.py
+++ b/config/settings.py
@@ -77,6 +77,11 @@ class Settings(BaseSettings):
     pto_engineer_telegram_ids: list[int] = []
     domain: str = "localhost"
 
+    # ── Web Push (VAPID) ─────────────────────
+    vapid_public_key: str = ""
+    vapid_private_key: str = ""
+    vapid_claims_email: str = "admin@construction-ai.ru"
+
     # ── tk-generator ───────────────────────────
     tk_generator_path: str = "../tk-generator"
 

--- a/core/analytics/notifications.py
+++ b/core/analytics/notifications.py
@@ -10,6 +10,7 @@ import aiosqlite
 import structlog
 from aiogram import Bot
 
+from api.routes.web_push import send_push_to_org
 from config.settings import settings
 from core.analytics.schedule_predictor import SchedulePredictor
 
@@ -78,6 +79,18 @@ class AnalyticsNotifier:
                 )
                 for chat_id in target_chat_ids:
                     await bot.send_message(chat_id=chat_id, text=message)
+
+                await send_push_to_org(
+                    "default",
+                    {
+                        "title": "⚠️ Риск срыва сроков",
+                        "body": (
+                            f"Проект {project_id}: delay rate {prediction['delay_rate']:.0%}, "
+                            f"прогноз {prediction.get('predicted_completion')}"
+                        ),
+                        "url": "/web",
+                    },
+                )
         finally:
             await bot.session.close()
 

--- a/migrations/versions/20260417_add_push_subscriptions.py
+++ b/migrations/versions/20260417_add_push_subscriptions.py
@@ -1,0 +1,46 @@
+"""create push_subscriptions table
+
+Revision ID: 20260417_add_push_subscriptions
+Revises: 20260417_add_org_branding
+Create Date: 2026-04-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260417_add_push_subscriptions"
+down_revision = "20260417_add_org_branding"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_subscriptions",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("endpoint", sa.Text(), nullable=False),
+        sa.Column("p256dh", sa.Text(), nullable=False),
+        sa.Column("auth", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_push_subscriptions_org_id", "push_subscriptions", ["org_id"], unique=False)
+    op.create_index(
+        "ix_push_subscriptions_endpoint",
+        "push_subscriptions",
+        ["endpoint"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_push_subscriptions_endpoint", table_name="push_subscriptions")
+    op.drop_index("ix_push_subscriptions_org_id", table_name="push_subscriptions")
+    op.drop_table("push_subscriptions")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "boto3>=1.34.0",
     "apscheduler>=3.10.4",
+    "pywebpush>=2.0.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -39,13 +39,17 @@ def test_subscribe_stores_subscription(tmp_path):
 
         engine = create_engine(settings.database_url, future=True)
         with engine.connect() as conn:
-            row = conn.execute(
-                text(
-                    "SELECT org_id, endpoint, p256dh, auth FROM push_subscriptions "
-                    "WHERE endpoint = :endpoint"
-                ),
-                {"endpoint": payload["subscription"]["endpoint"]},
-            ).mappings().one()
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT org_id, endpoint, p256dh, auth FROM push_subscriptions "
+                        "WHERE endpoint = :endpoint"
+                    ),
+                    {"endpoint": payload["subscription"]["endpoint"]},
+                )
+                .mappings()
+                .one()
+            )
     finally:
         settings.database_url = old_database_url
         settings.api_keys = old_api_keys
@@ -126,7 +130,7 @@ def test_sw_cache_strategy():
     source = open(sw_path, encoding="utf-8").read()
 
     assert 'const CACHE_NAME = "construction-ai-v2"' in source
-    assert 'fetch(event.request).catch(() => caches.match(event.request))' in source
+    assert "fetch(event.request).catch(() => caches.match(event.request))" in source
     assert 'self.addEventListener("push"' in source
 
     node_bin = shutil.which("node")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,0 +1,142 @@
+"""Tests for web push subscription and delivery."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from api.main import app
+from config.settings import settings
+
+
+def test_subscribe_stores_subscription(tmp_path):
+    old_database_url = settings.database_url
+    old_api_keys = settings.api_keys
+    settings.database_url = f"sqlite:///{tmp_path / 'push.db'}"
+    settings.api_keys = ["push-key"]
+
+    payload = {
+        "org_id": "org-1",
+        "subscription": {
+            "endpoint": "https://example.test/sub/1",
+            "keys": {
+                "p256dh": "p256dh-key",
+                "auth": "auth-key",
+            },
+        },
+    }
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/push/subscribe",
+                json=payload,
+                headers={"X-API-Key": "push-key"},
+            )
+
+        engine = create_engine(settings.database_url, future=True)
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT org_id, endpoint, p256dh, auth FROM push_subscriptions "
+                    "WHERE endpoint = :endpoint"
+                ),
+                {"endpoint": payload["subscription"]["endpoint"]},
+            ).mappings().one()
+    finally:
+        settings.database_url = old_database_url
+        settings.api_keys = old_api_keys
+
+    assert response.status_code == 200
+    assert row["org_id"] == "org-1"
+    assert row["p256dh"] == "p256dh-key"
+    assert row["auth"] == "auth-key"
+
+
+def test_send_push_calls_pywebpush(monkeypatch, tmp_path):
+    from api.routes import web_push
+
+    old_database_url = settings.database_url
+    old_api_keys = settings.api_keys
+    old_admin_api_keys = settings.admin_api_keys
+    old_vapid_public = settings.vapid_public_key
+    old_vapid_private = settings.vapid_private_key
+
+    settings.database_url = f"sqlite:///{tmp_path / 'push-send.db'}"
+    settings.api_keys = ["push-key"]
+    settings.admin_api_keys = ["push-key"]
+    settings.vapid_public_key = "public"
+    settings.vapid_private_key = "private"
+
+    calls: list[dict] = []
+
+    def _fake_webpush(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(web_push, "webpush", _fake_webpush)
+
+    subscribe_payload = {
+        "org_id": "org-2",
+        "subscription": {
+            "endpoint": "https://example.test/sub/2",
+            "keys": {
+                "p256dh": "p256dh-key-2",
+                "auth": "auth-key-2",
+            },
+        },
+    }
+    send_payload = {
+        "org_id": "org-2",
+        "title": "Alert",
+        "body": "Delayed section",
+        "url": "/web/projects/1",
+    }
+
+    try:
+        with TestClient(app) as client:
+            sub_resp = client.post(
+                "/api/push/subscribe",
+                json=subscribe_payload,
+                headers={"X-API-Key": "push-key"},
+            )
+            send_resp = client.post(
+                "/api/push/send",
+                json=send_payload,
+                headers={"X-API-Key": "push-key"},
+            )
+    finally:
+        settings.database_url = old_database_url
+        settings.api_keys = old_api_keys
+        settings.admin_api_keys = old_admin_api_keys
+        settings.vapid_public_key = old_vapid_public
+        settings.vapid_private_key = old_vapid_private
+
+    assert sub_resp.status_code == 200
+    assert send_resp.status_code == 200
+    assert send_resp.json()["sent"] == 1
+    assert len(calls) == 1
+    assert calls[0]["subscription_info"]["endpoint"] == "https://example.test/sub/2"
+
+
+def test_sw_cache_strategy():
+    sw_path = "web/sw.js"
+    source = open(sw_path, encoding="utf-8").read()
+
+    assert 'const CACHE_NAME = "construction-ai-v2"' in source
+    assert 'fetch(event.request).catch(() => caches.match(event.request))' in source
+    assert 'self.addEventListener("push"' in source
+
+    node_bin = shutil.which("node")
+    if node_bin is None:
+        return
+
+    result = subprocess.run(
+        [node_bin, "--check", sw_path],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/web/app.js
+++ b/web/app.js
@@ -2,6 +2,13 @@ const tg = window.Telegram?.WebApp;
 const queryParams = new URLSearchParams(window.location.search);
 const webApiKey = queryParams.get("api_key") || "";
 const authToken = window.localStorage.getItem("auth_token") || "";
+const apiKey = webApiKey || window.localStorage.getItem("api_key") || "";
+const currentOrgId =
+  queryParams.get("org_id") || window.localStorage.getItem("org_id") || "default";
+const VAPID_PUBLIC_KEY =
+  window.__VAPID_PUBLIC_KEY__ ||
+  document.querySelector('meta[name="vapid-public-key"]')?.getAttribute("content") ||
+  "";
 
 function buildAuthHeaders(extraHeaders = {}) {
   const headers = { ...extraHeaders };
@@ -11,6 +18,27 @@ function buildAuthHeaders(extraHeaders = {}) {
     headers["X-API-Key"] = webApiKey;
   }
   return headers;
+}
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+}
+
+async function subscribeToPush() {
+  if (!("PushManager" in window) || !VAPID_PUBLIC_KEY || !apiKey) return;
+  const reg = await navigator.serviceWorker.ready;
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+  });
+  await fetch("/api/push/subscribe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+    body: JSON.stringify({ subscription: sub.toJSON(), org_id: currentOrgId }),
+  });
 }
 
 if (tg) {
@@ -26,9 +54,12 @@ if (themeIndicator) {
 
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("/web/sw.js").catch((error) => {
-      console.error("Service Worker registration failed:", error);
-    });
+    navigator.serviceWorker
+      .register("/web/sw.js")
+      .then(() => subscribeToPush().catch((error) => console.warn("Push subscription failed", error)))
+      .catch((error) => {
+        console.error("Service Worker registration failed:", error);
+      });
   });
 }
 

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,9 +1,17 @@
 {
   "name": "Construction AI",
   "short_name": "ConstrAI",
-  "start_url": "/web/",
   "display": "standalone",
-  "background_color": "#1a1a1a",
-  "theme_color": "#1a1a1a",
-  "icons": []
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
 }

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,18 +1,29 @@
-const CACHE_NAME = "construction-ai-web-v1";
-const URLS_TO_CACHE = [
-  "/web/",
-  "/web/index.html",
-  "/web/styles.css",
-  "/web/app.js",
-  "/web/manifest.json"
-];
+const CACHE_NAME = "construction-ai-v2";
+const STATIC_ASSETS = ["/", "/index.html", "/app.js", "/styles.css", "/manifest.json"];
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(URLS_TO_CACHE)));
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)));
 });
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(
-    caches.match(event.request).then((cachedResponse) => cachedResponse || fetch(event.request))
+  if (event.request.method !== "GET") return;
+
+  event.respondWith(fetch(event.request).catch(() => caches.match(event.request)));
+});
+
+self.addEventListener("push", (event) => {
+  const data = event.data?.json() ?? {};
+  event.waitUntil(
+    self.registration.showNotification(data.title ?? "Construction AI", {
+      body: data.body,
+      icon: "/icon-192.png",
+      badge: "/badge-72.png",
+      data: data.url,
+    }),
   );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  event.waitUntil(clients.openWindow(event.notification.data ?? "/"));
 });


### PR DESCRIPTION
### Motivation
- Improve PWA UX by providing offline support (Service Worker pre-cache and network-first fallback) and enable Web Push notifications for users. 
- Provide backend support to persist push subscriptions and send notifications to all org subscribers. 
- Surface critical analytics alerts via Web Push in addition to existing Telegram notifications when delay risk is high. 

### Description
- Enhance Service Worker at `web/sw.js` with static pre-cache (`construction-ai-v2`), network-first `fetch` fallback to cache, `push` handling and `notificationclick` to open provided URL. 
- Add client-side subscription flow in `web/app.js`: `subscribeToPush()` uses the VAPID public key and posts subscription to `POST /api/push/subscribe` including `org_id`. 
- Update `web/manifest.json` for standalone portrait PWA and include production icons (192/512 maskable). 
- Add FastAPI router `api/routes/web_push.py` exposing `POST /api/push/subscribe` to store/update subscriptions and `POST /api/push/send` (admin-restricted) to fan out notifications using `pywebpush`, plus helper `send_push_to_org`. 
- Add Alembic migration `migrations/versions/20260417_add_push_subscriptions.py` creating `push_subscriptions` table and add VAPID settings in `config/settings.py`. 
- Integrate `send_push_to_org` into `core/analytics/notifications.py` to send Web Push when `delay_rate > 0.3`. 
- Add tests in `tests/test_push.py` covering subscription persistence, `pywebpush` invocation (monkeypatched), and a static check of `web/sw.js`. 
- Add runtime dependency `pywebpush` in `pyproject.toml`.

### Testing
- Lint/format checks run with `ruff check api/routes/web_push.py tests/test_push.py core/analytics/notifications.py` and issues were fixed automatically; final check reported no problems. 
- Unit tests executed with `pytest -q tests/test_push.py` and passed: `3 passed`. 
- The new tests are `test_subscribe_stores_subscription`, `test_send_push_calls_pywebpush`, and `test_sw_cache_strategy` located in `tests/test_push.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f6bddc84832f882fa2a569c3f8e5)