### PR TITLE
Remove service metrics from assistant reply and expose conflict_rate as metadata

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -27,6 +27,7 @@ class ChatResponse(BaseModel):
     session_id: str
     agents_used: list[str] = []
     confidence: float | None = None
+    conflict_rate: float | None = None
 
 
 @router.post(
@@ -67,4 +68,5 @@ async def chat(
         session_id=str(result.get("session_id", session_id)),
         agents_used=list(result.get("agents_used", [])),
         confidence=result.get("confidence"),
+        conflict_rate=result.get("conflict_rate"),
     )

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -194,7 +194,14 @@ class Orchestrator:
         """Удалить служебные метрики из текста ответа."""
         if not raw_reply:
             return ""
-        return METRICS_PATTERN.sub("", raw_reply).strip()
+        without_inline_metrics = METRICS_PATTERN.sub("", raw_reply)
+        without_metric_lines = re.sub(
+            r"^\s*Метрика \w+:\s*.+$",
+            "",
+            without_inline_metrics,
+            flags=re.MULTILINE | re.UNICODE,
+        )
+        return re.sub(r"\n{3,}", "\n\n", without_metric_lines).strip()
 
     async def _run_pipeline(
         self,
@@ -281,12 +288,14 @@ class Orchestrator:
         last_output = ""
         if history and isinstance(history[-1], dict):
             last_output = str(history[-1].get("output", ""))
-        clean_reply = self._clean_reply(last_output)
+        raw_reply = last_output or str(final_state.get("final_output", "") or "")
+        clean_reply = self._clean_reply(raw_reply)
         result_payload = {
             "reply": clean_reply,
             "session_id": session_id,
             "agents_used": pipeline,
             "confidence": final_state.get("confidence"),
+            "conflict_rate": final_state.get("conflict_rate"),
             "state": final_state,
         }
         if tk_bridge_result:

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -13,6 +13,7 @@ export interface ChatResponse {
   session_id?: string;
   agents_used?: string[];
   confidence?: number | null;
+  conflict_rate?: number | null;
 }
 
 export interface ChatResponseMeta {

--- a/desktop/src/components/MessageBubble.tsx
+++ b/desktop/src/components/MessageBubble.tsx
@@ -1,9 +1,13 @@
 import type { ChatMessage } from '../store/chatStore';
-import type { ChatResponseMeta } from '../api/coreClient';
+
+export interface MessageMetadata {
+  agents?: string[];
+  confidence?: number;
+}
 
 interface Props {
   message: ChatMessage;
-  metadata?: ChatResponseMeta;
+  metadata?: MessageMetadata;
 }
 
 function getConfidenceBadge(confidence?: number) {


### PR DESCRIPTION
### Motivation
- Prevent service/diagnostic metric strings like `Метрика ...` from appearing in the human-readable `reply` text returned to clients.
- Keep numeric metrics (`confidence`, `conflict_rate`, `agents_used`) as structured metadata fields instead of inline text.
- Ensure frontend type definitions match backend response shape so UI can render `agents_used` and `confidence`/`conflict_rate` reliably.

### Description
- Strengthened reply sanitization in `Orchestrator._clean_reply` to remove both inline metric fragments (via `METRICS_PATTERN`) and full metric lines, and to normalize excessive blank lines before returning the cleaned `reply`.
- Use a fallback `final_output` when `history[-1].output` is empty so the same cleaning is always applied to the pipeline result in `_run_pipeline`.
- Return `conflict_rate` from the orchestrator result payload as a separate field rather than leaving metric text in `reply`.
- Updated API model in `api/routes/chat.py` to include `conflict_rate` in `ChatResponse` and to populate it from the orchestrator result.
- Synchronized desktop typings in `desktop/src/api/coreClient.ts` by adding optional `conflict_rate` to `ChatResponse` and tightened `MessageBubble` props typing by introducing `MessageMetadata` in `desktop/src/components/MessageBubble.tsx`.

### Testing
- Ran `python -m compileall core/orchestrator.py api/routes/chat.py` and it completed successfully.
- Ran desktop build via `npm --prefix desktop run -s build` and it completed successfully.
- Attempted `npm --prefix desktop run -s typecheck`, which failed because the project has no `typecheck` script (no typecheck step was present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3407b8a38832f86915adf259f659f)