### PR TITLE
Secure ISUP callback and submissions endpoints

### DIFF
--- a/api/routes/isup.py
+++ b/api/routes/isup.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import secrets
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import create_engine, text
 
 from config.settings import settings
+from core.projects import Project, get_projects_sessionmaker
 from core.integrations.isup import ISUPClient, _fetch_doc_payload
 
 router = APIRouter(prefix="/api/isup", tags=["isup"])
@@ -35,6 +38,27 @@ class ISUPCallbackPayload(BaseModel):
     submission_id: str
     status: str
     comment: str = ""
+
+
+def _require_project_access(project_id: str, request: Request) -> None:
+    username = getattr(request.state, "username", None)
+    if not username:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    try:
+        project_uuid = UUID(project_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid project ID") from exc
+
+    session_local = get_projects_sessionmaker(settings.sqlite_db_path)
+    with session_local() as session:
+        project = session.get(Project, project_uuid)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+
+        members = project.members or []
+        if username != project.owner_id and username not in members:
+            raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.post("/submit-document")
@@ -78,8 +102,16 @@ async def get_status(submission_id: str, request: Request) -> dict:
 
 
 @router.post("/callback")
-async def isup_status_callback(payload: ISUPCallbackPayload) -> dict:
+async def isup_status_callback(payload: ISUPCallbackPayload, request: Request) -> dict:
     """Вебхук от ИСУП: обновить статус отправки."""
+    configured_secret = settings.isup_webhook_secret.strip()
+    if not configured_secret:
+        raise HTTPException(status_code=503, detail="ISUP webhook secret is not configured")
+
+    provided_secret = request.headers.get("X-ISUP-Webhook-Secret", "")
+    if not secrets.compare_digest(provided_secret, configured_secret):
+        raise HTTPException(status_code=403, detail="Invalid webhook secret")
+
     engine = create_engine(settings.database_url, future=True)
     query = text(
         """
@@ -99,8 +131,10 @@ async def isup_status_callback(payload: ISUPCallbackPayload) -> dict:
 
 
 @router.get("/submissions/{project_id}")
-async def list_isup_submissions(project_id: str) -> dict:
+async def list_isup_submissions(project_id: str, request: Request) -> dict:
     """Список отправок в ИСУП по проекту для polling из фронтенда."""
+    _require_project_access(project_id, request)
+
     engine = create_engine(settings.database_url, future=True)
     with engine.connect() as conn:
         rows = (

--- a/tests/test_isup_callback.py
+++ b/tests/test_isup_callback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from api.main import app
+from api.routes.auth import _create_token
 from api.routes import isup as isup_routes
 from config.settings import settings
 
@@ -78,7 +79,9 @@ class _FakeEngine:
 
 def test_callback_updates_status(monkeypatch):
     old_keys = settings.api_keys
+    old_secret = settings.isup_webhook_secret
     settings.api_keys = ["test-key"]
+    settings.isup_webhook_secret = "super-secret"
     engine = _FakeEngine()
     monkeypatch.setattr(isup_routes, "create_engine", lambda *args, **kwargs: engine)
 
@@ -87,10 +90,14 @@ def test_callback_updates_status(monkeypatch):
             response = client.post(
                 "/api/isup/callback",
                 json={"submission_id": "sub-123", "status": "accepted", "comment": "ok"},
-                headers={"X-API-Key": "test-key"},
+                headers={
+                    "X-API-Key": "test-key",
+                    "X-ISUP-Webhook-Secret": "super-secret",
+                },
             )
     finally:
         settings.api_keys = old_keys
+        settings.isup_webhook_secret = old_secret
 
     assert response.status_code == 200
     assert response.json() == {"ok": True}
@@ -104,6 +111,7 @@ def test_callback_updates_status(monkeypatch):
 
 def test_list_submissions(monkeypatch):
     old_keys = settings.api_keys
+    token = _create_token("alice", "admin")
     settings.api_keys = ["test-key"]
     rows = [
         {
@@ -121,15 +129,40 @@ def test_list_submissions(monkeypatch):
     ]
     engine = _FakeEngine(rows=rows)
     monkeypatch.setattr(isup_routes, "create_engine", lambda *args, **kwargs: engine)
+    monkeypatch.setattr(isup_routes, "_require_project_access", lambda *args, **kwargs: None)
 
     try:
         with TestClient(app) as client:
             response = client.get(
-                "/api/isup/submissions/project-1",
-                headers={"X-API-Key": "test-key"},
+                "/api/isup/submissions/00000000-0000-0000-0000-000000000001",
+                headers={"Authorization": f"Bearer {token}"},
             )
     finally:
         settings.api_keys = old_keys
 
     assert response.status_code == 200
     assert response.json() == {"submissions": rows}
+
+
+def test_callback_rejects_invalid_secret(monkeypatch):
+    old_keys = settings.api_keys
+    old_secret = settings.isup_webhook_secret
+    settings.api_keys = ["test-key"]
+    settings.isup_webhook_secret = "expected-secret"
+    engine = _FakeEngine()
+    monkeypatch.setattr(isup_routes, "create_engine", lambda *args, **kwargs: engine)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/isup/callback",
+                json={"submission_id": "sub-123", "status": "accepted", "comment": "ok"},
+                headers={"X-API-Key": "test-key", "X-ISUP-Webhook-Secret": "wrong-secret"},
+            )
+    finally:
+        settings.api_keys = old_keys
+        settings.isup_webhook_secret = old_secret
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid webhook secret"
+    assert engine.begin_conn.executed == []


### PR DESCRIPTION
### Motivation
- Remediate an authorization and verification gap in the ISUP integration where `/api/isup/callback` could be used to modify submission status without verifying a webhook secret, and `/api/isup/submissions/{project_id}` returned other projects' data without checking project membership.

### Description
- Require a configured `isup_webhook_secret` and validate incoming `X-ISUP-Webhook-Secret` using `secrets.compare_digest` in `api/routes/isup.py` before applying any status update to `isup_submissions`.
- Add `_require_project_access(project_id, request)` which validates `project_id` as a `UUID`, requires the JWT-populated `request.state.username`, and enforces project ownership/membership using `core.projects` before returning submissions.
- Update route signatures to accept `Request` where needed and add imports for `secrets`, `UUID`, and `get_projects_sessionmaker`/`Project` in `api/routes/isup.py`.
- Extend `tests/test_isup_callback.py` to set `settings.isup_webhook_secret`, include the webhook header in the happy-path test, add a rejection test for an invalid secret, and adapt the submissions test to use a JWT token while stubbing project-access in test scope.

### Testing
- Ran the ISUP route unit tests with `pytest -q tests/test_isup_callback.py` and observed `3 passed`.
- Tests cover successful callback update with the secret, rejection of an invalid secret, and the submissions polling flow (with test-scoped bypass of the access check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e161f7039c832f84fb97de1caa3525)