### PR TITLE
Validate Telegram webhook secret and pass `secret_token` to `set_webhook`

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@
 
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from hmac import compare_digest
 from typing import cast
 
 from aiogram.types import Update
@@ -61,7 +62,10 @@ async def lifespan(app: FastAPI):
     if settings.telegram_webhook_url and settings.bot_token:
         app.state.telegram_bot = create_bot()
         app.state.telegram_dp = create_dispatcher()
-        await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url)
+        webhook_kwargs: dict[str, str] = {}
+        if settings.telegram_webhook_secret:
+            webhook_kwargs["secret_token"] = settings.telegram_webhook_secret
+        await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url, **webhook_kwargs)
     print("🚀 Construction AI Core запускается...")
     yield
     await analytics_notifier.stop()
@@ -154,6 +158,15 @@ async def telegram_webhook_handler(request: Request) -> dict[str, bool]:
     dp = request.app.state.telegram_dp
     if bot is None or dp is None:
         raise HTTPException(status_code=503, detail="Telegram webhook is not configured")
+    if not settings.telegram_webhook_secret:
+        raise HTTPException(
+            status_code=503,
+            detail="Telegram webhook secret is not configured",
+        )
+
+    received_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    if not compare_digest(received_secret, settings.telegram_webhook_secret):
+        raise HTTPException(status_code=403, detail="Invalid Telegram webhook secret")
 
     payload = await request.json()
     update = Update.model_validate(payload, context={"bot": bot})

--- a/api/main.py
+++ b/api/main.py
@@ -62,10 +62,13 @@ async def lifespan(app: FastAPI):
     if settings.telegram_webhook_url and settings.bot_token:
         app.state.telegram_bot = create_bot()
         app.state.telegram_dp = create_dispatcher()
-        webhook_kwargs: dict[str, str] = {}
         if settings.telegram_webhook_secret:
-            webhook_kwargs["secret_token"] = settings.telegram_webhook_secret
-        await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url, **webhook_kwargs)
+            await app.state.telegram_bot.set_webhook(
+                settings.telegram_webhook_url,
+                secret_token=settings.telegram_webhook_secret,
+            )
+        else:
+            await app.state.telegram_bot.set_webhook(settings.telegram_webhook_url)
     print("🚀 Construction AI Core запускается...")
     yield
     await analytics_notifier.stop()

--- a/config/settings.py
+++ b/config/settings.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     core_api_url: str = "http://api:8000"
     telegram_bot_token: str = ""
     telegram_webhook_url: str = ""
+    telegram_webhook_secret: str = ""
     admin_telegram_ids: list[int] = []
     pto_engineer_telegram_ids: list[int] = []
     domain: str = "localhost"

--- a/telegram/main.py
+++ b/telegram/main.py
@@ -35,10 +35,13 @@ async def main() -> None:
         await dp.start_polling(bot)
         return
 
-    webhook_kwargs: dict[str, str] = {}
     if settings.telegram_webhook_secret:
-        webhook_kwargs["secret_token"] = settings.telegram_webhook_secret
-    await bot.set_webhook(settings.telegram_webhook_url, **webhook_kwargs)
+        await bot.set_webhook(
+            settings.telegram_webhook_url,
+            secret_token=settings.telegram_webhook_secret,
+        )
+    else:
+        await bot.set_webhook(settings.telegram_webhook_url)
     await asyncio.Event().wait()
 
 

--- a/telegram/main.py
+++ b/telegram/main.py
@@ -35,7 +35,10 @@ async def main() -> None:
         await dp.start_polling(bot)
         return
 
