### PR TITLE
Fix desktop form generation failures and add DOCX download flows

### DIFF
--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -63,7 +63,11 @@ const LEGACY_DEFAULT_API_URL = 'http://vanekpetrov1997.fvds.ru';
 export const normalizeApiUrl = (apiUrl: string) => {
   const trimmedUrl = apiUrl.trim().replace(/\/+$/, '');
 
-  if (!trimmedUrl || trimmedUrl === LEGACY_DEFAULT_API_URL) {
+  if (
+    !trimmedUrl ||
+    trimmedUrl === LEGACY_DEFAULT_API_URL ||
+    trimmedUrl === 'http://vanekpetrov1997.fvds.ru'
+  ) {
     return DEFAULT_API_URL;
   }
 
@@ -120,13 +124,21 @@ async function postJson<TRequest>(
   endpoint: string,
   payload: TRequest
 ): Promise<GenerateDocumentResponse> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => {
+    controller.abort();
+  }, 30_000);
+
   const response = await apiFetch(apiUrl, endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': apiKey.trim()
     },
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
+    signal: controller.signal
+  }).finally(() => {
+    window.clearTimeout(timeoutId);
   });
 
   await assertOk(response, endpoint);
@@ -137,8 +149,15 @@ async function postJson<TRequest>(
 export async function getApiConfig(): Promise<ApiConfig> {
   const store = await Store.load('settings.json');
   const savedUrl = await store.get<string>('api_url');
-  const apiUrl = normalizeApiUrl(savedUrl || (await invoke<string>('get_api_url')) || DEFAULT_API_URL);
+  const fallbackUrl = (await invoke<string>('get_api_url')) || DEFAULT_API_URL;
+  const apiUrl = normalizeApiUrl(savedUrl || fallbackUrl || DEFAULT_API_URL);
   const apiKey = ((await store.get<string>('api_key')) || '').trim();
+
+  const isDev = Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
+  if (isDev) {
+    console.debug('[API] url=', apiUrl, 'keyLen=', apiKey.length);
+  }
+
   return { apiUrl, apiKey };
 }
 
@@ -176,6 +195,38 @@ export function generateKS(apiUrl: string, apiKey: string, payload: KSRequest) {
 
 export async function downloadTKDocx(apiUrl: string, apiKey: string, sessionId: string): Promise<Blob> {
   const endpoint = `/api/generate/tk/${encodeURIComponent(sessionId)}/download`;
+  const response = await apiFetch(apiUrl, endpoint, {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey.trim()
+    }
+  });
+
+  await assertOk(response, endpoint);
+
+  return await response.blob();
+}
+
+export async function downloadLetterDocx(
+  apiUrl: string,
+  apiKey: string,
+  sessionId: string
+): Promise<Blob> {
+  const endpoint = `/api/generate/letter/${encodeURIComponent(sessionId)}/download`;
+  const response = await apiFetch(apiUrl, endpoint, {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey.trim()
+    }
+  });
+
+  await assertOk(response, endpoint);
+
+  return await response.blob();
+}
+
+export async function downloadKSDocx(apiUrl: string, apiKey: string, sessionId: string): Promise<Blob> {
+  const endpoint = `/api/generate/ks/${encodeURIComponent(sessionId)}/download`;
   const response = await apiFetch(apiUrl, endpoint, {
     method: 'GET',
     headers: {

--- a/desktop/src/components/DocumentForm.tsx
+++ b/desktop/src/components/DocumentForm.tsx
@@ -14,6 +14,8 @@ interface DocumentFormProps {
   fields: DocumentField[];
   onSubmit: (data: Record<string, string>) => void;
   isLoading: boolean;
+  error?: string;
+  disabledOnLoading?: boolean;
 }
 
 const makeInitialValues = (fields: DocumentField[]): Record<string, string> =>
@@ -22,7 +24,13 @@ const makeInitialValues = (fields: DocumentField[]): Record<string, string> =>
     return acc;
   }, {});
 
-export default function DocumentForm({ fields, onSubmit, isLoading }: DocumentFormProps) {
+export default function DocumentForm({
+  fields,
+  onSubmit,
+  isLoading,
+  error,
+  disabledOnLoading = true
+}: DocumentFormProps) {
   const initialValues = useMemo(() => makeInitialValues(fields), [fields]);
   const [values, setValues] = useState<Record<string, string>>(initialValues);
 
@@ -50,12 +58,14 @@ export default function DocumentForm({ fields, onSubmit, isLoading }: DocumentFo
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
               placeholder={field.placeholder}
+              disabled={disabledOnLoading && isLoading}
               required
             />
           ) : field.type === 'select' ? (
             <select
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
+              disabled={disabledOnLoading && isLoading}
               required
             >
               <option value="" disabled>
@@ -73,6 +83,7 @@ export default function DocumentForm({ fields, onSubmit, isLoading }: DocumentFo
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
               placeholder={field.placeholder}
+              disabled={disabledOnLoading && isLoading}
               required
             />
           )}
@@ -80,14 +91,17 @@ export default function DocumentForm({ fields, onSubmit, isLoading }: DocumentFo
       ))}
 
       <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <button type="submit" disabled={isLoading}>
-          Сгенерировать
+        <button type="submit" disabled={disabledOnLoading && isLoading}>
+          {isLoading ? '⏳ Сгенерировать' : 'Сгенерировать'}
         </button>
-        <button type="button" onClick={handleClear} disabled={isLoading}>
+        <button type="button" onClick={handleClear} disabled={disabledOnLoading && isLoading}>
           Очистить
         </button>
         {isLoading && <span role="status">⏳ Генерация...</span>}
       </div>
+      {error && error.includes('Failed to fetch') && (
+        <p style={{ color: '#8a6d3b' }}>Проверьте API URL и API Key в разделе Настройки</p>
+      )}
     </form>
   );
 }

