### PR TITLE
Harden ISUP routes with project authorization checks

### DIFF
--- a/api/routes/isup.py
+++ b/api/routes/isup.py
@@ -37,10 +37,50 @@ class ISUPCallbackPayload(BaseModel):
     comment: str = ""
 
 
+def _require_isup_project_access(request: Request, project_id: str) -> None:
+    """Проверить доступ к операциям ИСУП в рамках проекта."""
+    username = getattr(request.state, "username", None)
+    user_role = str(getattr(request.state, "user_role", "") or "")
+    if not username:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if user_role == "admin":
+        return
+
+    engine = create_engine(settings.database_url, future=True)
+    query = text(
+        """
+        SELECT owner_id, members
+        FROM projects
+        WHERE id = :project_id
+        LIMIT 1
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(query, {"project_id": project_id}).mappings().first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    owner_id = str(row.get("owner_id") or "")
+    members_raw = row.get("members")
+    members: list[str] = []
+    if isinstance(members_raw, list):
+        members = [str(member) for member in members_raw]
+    elif isinstance(members_raw, str):
+        try:
+            parsed = json.loads(members_raw)
+        except json.JSONDecodeError:
+            parsed = []
+        if isinstance(parsed, list):
+            members = [str(member) for member in parsed]
+
+    if str(username) != owner_id and str(username) not in members:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
 @router.post("/submit-document")
 async def submit_document(payload: SubmitDocumentRequest, request: Request) -> dict:
     """Передать ИД-документ в ИСУП."""
-    _ = request
     if not settings.isup_enabled:
         raise HTTPException(status_code=503, detail="ISUP integration is disabled")
 
@@ -51,6 +91,8 @@ async def submit_document(payload: SubmitDocumentRequest, request: Request) -> d
     if doc_payload["project_id"] != payload.project_id:
         raise HTTPException(status_code=400, detail="project_id does not match doc")
 
+    _require_isup_project_access(request, payload.project_id)
+
     result = await ISUPClient().submit_document(doc_payload)
     return {"ok": True, "result": result}
 
@@ -58,9 +100,10 @@ async def submit_document(payload: SubmitDocumentRequest, request: Request) -> d
 @router.post("/submit-album")
 async def submit_album(payload: SubmitAlbumRequest, request: Request) -> dict:
     """Передать исполнительный альбом в ИСУП."""
-    _ = request
     if not settings.isup_enabled:
         raise HTTPException(status_code=503, detail="ISUP integration is disabled")
+
+    _require_isup_project_access(request, payload.project_id)
 
     result = await ISUPClient().submit_exec_album(payload.project_id, payload.section)
     return {"ok": True, "result": result}
@@ -69,9 +112,24 @@ async def submit_album(payload: SubmitAlbumRequest, request: Request) -> dict:
 @router.get("/status/{submission_id}")
 async def get_status(submission_id: str, request: Request) -> dict:
     """Получить статус отправки в ИСУП."""
-    _ = request
     if not settings.isup_enabled:
         raise HTTPException(status_code=503, detail="ISUP integration is disabled")
+
+    engine = create_engine(settings.database_url, future=True)
+    query = text(
+        """
+        SELECT project_id
+        FROM isup_submissions
+        WHERE submission_id = :submission_id
+        LIMIT 1
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(query, {"submission_id": submission_id}).mappings().first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    _require_isup_project_access(request, str(row["project_id"]))
 
     result = await ISUPClient().get_submission_status(submission_id)
     return {"ok": True, "result": result}

--- a/tests/test_isup_auth.py
+++ b/tests/test_isup_auth.py
@@ -1,0 +1,121 @@
+"""Authorization tests for ISUP submission routes."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import isup as isup_routes
+from api.routes.auth import _create_token
+from config.settings import settings
+
+
+class _FakeRowResult:
+    def __init__(self, row: dict[str, object] | None):
+        self._row = row
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._row
+
+
+class _FakeConn:
+    def __init__(self, row: dict[str, object] | None):
+        self._row = row
+
+    def execute(self, query, params):
+        _ = (query, params)
+        return _FakeRowResult(self._row)
+
+
+class _FakeConnectContext:
+    def __init__(self, conn: _FakeConn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self._conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+class _FakeEngine:
+    def __init__(self, row: dict[str, object] | None):
+        self._row = row
+
+    def connect(self):
+        return _FakeConnectContext(_FakeConn(self._row))
+
+
+def test_submit_document_rejects_api_key_without_user_context(monkeypatch):
+    old_enabled = settings.isup_enabled
+    old_keys = settings.api_keys
+    settings.isup_enabled = True
+    settings.api_keys = ["test-key"]
+
+    monkeypatch.setattr(
+        isup_routes,
+        "_fetch_doc_payload",
+        lambda doc_id: {"doc_id": doc_id, "project_id": "project-1"},
+    )
+
+    class _Client:
+        async def submit_document(self, doc_payload):
+            _ = doc_payload
+            return {"submission_id": "sub-1"}
+
+    monkeypatch.setattr(isup_routes, "ISUPClient", lambda: _Client())
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/isup/submit-document",
+                json={"project_id": "project-1", "doc_id": "doc-1"},
+                headers={"X-API-Key": "test-key"},
+            )
+    finally:
+        settings.isup_enabled = old_enabled
+        settings.api_keys = old_keys
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+def test_submit_document_allows_member_with_jwt(monkeypatch):
+    old_enabled = settings.isup_enabled
+    settings.isup_enabled = True
+    token = _create_token("member", "pto_engineer")
+
+    monkeypatch.setattr(
+        isup_routes,
+        "_fetch_doc_payload",
+        lambda doc_id: {"doc_id": doc_id, "project_id": "project-1"},
+    )
+    monkeypatch.setattr(
+        isup_routes,
+        "create_engine",
+        lambda *args, **kwargs: _FakeEngine({"owner_id": "owner", "members": ["member"]}),
+    )
+
+    class _Client:
+        async def submit_document(self, doc_payload):
+            _ = doc_payload
+            return {"submission_id": "sub-1", "status": "accepted"}
+
+    monkeypatch.setattr(isup_routes, "ISUPClient", lambda: _Client())
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/isup/submit-document",
+                json={"project_id": "project-1", "doc_id": "doc-1"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+    finally:
+        settings.isup_enabled = old_enabled
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert response.json()["result"]["submission_id"] == "sub-1"


### PR DESCRIPTION
### Motivation
- The ISUP integration routes were calling external APIs using `project_id`/`doc_id`/`submission_id` without verifying that the caller is a project member or admin, enabling IDOR-style access and unauthorized submissions. 
- The goal is to enforce per-project authorization consistent with other project routes while preserving admin bypass and existing ISUP client behavior.

### Description
- Added a helper ` _require_isup_project_access(request, project_id)` in `api/routes/isup.py` that requires an authenticated JWT user, allows `admin` role bypass, and verifies owner/member membership by querying the `projects` table. 
- Enforced the guard in `POST /api/isup/submit-document`, `POST /api/isup/submit-album`, and `GET /api/isup/status/{submission_id}` (the latter resolves the submission’s `project_id` from `isup_submissions` before checking). 
- Preserved existing checks for `settings.isup_enabled` and document/project consistency, and retained existing calls to `ISUPClient`. 
- Added regression tests in `tests/test_isup_auth.py` that assert API-key-only requests are rejected (`401`) and JWT-authenticated project members can submit (`200`).

### Testing
- Ran `pytest -q tests/test_isup_auth.py tests/test_isup_callback.py` which completed successfully. 
- Test summary: `4 passed` (all new and related callback/submissions tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16384dbbc832fb32285d59f03d87e)