-    await bot.set_webhook(settings.telegram_webhook_url)
+    webhook_kwargs: dict[str, str] = {}
+    if settings.telegram_webhook_secret:
+        webhook_kwargs["secret_token"] = settings.telegram_webhook_secret
+    await bot.set_webhook(settings.telegram_webhook_url, **webhook_kwargs)
     await asyncio.Event().wait()
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,8 @@
 """Tests for API key middleware behavior."""
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -106,5 +108,67 @@ def test_cors_preflight_with_api_key_header_is_allowed():
         assert response.status_code == 200
         assert response.headers["access-control-allow-origin"] == "http://localhost:1420"
         assert "x-api-key" in response.headers["access-control-allow-headers"].lower()
+
+    asyncio.run(_run())
+
+
+def test_telegram_webhook_rejects_missing_secret_header(monkeypatch: pytest.MonkeyPatch):
+    """Webhook must reject requests without Telegram secret header."""
+
+    async def _run() -> None:
+        old_secret = settings.telegram_webhook_secret
+        old_bot = getattr(app.state, "telegram_bot", None)
+        old_dp = getattr(app.state, "telegram_dp", None)
+
+        settings.telegram_webhook_secret = "super-secret"
+        app.state.telegram_bot = object()
+        app.state.telegram_dp = SimpleNamespace(feed_update=AsyncMock())
+        monkeypatch.setattr("api.main.Update.model_validate", lambda payload, context: payload)
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/telegram/webhook", json={"update_id": 1})
+        finally:
+            settings.telegram_webhook_secret = old_secret
+            app.state.telegram_bot = old_bot
+            app.state.telegram_dp = old_dp
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Invalid Telegram webhook secret"}
+
+    asyncio.run(_run())
+
+
+def test_telegram_webhook_accepts_valid_secret_header(monkeypatch: pytest.MonkeyPatch):
+    """Webhook should accept Telegram updates with a valid secret header."""
+
+    async def _run() -> None:
+        old_secret = settings.telegram_webhook_secret
+        old_bot = getattr(app.state, "telegram_bot", None)
+        old_dp = getattr(app.state, "telegram_dp", None)
+        feed_update = AsyncMock()
+
+        settings.telegram_webhook_secret = "super-secret"
+        app.state.telegram_bot = object()
+        app.state.telegram_dp = SimpleNamespace(feed_update=feed_update)
+        monkeypatch.setattr("api.main.Update.model_validate", lambda payload, context: payload)
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/telegram/webhook",
+                    json={"update_id": 1},
+                    headers={"X-Telegram-Bot-Api-Secret-Token": "super-secret"},
+                )
+        finally:
+            settings.telegram_webhook_secret = old_secret
+            app.state.telegram_bot = old_bot
+            app.state.telegram_dp = old_dp
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        feed_update.assert_awaited_once()
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation

- Protect the Telegram webhook endpoint from unauthorized requests by requiring and validating a shared secret token.
- Ensure the bot webhook registration uses the same secret so Telegram includes the header when delivering updates.
- Prevent timing-attack risks during secret comparison by using a constant-time comparison.

### Description

- Added `telegram_webhook_secret` setting to `Settings` in `config/settings.py`.
- Updated webhook registration in `api/main.py` and `telegram/main.py` to pass `secret_token` to `Bot.set_webhook` when `telegram_webhook_secret` is set.
- Implemented validation in the `/telegram/webhook` handler to return `503` if the secret is not configured and `403` if the `X-Telegram-Bot-Api-Secret-Token` header does not match using `hmac.compare_digest`.
- Extended `tests/test_middleware.py` with two tests: `test_telegram_webhook_rejects_missing_secret_header` and `test_telegram_webhook_accepts_valid_secret_header`, and added necessary mocks (`SimpleNamespace`, `AsyncMock`) to simulate `app.state.telegram_dp.feed_update`.

### Testing

- Ran the updated test module with `pytest tests/test_middleware.py` and the new webhook tests `test_telegram_webhook_rejects_missing_secret_header` and `test_telegram_webhook_accepts_valid_secret_header` passed.
- Existing middleware and CORS-related tests in `tests/test_middleware.py` were also exercised and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33d156a10832f82e43c21c146b8f0)