--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
-import { generateKS, getApiConfig, type KSWorkItem } from '../api/coreClient';
+import { downloadKSDocx, generateKS, getApiConfig, type KSWorkItem } from '../api/coreClient';
 
 const fields: DocumentField[] = [
   { name: 'object_name', label: 'Название объекта', type: 'text' },
   { name: 'contract_number', label: 'Номер договора', type: 'text' },
-  { name: 'date_from', label: 'Период с', type: 'text', placeholder: 'YYYY-MM-DD' },
-  { name: 'date_to', label: 'Период по', type: 'text', placeholder: 'YYYY-MM-DD' },
+  { name: 'date_from', label: 'Период с', type: 'text', placeholder: 'ДД.ММ.ГГГГ' },
+  { name: 'date_to', label: 'Период по', type: 'text', placeholder: 'ДД.ММ.ГГГГ' },
   {
     name: 'work_items',
     label: 'Перечень работ',
@@ -15,14 +15,59 @@ const fields: DocumentField[] = [
   }
 ];
 
+function parseDateRU(val: string): string {
+  const normalized = val.trim();
+  const isoPattern = /^\d{4}-\d{2}-\d{2}$/;
+
+  if (isoPattern.test(normalized)) {
+    return normalized;
+  }
+
+  const ruPattern = /^(\d{2})\.(\d{2})\.(\d{4})$/;
+  const ruMatch = normalized.match(ruPattern);
+
+  if (!ruMatch) {
+    throw new Error('Неверный формат даты. Используйте ДД.ММ.ГГГГ');
+  }
+
+  const [, dayStr, monthStr, yearStr] = ruMatch;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() + 1 !== month ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    throw new Error('Неверный формат даты. Используйте ДД.ММ.ГГГГ');
+  }
+
+  return `${yearStr}-${monthStr}-${dayStr}`;
+}
+
+interface KSSummary {
+  ks2: string;
+  ks3: string;
+  total_cost: string;
+  total_hours: string;
+}
+
 export default function GenerateKSPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState('');
   const [error, setError] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [downloadLoading, setDownloadLoading] = useState(false);
