### PR TITLE
Fix chat response cleanup and expose metadata in UI

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -62,4 +62,9 @@ async def chat(
         session_id=session_id,
         role=payload.role,
     )
-    return result
+    return ChatResponse(
+        reply=str(result.get("reply", "")),
+        session_id=str(result.get("session_id", session_id)),
+        agents_used=list(result.get("agents_used", [])),
+        confidence=result.get("confidence"),
+    )

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -8,6 +8,7 @@ Supervisor-паттерн на LangGraph. Управляет pipeline'ами:
 """
 
 import json
+import re
 import uuid
 from pathlib import Path
 from typing import Any, TypedDict, cast
@@ -26,6 +27,8 @@ from api.metrics import PIPELINE_DURATION
 from core.llm_router import LLMRouter
 from core.session_memory import SessionMemory
 from core.tk_bridge import TKGeneratorBridge
+
+METRICS_PATTERN = re.compile(r"Метрика \w+:\s*\S+\.?\s*", re.UNICODE)
 
 
 class PipelineState(TypedDict):
@@ -187,6 +190,12 @@ class Orchestrator:
         }
         return payload
 
+    def _clean_reply(self, raw_reply: str | None) -> str:
+        """Удалить служебные метрики из текста ответа."""
+        if not raw_reply:
+            return ""
+        return METRICS_PATTERN.sub("", raw_reply).strip()
+
     async def _run_pipeline(
         self,
         intent: str,
@@ -272,8 +281,9 @@ class Orchestrator:
         last_output = ""
         if history and isinstance(history[-1], dict):
             last_output = str(history[-1].get("output", ""))
+        clean_reply = self._clean_reply(last_output)
         result_payload = {
-            "reply": last_output,
+            "reply": clean_reply,
             "session_id": session_id,
             "agents_used": pipeline,
             "confidence": final_state.get("confidence"),
@@ -337,9 +347,10 @@ class Orchestrator:
                 prompt=message,
                 system_prompt=system_prompt,
             )
-            await self.session_memory.add(session_id, role="assistant", content=response.text)
+            clean_reply = self._clean_reply(response.text)
+            await self.session_memory.add(session_id, role="assistant", content=clean_reply)
             return {
-                "reply": response.text,
+                "reply": clean_reply,
                 "session_id": session_id,
                 "agents_used": ["researcher"],  # базовый режим
                 "confidence": None,

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -10,6 +10,14 @@ export interface ChatRequest {
 
 export interface ChatResponse {
   reply: string;
+  session_id?: string;
+  agents_used?: string[];
+  confidence?: number | null;
+}
+
+export interface ChatResponseMeta {
+  agents?: string[];
+  confidence?: number;
 }
 
 export interface TKRequest {

--- a/desktop/src/components/ChatWindow.tsx
+++ b/desktop/src/components/ChatWindow.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useRef, useState } from 'react';
 import MessageBubble from './MessageBubble';
 import { useChatStore } from '../store/chatStore';
 import { sendChatMessage } from '../api/coreClient';
+import type { ChatResponseMeta } from '../api/coreClient';
 import { Store } from '@tauri-apps/plugin-store';
 
 export default function ChatWindow() {
@@ -46,12 +47,17 @@ export default function ChatWindow() {
         role,
         session_id: sessionId
       });
+      const metadata: ChatResponseMeta = {
+        agents: response.agents_used,
+        confidence: typeof response.confidence === 'number' ? response.confidence : undefined
+      };
 
       addMessage({
         id: crypto.randomUUID(),
         role: 'assistant',
         content: response.reply,
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
+        metadata
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Ошибка отправки сообщения');
@@ -76,7 +82,7 @@ export default function ChatWindow() {
         }}
       >
         {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
+          <MessageBubble key={message.id} message={message} metadata={message.metadata} />
         ))}
         {isTyping && <div style={{ color: '#777' }}>Assistant печатает…</div>}
       </div>

--- a/desktop/src/components/MessageBubble.tsx
+++ b/desktop/src/components/MessageBubble.tsx
@@ -1,11 +1,40 @@
 import type { ChatMessage } from '../store/chatStore';
+import type { ChatResponseMeta } from '../api/coreClient';
 
 interface Props {
   message: ChatMessage;
+  metadata?: ChatResponseMeta;
 }
 
-export default function MessageBubble({ message }: Props) {
+function getConfidenceBadge(confidence?: number) {
+  if (typeof confidence !== 'number') {
+    return null;
+  }
+
+  if (confidence >= 0.8) {
+    return { label: '✓ Высокая', color: '#2e7d32' };
+  }
+
+  if (confidence >= 0.5) {
+    return { label: '~ Средняя', color: '#f9a825' };
+  }
+
+  return { label: '? Низкая', color: '#9e9e9e' };
+}
+
+export default function MessageBubble({ message, metadata }: Props) {
   const isUser = message.role === 'user';
+  const effectiveMetadata = metadata ?? message.metadata;
+  const agents = effectiveMetadata?.agents ?? [];
+  const confidenceBadge = getConfidenceBadge(effectiveMetadata?.confidence);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+    } catch {
+      // noop: в некоторых окружениях clipboard может быть недоступен
+    }
+  };
 
   return (
     <div
@@ -19,6 +48,47 @@ export default function MessageBubble({ message }: Props) {
     >
       <strong style={{ display: 'block', marginBottom: 4 }}>{isUser ? 'Вы' : 'Assistant'}</strong>
       <span>{message.content}</span>
+      {!isUser && (
+        <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
+          {agents.map((agent) => (
+            <span
+              key={agent}
+              style={{
+                fontSize: 11,
+                color: '#777',
+                border: '1px solid #d5d5d5',
+                borderRadius: 999,
+                padding: '1px 8px'
+              }}
+            >
+              {agent}
+            </span>
+          ))}
+          {confidenceBadge && (
+            <span style={{ fontSize: 11, color: confidenceBadge.color }}>
+              {confidenceBadge.label}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onCopy}
+            style={{
+              marginLeft: 'auto',
+              fontSize: 12,
+              color: '#666',
+              background: 'transparent',
+              border: '1px solid #d5d5d5',
+              borderRadius: 8,
+              cursor: 'pointer',
+              padding: '2px 8px'
+            }}
+            aria-label="Копировать сообщение"
+            title="Копировать"
+          >
+            📋 Копировать
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/desktop/src/store/chatStore.ts
+++ b/desktop/src/store/chatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { ChatResponseMeta } from '../api/coreClient';
 
 export type ChatRole = 'pto_engineer' | 'foreman' | 'tender_specialist' | 'admin';
 export type MessageRole = 'user' | 'assistant';
@@ -8,6 +9,7 @@ export interface ChatMessage {
   role: MessageRole;
   content: string;
   createdAt: string;
+  metadata?: ChatResponseMeta;
 }
 
 interface ChatSession {


### PR DESCRIPTION
### Motivation
- Prevent service/debug metric fragments like `Метрика <name>: <value>` from leaking into the human-readable assistant reply text. 
- Ensure `confidence` and `agents_used` are returned as structured metadata fields rather than embedded in `reply`. 
- Surface those metadata fields in the desktop UI with strict typing so the client can render agent chips, confidence badges and provide a copy action. 

### Description
- Added `METRICS_PATTERN = re.compile(r"Метрика \w+:\s*\S+\.?\s*", re.UNICODE)` and `_clean_reply` in `core/orchestrator.py` and applied it to both pipeline and chat branches so returned/stored `reply` is cleaned. 
- Modified `_run_pipeline` and `process` to use the cleaned reply while preserving `confidence` and `agents_used` as separate fields in the orchestrator result. 
- Changed `/api/chat` handler (`api/routes/chat.py`) to explicitly construct and return a `ChatResponse` with `reply`, `session_id`, `agents_used` and `confidence` mapped from the orchestrator result. 
- Desktop changes: extended `ChatResponse` and added `ChatResponseMeta` in `desktop/src/api/coreClient.ts`, added optional `metadata` to `ChatMessage` in `desktop/src/store/chatStore.ts`, populated `metadata` in `ChatWindow` from API response, and enhanced `MessageBubble` to accept `metadata`, render agent chips, show a colored confidence badge by threshold (`>=0.8`, `0.5-0.8`, `<0.5`) and add a per-message copy button (`📋 Копировать`). 

### Testing
- Ran Python compile check with `python -m compileall core/orchestrator.py api/routes/chat.py` and it completed successfully. 
- Built the desktop bundle with `npm --prefix desktop run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e339af5ee8832f9e7eafd861ea8bb8)