+  const [summary, setSummary] = useState<KSSummary | null>(null);
 
   const handleSubmit = async (data: Record<string, string>) => {
     setIsLoading(true);
     setError('');
+    setSuccess(false);
+    setSummary(null);
 
     try {
       const workItems: KSWorkItem[] = data.work_items
@@ -57,9 +102,18 @@ export default function GenerateKSPage() {
       const response = await generateKS(apiUrl, apiKey, {
         object_name: data.object_name,
         contract_number: data.contract_number,
-        period_from: data.date_from,
-        period_to: data.date_to,
+        period_from: parseDateRU(data.date_from),
+        period_to: parseDateRU(data.date_to),
         work_items: workItems
+      });
+
+      setSessionId(String(response.session_id ?? ''));
+      setSuccess(true);
+      setSummary({
+        ks2: String(response.ks2 ?? ''),
+        ks3: String(response.ks3 ?? ''),
+        total_cost: String(response.total_cost ?? ''),
+        total_hours: String(response.total_hours ?? '')
       });
 
       const normalizedResult =
@@ -79,15 +133,65 @@ export default function GenerateKSPage() {
     }
   };
 
+  const handleDownload = async () => {
+    if (!sessionId) {
+      setError('Нет session_id для скачивания DOCX');
+      return;
+    }
+
+    setDownloadLoading(true);
+    setError('');
+
+    try {
+      const { apiUrl, apiKey } = await getApiConfig();
+      const blob = await downloadKSDocx(apiUrl, apiKey, sessionId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `ks-${sessionId}.docx`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (downloadError) {
+      setError(downloadError instanceof Error ? downloadError.message : 'Ошибка скачивания DOCX');
+    } finally {
+      setDownloadLoading(false);
+    }
+  };
+
   return (
     <section style={{ display: 'grid', gap: 12 }}>
       <h2>Генерация КС</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} />
+      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ КС сгенерирована</p>}
       {error && <p style={{ color: 'crimson' }}>{error}</p>}
+      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
+      {summary && (
+        <table style={{ borderCollapse: 'collapse', width: '100%', maxWidth: 700 }}>
+          <thead>
+            <tr>
+              <th style={{ border: '1px solid #ddd', padding: 8 }}>ks2 (стоимость)</th>
+              <th style={{ border: '1px solid #ddd', padding: 8 }}>ks3 (выполнение)</th>
+              <th style={{ border: '1px solid #ddd', padding: 8 }}>total_cost</th>
+              <th style={{ border: '1px solid #ddd', padding: 8 }}>total_hours</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.ks2 || '—'}</td>
+              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.ks3 || '—'}</td>
+              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.total_cost || '—'}</td>
+              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.total_hours || '—'}</td>
+            </tr>
+          </tbody>
+        </table>
+      )}
       <label style={{ display: 'grid', gap: 8 }}>
         <span>Результат</span>
         <textarea value={result} rows={12} readOnly />
       </label>
+      <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
+        {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
+      </button>
     </section>
   );
 }

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
-import { generateLetter, getApiConfig } from '../api/coreClient';
+import { downloadLetterDocx, generateLetter, getApiConfig } from '../api/coreClient';
 
 
 const letterTypeMap: Record<string, 'запрос' | 'претензия' | 'уведомление' | 'ответ'> = {
@@ -25,11 +25,15 @@ const fields: DocumentField[] = [
 export default function GenerateLetterPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState('');
+  const [sessionId, setSessionId] = useState('');
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [downloadLoading, setDownloadLoading] = useState(false);
 
   const handleSubmit = async (data: Record<string, string>) => {
     setIsLoading(true);
     setError('');
+    setSuccess(false);
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
@@ -52,6 +56,8 @@ export default function GenerateLetterPage() {
           ? normalizedResult
           : JSON.stringify(normalizedResult, null, 2)
       );
+      setSessionId(String(response.session_id ?? ''));
+      setSuccess(true);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации письма');
     } finally {
@@ -59,15 +65,45 @@ export default function GenerateLetterPage() {
     }
   };
 
+  const handleDownload = async () => {
+    if (!sessionId) {
+      setError('Нет session_id для скачивания DOCX');
+      return;
+    }
+
+    setDownloadLoading(true);
+    setError('');
+
+    try {
+      const { apiUrl, apiKey } = await getApiConfig();
+      const blob = await downloadLetterDocx(apiUrl, apiKey, sessionId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `letter-${sessionId}.docx`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (downloadError) {
+      setError(downloadError instanceof Error ? downloadError.message : 'Ошибка скачивания DOCX');
+    } finally {
+      setDownloadLoading(false);
+    }
+  };
+
   return (
     <section style={{ display: 'grid', gap: 12 }}>
       <h2>Генерация письма</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} />
+      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ Письмо сгенерировано</p>}
       {error && <p style={{ color: 'crimson' }}>{error}</p>}
+      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
       <label style={{ display: 'grid', gap: 8 }}>
         <span>Результат</span>
         <textarea value={result} rows={12} readOnly />
       </label>
+      <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
+        {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
+      </button>
     </section>
   );
 }

--- a/desktop/src/pages/GenerateTKPage.tsx
+++ b/desktop/src/pages/GenerateTKPage.tsx
@@ -17,13 +17,16 @@ const fields: DocumentField[] = [
 export default function GenerateTKPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState('');
+  const [documentJson, setDocumentJson] = useState('');
   const [sessionId, setSessionId] = useState('');
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
   const [downloadLoading, setDownloadLoading] = useState(false);
 
   const handleSubmit = async (data: Record<string, string>) => {
     setIsLoading(true);
     setError('');
+    setSuccess(false);
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
@@ -41,7 +44,9 @@ export default function GenerateTKPage() {
           ? normalizedResult
           : JSON.stringify(normalizedResult, null, 2)
       );
+      setDocumentJson(response.document ? JSON.stringify(response.document, null, 2) : '');
       setSessionId(String(response.session_id ?? ''));
+      setSuccess(true);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации ТК');
     } finally {
@@ -77,12 +82,20 @@ export default function GenerateTKPage() {
   return (
     <section style={{ display: 'grid', gap: 12 }}>
       <h2>Генерация ТК</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} />
+      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ ТК сгенерирована</p>}
       {error && <p style={{ color: 'crimson' }}>{error}</p>}
+      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
       <label style={{ display: 'grid', gap: 8 }}>
         <span>Результат</span>
         <textarea value={result} rows={12} readOnly />
       </label>
+      {documentJson && (
+        <label style={{ display: 'grid', gap: 8 }}>
+          <span>document (JSON)</span>
+          <textarea value={documentJson} rows={10} readOnly />
+        </label>
+      )}
       <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
         {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
       </button>


### PR DESCRIPTION
### Motivation
- Исправить «Failed to fetch» в десктоп-приложении за счёт корректной работы конфигурации API и обработки отсутствующего API Key при первом запуске.
- Обеспечить удобный UX для всех трёх форм: сразу доступная кнопка скачивания DOCX, отображение `session_id` и подсказки для сетевых ошибок.

### Description
- Жёсткий fallback в `getApiConfig()` и улучшенная нормализация URL в `normalizeApiUrl` чтобы пустой или legacy `http://vanekpetrov1997.fvds.ru` возвращал `DEFAULT_API_URL`, и добавлен dev-лог `console.debug('[API] url=', apiUrl, 'keyLen=', apiKey.length)`.
- Добавлен 30s таймаут в `postJson()` через `AbortController` и добавлены экспортные helpers `downloadLetterDocx` и `downloadKSDocx` аналогично `downloadTKDocx` (в `desktop/src/api/coreClient.ts`).
- Обновлён `DocumentForm` с новым пропом `disabledOnLoading?: boolean` (по умолчанию `true`), кнопка Submit показывает `⏳` при загрузке, поля блокируются при загрузке и показывается подсказка при ошибке содержащей `Failed to fetch` (в `desktop/src/components/DocumentForm.tsx`).
- Обновлён `GenerateTKPage` чтобы показывать зелёный статус при успехе, отображать `session_id`, выводить `response.document` в prettified JSON и разрешать скачивание DOCX сразу при наличии `session_id` (в `desktop/src/pages/GenerateTKPage.tsx`).
- Обновлён `GenerateLetterPage` чтобы сохранять `session_id`, показывать успешный статус и добавить кнопку скачивания DOCX через `downloadLetterDocx` (в `desktop/src/pages/GenerateLetterPage.tsx`).
- Обновлён `GenerateKSPage`: плейсхолдеры дат изменены на `ДД.ММ.ГГГГ`, добавлена функция `parseDateRU()` для конвертации/валидации дат в `YYYY-MM-DD`, применяется перед отправкой, добавлена кнопка скачивания DOCX через `downloadKSDocx` и таблица с `ks2`, `ks3`, `total_cost`, `total_hours` после успешной генерации (в `desktop/src/pages/GenerateKSPage.tsx`).

### Testing
- Запущена сборка в `desktop/` через `npm run build`, сборка прошла успешно.
- Нет других автоматизированных тестов для этого хотфикса (интеграционные/GUI-скриншоты не выполнялись в CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3346a17dc832f86b9efb3dbe464ce)