### PR TITLE
feat(desktop): add minimal design system for desktop UI

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { getApiConfig } from './api/coreClient';
 import Sidebar from './components/Sidebar';
 import { resolveRoute } from './router';
+import { colors, spacing, typography } from './styles/tokens';
 import type { BrandingConfig } from './store/brandingStore';
 import { useBrandingStore } from './store/brandingStore';
 
@@ -62,19 +63,22 @@ export default function App() {
   const appTheme = useMemo(
     () => ({
       minHeight: '100vh',
-      padding: 16,
-      fontFamily: 'Inter, Arial, sans-serif',
+      fontFamily: typography.fontFamily,
       display: 'flex',
-      gap: 16,
-      borderTop: `4px solid ${branding?.primary_color ?? '#2563eb'}`
+      gap: spacing.lg,
+      borderTop: `4px solid ${branding?.primary_color ?? '#2563eb'}`,
+      background: colors.bgPage
     }),
     [branding?.primary_color]
   );
 
   return (
-    <main style={appTheme}>
-      <Sidebar currentPath={currentPath} onNavigate={navigate} />
-      <section style={{ flex: 1 }}>{resolveRoute(currentPath, () => navigate('/'))}</section>
-    </main>
+    <>
+      <style>{`*, *::before, *::after { box-sizing: border-box; } body { margin: 0; }`}</style>
+      <main style={appTheme}>
+        <Sidebar currentPath={currentPath} onNavigate={navigate} />
+        <section style={{ flex: 1, padding: spacing.lg }}>{resolveRoute(currentPath, () => navigate('/'))}</section>
+      </main>
+    </>
   );
 }

--- a/desktop/src/components/DocumentForm.tsx
+++ b/desktop/src/components/DocumentForm.tsx
@@ -1,4 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import Button from './ui/Button';
+import Input from './ui/Input';
+import { colors, radius, spacing, typography } from '../styles/tokens';
 
 export type DocumentFieldType = 'text' | 'number' | 'select' | 'textarea';
 
@@ -48,59 +51,74 @@ export default function DocumentForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} style={{ display: 'grid', gap: 12, maxWidth: 700 }}>
+    <form onSubmit={handleSubmit} style={{ display: 'grid', gap: spacing.md, maxWidth: 700 }}>
       {fields.map((field) => (
-        <label key={field.name} style={{ display: 'grid', gap: 6 }}>
-          <span>{field.label}</span>
+        <div key={field.name}>
           {field.type === 'textarea' ? (
-            <textarea
+            <Input
+              type="textarea"
               rows={6}
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
               placeholder={field.placeholder}
               disabled={disabledOnLoading && isLoading}
               required
+              label={field.label}
             />
           ) : field.type === 'select' ? (
-            <select
-              value={values[field.name] ?? ''}
-              onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
-              disabled={disabledOnLoading && isLoading}
-              required
-            >
-              <option value="" disabled>
-                Выберите значение
-              </option>
-              {(field.options ?? []).map((option) => (
-                <option key={option} value={option}>
-                  {option}
+            <label style={{ display: 'grid', gap: spacing.xs }}>
+              <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
+                {field.label}
+              </span>
+              <select
+                value={values[field.name] ?? ''}
+                onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
+                disabled={disabledOnLoading && isLoading}
+                required
+                style={{
+                  width: '100%',
+                  borderRadius: radius.md,
+                  border: `1px solid ${colors.border}`,
+                  padding: `${spacing.sm}px ${spacing.md}px`,
+                  fontFamily: typography.fontFamily,
+                  fontSize: typography.body.fontSize
+                }}
+              >
+                <option value="" disabled>
+                  Выберите значение
                 </option>
-              ))}
-            </select>
+                {(field.options ?? []).map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
           ) : (
-            <input
+            <Input
               type={field.type}
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
               placeholder={field.placeholder}
               disabled={disabledOnLoading && isLoading}
               required
+              label={field.label}
             />
           )}
-        </label>
+        </div>
       ))}
 
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <button type="submit" disabled={disabledOnLoading && isLoading}>
-          {isLoading ? '⏳ Сгенерировать' : 'Сгенерировать'}
-        </button>
-        <button type="button" onClick={handleClear} disabled={disabledOnLoading && isLoading}>
+      <div style={{ display: 'flex', gap: spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
+        <Button type="submit" loading={isLoading} disabled={disabledOnLoading && isLoading}>
+          {isLoading ? 'Сгенерировать...' : 'Сгенерировать'}
+        </Button>
+        <Button type="button" variant="secondary" onClick={handleClear} disabled={disabledOnLoading && isLoading}>
           Очистить
-        </button>
+        </Button>
         {isLoading && <span role="status">⏳ Генерация...</span>}
       </div>
       {error && error.includes('Failed to fetch') && (
-        <p style={{ color: '#8a6d3b' }}>Проверьте API URL и API Key в разделе Настройки</p>
+        <p style={{ color: colors.warning }}>Проверьте API URL и API Key в разделе Настройки</p>
       )}
     </form>
   );

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -1,10 +1,12 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useChatStore } from '../store/chatStore';
+import Button from './ui/Button';
+import { colors, radius, spacing, typography } from '../styles/tokens';
 
 interface NavItem {
   path: string;
   label: string;
-  icon?: ReactNode;
+  icon: ReactNode;
 }
 
 interface SidebarProps {
@@ -12,69 +14,99 @@ interface SidebarProps {
   onNavigate: (path: string) => void;
 }
 
-function CheckBadgeIcon() {
+function BaseIcon({ children }: { children: ReactNode }) {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.8}
-      style={{ width: 18, height: 18 }}
-      aria-hidden
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-3.75-7.5a2.25 2.25 0 0 0-2.25-2.25h-6a2.25 2.25 0 0 0-2.25 2.25v.372a2.25 2.25 0 0 1-.659 1.591l-.264.264a2.25 2.25 0 0 0 0 3.182l.264.264c.422.422.659.995.659 1.591v.372a2.25 2.25 0 0 0 2.25 2.25h6a2.25 2.25 0 0 0 2.25-2.25v-.372c0-.597.237-1.169.659-1.591l.264-.264a2.25 2.25 0 0 0 0-3.182l-.264-.264a2.25 2.25 0 0 1-.659-1.591v-.372Z"
-      />
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} style={{ width: 18, height: 18 }} aria-hidden>
+      {children}
     </svg>
   );
 }
 
+const ChatIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M8.625 9.75h6.75m-6.75 3h4.5m6.375-.75a8.25 8.25 0 1 1-3.955-7.052c.707.42 1.61.183 2.023-.524a.75.75 0 0 1 1.3.75A9.733 9.733 0 0 0 21 12c0 5.385-4.365 9.75-9.75 9.75A9.75 9.75 0 0 1 1.5 12c0-5.385 4.365-9.75 9.75-9.75 1.804 0 3.494.49 4.945 1.343" /></BaseIcon>;
+const SettingsIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M11.983 5.25c.483-1.041 1.964-1.041 2.447 0l.407.877a1.5 1.5 0 0 0 1.126.84l.969.142c1.15.168 1.607 1.58.774 2.392l-.701.684a1.5 1.5 0 0 0-.43 1.328l.166.963c.197 1.146-1.007 2.02-2.035 1.48l-.866-.455a1.5 1.5 0 0 0-1.396 0l-.866.455c-1.028.54-2.232-.334-2.035-1.48l.166-.963a1.5 1.5 0 0 0-.43-1.328l-.701-.684c-.833-.812-.376-2.224.774-2.392l.969-.142a1.5 1.5 0 0 0 1.126-.84l.406-.877ZM13.2 12a1.2 1.2 0 1 1-2.4 0 1.2 1.2 0 0 1 2.4 0Z" /></BaseIcon>;
+const TKIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M7.5 3.75h6l3 3v13.5H7.5V3.75Zm6 0v3h3M9.75 14.25l4.5-4.5 1.5 1.5-4.5 4.5H9.75v-1.5Z" /></BaseIcon>;
+const LetterIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5v10.5H3.75V6.75Zm0 0 8.25 6 8.25-6" /></BaseIcon>;
+const KSIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 5.25h15v13.5h-15V5.25Zm0 4.5h15M10.5 5.25v13.5" /></BaseIcon>;
+const HandoverIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></BaseIcon>;
+
 const navItems: NavItem[] = [
-  { path: '/', label: 'Чат' },
-  { path: '/settings', label: 'Настройки' },
-  { path: '/generate/tk', label: 'Генерация ТК' },
-  { path: '/generate/letter', label: 'Генерация письма' },
-  { path: '/generate/ks', label: 'Генерация КС' },
-  { path: '/handover', label: 'Сдача объекта', icon: <CheckBadgeIcon /> }
+  { path: '/', label: 'Чат', icon: <ChatIcon /> },
+  { path: '/settings', label: 'Настройки', icon: <SettingsIcon /> },
+  { path: '/generate/tk', label: 'Генерация ТК', icon: <TKIcon /> },
+  { path: '/generate/letter', label: 'Генерация письма', icon: <LetterIcon /> },
+  { path: '/generate/ks', label: 'Генерация КС', icon: <KSIcon /> },
+  { path: '/handover', label: 'Сдача объекта', icon: <HandoverIcon /> }
 ];
 
 export default function Sidebar({ currentPath, onNavigate }: SidebarProps) {
   const sessions = useChatStore((s) => s.sessions);
   const resetSession = useChatStore((s) => s.resetSession);
+  const [hoveredSession, setHoveredSession] = useState<string | null>(null);
 
   return (
-    <aside style={{ minWidth: 260, borderRight: '1px solid #ddd', paddingRight: 12 }}>
-      <h3 style={{ marginTop: 0 }}>Разделы</h3>
-      <nav style={{ display: 'grid', gap: 6, marginBottom: 12 }}>
-        {navItems.map((item) => (
-          <button
-            key={item.path}
-            onClick={() => onNavigate(item.path)}
-            style={{
-              textAlign: 'left',
-              fontWeight: currentPath === item.path ? 700 : 400,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8
-            }}
-          >
-            {item.icon}
-            {item.label}
-          </button>
-        ))}
+    <aside style={{ minWidth: 240, borderRight: `1px solid ${colors.border}`, padding: spacing.md, background: colors.bgSidebar, borderRadius: radius.lg }}>
+      <h3 style={{ margin: 0, marginBottom: spacing.md }}>Разделы</h3>
+      <nav style={{ display: 'grid', gap: spacing.xs, marginBottom: spacing.lg }}>
+        {navItems.map((item) => {
+          const active = currentPath === item.path;
+          return (
+            <button
+              key={item.path}
+              type="button"
+              onClick={() => onNavigate(item.path)}
+              style={{
+                textAlign: 'left',
+                fontWeight: active ? 600 : 500,
+                display: 'flex',
+                alignItems: 'center',
+                gap: spacing.sm,
+                border: 'none',
+                borderLeft: `3px solid ${active ? colors.primary : 'transparent'}`,
+                background: active ? colors.bgActiveNav : 'transparent',
+                color: colors.textPrimary,
+                borderRadius: radius.md,
+                padding: `${spacing.sm}px ${spacing.sm}px ${spacing.sm}px ${spacing.md}`,
+                cursor: 'pointer',
+                fontFamily: typography.fontFamily
+              }}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          );
+        })}
       </nav>
 
-      <button onClick={resetSession} style={{ width: '100%', marginBottom: 10 }}>
+      <Button onClick={resetSession} style={{ width: '100%', marginBottom: spacing.md }}>
         + Новая сессия
-      </button>
-      <h3>История сессий</h3>
-      <ul style={{ paddingInlineStart: 20 }}>
-        {sessions.map((session) => (
-          <li key={session.id}>{session.title}</li>
-        ))}
+      </Button>
+      <h3 style={{ marginTop: 0, marginBottom: spacing.sm }}>История сессий</h3>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: spacing.xs }}>
+        {sessions.map((session) => {
+          const isHovered = hoveredSession === session.id;
+          return (
+            <li key={session.id}>
+              <button
+                type="button"
+                onClick={() => undefined}
+                onMouseEnter={() => setHoveredSession(session.id)}
+                onMouseLeave={() => setHoveredSession(null)}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  border: `1px solid ${isHovered ? colors.primary : colors.border}`,
+                  borderRadius: radius.sm,
+                  background: isHovered ? '#eff6ff' : '#fff',
+                  color: colors.textSecondary,
+                  padding: `${spacing.xs}px ${spacing.sm}px`,
+                  cursor: 'pointer'
+                }}
+              >
+                {session.title}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </aside>
   );

--- a/desktop/src/components/ui/Button.tsx
+++ b/desktop/src/components/ui/Button.tsx
@@ -1,0 +1,141 @@
+import { type ButtonHTMLAttributes, useMemo, useState } from 'react';
+import { colors, radius, spacing, typography } from '../../styles/tokens';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+}
+
+const sizeStyles: Record<ButtonSize, { padding: string; fontSize: number }> = {
+  sm: { padding: `${spacing.xs}px ${spacing.md}px`, fontSize: 12 },
+  md: { padding: `${spacing.sm}px ${spacing.lg}px`, fontSize: 14 },
+  lg: { padding: `${spacing.md}px ${spacing.xl}px`, fontSize: 15 }
+};
+
+const variantStyles: Record<ButtonVariant, { bg: string; color: string; border: string; hoverBg: string; activeBg: string }> = {
+  primary: {
+    bg: colors.primary,
+    color: '#fff',
+    border: colors.primary,
+    hoverBg: colors.primaryHover,
+    activeBg: colors.primaryActive
+  },
+  secondary: {
+    bg: '#fff',
+    color: colors.textPrimary,
+    border: colors.border,
+    hoverBg: '#f3f4f6',
+    activeBg: '#e5e7eb'
+  },
+  ghost: {
+    bg: 'transparent',
+    color: colors.textPrimary,
+    border: 'transparent',
+    hoverBg: '#f3f4f6',
+    activeBg: '#e5e7eb'
+  },
+  danger: {
+    bg: colors.error,
+    color: '#fff',
+    border: colors.error,
+    hoverBg: '#991b1b',
+    activeBg: '#7f1d1d'
+  }
+};
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: 14,
+        height: 14,
+        borderRadius: '50%',
+        border: '2px solid rgba(255, 255, 255, 0.55)',
+        borderTopColor: 'currentColor',
+        display: 'inline-block',
+        animation: 'ui-spin 0.8s linear infinite'
+      }}
+    />
+  );
+}
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled,
+  children,
+  onMouseEnter,
+  onMouseLeave,
+  onMouseDown,
+  onMouseUp,
+  style,
+  ...rest
+}: ButtonProps) {
+  const [isHovered, setHovered] = useState(false);
+  const [isActive, setActive] = useState(false);
+  const isDisabled = disabled || loading;
+
+  const palette = variantStyles[variant];
+  const currentBg = useMemo(() => {
+    if (isDisabled) {
+      return variant === 'ghost' ? 'transparent' : '#9ca3af';
+    }
+    if (isActive) return palette.activeBg;
+    if (isHovered) return palette.hoverBg;
+    return palette.bg;
+  }, [isDisabled, isActive, isHovered, palette, variant]);
+
+  return (
+    <>
+      <style>{'@keyframes ui-spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }'}</style>
+      <button
+        {...rest}
+        disabled={isDisabled}
+        onMouseEnter={(event) => {
+          setHovered(true);
+          onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          setHovered(false);
+          setActive(false);
+          onMouseLeave?.(event);
+        }}
+        onMouseDown={(event) => {
+          setActive(true);
+          onMouseDown?.(event);
+        }}
+        onMouseUp={(event) => {
+          setActive(false);
+          onMouseUp?.(event);
+        }}
+        style={{
+          borderRadius: radius.md,
+          border: `1px solid ${palette.border}`,
+          background: currentBg,
+          color: palette.color,
+          cursor: isDisabled ? 'not-allowed' : 'pointer',
+          fontFamily: typography.fontFamily,
+          fontWeight: 600,
+          lineHeight: 1.2,
+          opacity: isDisabled ? 0.8 : 1,
+          transition: 'background-color 0.12s ease, transform 0.08s ease, opacity 0.12s ease',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: spacing.sm,
+          ...(sizeStyles[size] ?? sizeStyles.md),
+          ...style
+        }}
+      >
+        {loading && <Spinner />}
+        {children}
+      </button>
+    </>
+  );
+}

--- a/desktop/src/components/ui/Card.tsx
+++ b/desktop/src/components/ui/Card.tsx
@@ -1,0 +1,25 @@
+import { type PropsWithChildren } from 'react';
+import { colors, radius, spacing } from '../../styles/tokens';
+
+interface CardProps extends PropsWithChildren {
+  padding?: keyof typeof spacing;
+  shadow?: boolean;
+  style?: React.CSSProperties;
+}
+
+export default function Card({ children, padding = 'lg', shadow = true, style }: CardProps) {
+  return (
+    <section
+      style={{
+        background: colors.bgCard,
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.lg,
+        padding: spacing[padding],
+        boxShadow: shadow ? '0 6px 16px rgba(15, 23, 42, 0.08)' : 'none',
+        ...style
+      }}
+    >
+      {children}
+    </section>
+  );
+}

--- a/desktop/src/components/ui/Input.tsx
+++ b/desktop/src/components/ui/Input.tsx
@@ -1,0 +1,75 @@
+import { type InputHTMLAttributes, type TextareaHTMLAttributes, useState } from 'react';
+import { colors, radius, spacing, typography } from '../../styles/tokens';
+
+type BaseProps = {
+  label?: string;
+  error?: string;
+  hint?: string;
+  type?: InputHTMLAttributes<HTMLInputElement>['type'] | 'textarea';
+};
+
+type InputProps = BaseProps & InputHTMLAttributes<HTMLInputElement> & TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export default function Input({ label, error, hint, type = 'text', style, ...rest }: InputProps) {
+  const [isFocused, setFocused] = useState(false);
+  const message = error ?? hint;
+
+  const commonStyle = {
+    width: '100%',
+    borderRadius: radius.md,
+    border: `1px solid ${error ? colors.error : isFocused ? colors.borderFocus : colors.border}`,
+    padding: `${spacing.sm}px ${spacing.md}px`,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.body.fontSize,
+    lineHeight: String(typography.body.lineHeight),
+    color: colors.textPrimary,
+    outline: 'none',
+    background: '#fff',
+    transition: 'border-color 0.12s ease, box-shadow 0.12s ease',
+    boxShadow: isFocused ? `0 0 0 3px ${colors.primary}22` : 'none',
+    ...style
+  } as const;
+
+  return (
+    <label style={{ display: 'grid', gap: spacing.xs }}>
+      {label && (
+        <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
+          {label}
+        </span>
+      )}
+      {type === 'textarea' ? (
+        <textarea
+          {...(rest as TextareaHTMLAttributes<HTMLTextAreaElement>)}
+          onFocus={(event) => {
+            setFocused(true);
+            rest.onFocus?.(event);
+          }}
+          onBlur={(event) => {
+            setFocused(false);
+            rest.onBlur?.(event);
+          }}
+          style={commonStyle}
+        />
+      ) : (
+        <input
+          {...(rest as InputHTMLAttributes<HTMLInputElement>)}
+          type={type}
+          onFocus={(event) => {
+            setFocused(true);
+            rest.onFocus?.(event);
+          }}
+          onBlur={(event) => {
+            setFocused(false);
+            rest.onBlur?.(event);
+          }}
+          style={commonStyle}
+        />
+      )}
+      {message && (
+        <span style={{ color: error ? colors.error : colors.textSecondary, fontSize: typography.small.fontSize }}>
+          {message}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/desktop/src/pages/ChatPage.tsx
+++ b/desktop/src/pages/ChatPage.tsx
@@ -1,11 +1,14 @@
 import ChatWindow from '../components/ChatWindow';
 import RoleSelector from '../components/RoleSelector';
+import Card from '../components/ui/Card';
 
 export default function ChatPage() {
   return (
-    <div style={{ display: 'grid', gap: 12 }}>
-      <RoleSelector />
-      <ChatWindow />
-    </div>
+    <Card>
+      <div style={{ display: 'grid', gap: 12 }}>
+        <RoleSelector />
+        <ChatWindow />
+      </div>
+    </Card>
   );
 }

--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import Input from '../components/ui/Input';
+import { colors, spacing } from '../styles/tokens';
 import { downloadKSDocx, generateKS, getApiConfig, type KSWorkItem } from '../api/coreClient';
 
 const fields: DocumentField[] = [
@@ -159,39 +163,38 @@ export default function GenerateKSPage() {
   };
 
   return (
-    <section style={{ display: 'grid', gap: 12 }}>
-      <h2>Генерация КС</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
-      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ КС сгенерирована</p>}
-      {error && <p style={{ color: 'crimson' }}>{error}</p>}
-      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
-      {summary && (
-        <table style={{ borderCollapse: 'collapse', width: '100%', maxWidth: 700 }}>
-          <thead>
-            <tr>
-              <th style={{ border: '1px solid #ddd', padding: 8 }}>ks2 (стоимость)</th>
-              <th style={{ border: '1px solid #ddd', padding: 8 }}>ks3 (выполнение)</th>
-              <th style={{ border: '1px solid #ddd', padding: 8 }}>total_cost</th>
-              <th style={{ border: '1px solid #ddd', padding: 8 }}>total_hours</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.ks2 || '—'}</td>
-              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.ks3 || '—'}</td>
-              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.total_cost || '—'}</td>
-              <td style={{ border: '1px solid #ddd', padding: 8 }}>{summary.total_hours || '—'}</td>
-            </tr>
-          </tbody>
-        </table>
-      )}
-      <label style={{ display: 'grid', gap: 8 }}>
-        <span>Результат</span>
-        <textarea value={result} rows={12} readOnly />
-      </label>
-      <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
-        {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
-      </button>
-    </section>
+    <Card>
+      <section style={{ display: 'grid', gap: spacing.md }}>
+        <h2>Генерация КС</h2>
+        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ КС сгенерирована</p>}
+        {error && <p style={{ color: colors.error }}>{error}</p>}
+        {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
+        {summary && (
+          <table style={{ borderCollapse: 'collapse', width: '100%', maxWidth: 700 }}>
+            <thead>
+              <tr>
+                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>ks2 (стоимость)</th>
+                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>ks3 (выполнение)</th>
+                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>total_cost</th>
+                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>total_hours</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.ks2 || '—'}</td>
+                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.ks3 || '—'}</td>
+                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.total_cost || '—'}</td>
+                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.total_hours || '—'}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+        <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
+        <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
+          {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
+        </Button>
+      </section>
+    </Card>
   );
 }

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import Input from '../components/ui/Input';
+import { colors, spacing } from '../styles/tokens';
 import { downloadLetterDocx, generateLetter, getApiConfig } from '../api/coreClient';
-
 
 const letterTypeMap: Record<string, 'запрос' | 'претензия' | 'уведомление' | 'ответ'> = {
   Запрос: 'запрос',
@@ -91,19 +94,20 @@ export default function GenerateLetterPage() {
   };
 
   return (
-    <section style={{ display: 'grid', gap: 12 }}>
-      <h2>Генерация письма</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
-      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ Письмо сгенерировано</p>}
-      {error && <p style={{ color: 'crimson' }}>{error}</p>}
-      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
-      <label style={{ display: 'grid', gap: 8 }}>
-        <span>Результат</span>
-        <textarea value={result} rows={12} readOnly />
-      </label>
-      <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
-        {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
-      </button>
-    </section>
+    <Card>
+      <section style={{ display: 'grid', gap: spacing.md }}>
+        <h2>Генерация письма</h2>
+        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ Письмо сгенерировано</p>}
+        {error && <p style={{ color: colors.error }}>{error}</p>}
+        {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
+
+        <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
+
+        <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
+          {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
+        </Button>
+      </section>
+    </Card>
   );
 }

--- a/desktop/src/pages/GenerateTKPage.tsx
+++ b/desktop/src/pages/GenerateTKPage.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import Input from '../components/ui/Input';
+import { colors, spacing } from '../styles/tokens';
 import { downloadTKDocx, generateTK, getApiConfig } from '../api/coreClient';
 
 const fields: DocumentField[] = [
@@ -80,25 +84,22 @@ export default function GenerateTKPage() {
   };
 
   return (
-    <section style={{ display: 'grid', gap: 12 }}>
-      <h2>Генерация ТК</h2>
-      <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
-      {success && <p style={{ color: 'green', fontWeight: 600 }}>✓ ТК сгенерирована</p>}
-      {error && <p style={{ color: 'crimson' }}>{error}</p>}
-      {sessionId && <p style={{ color: '#777', fontSize: 12 }}>session_id: {sessionId}</p>}
-      <label style={{ display: 'grid', gap: 8 }}>
-        <span>Результат</span>
-        <textarea value={result} rows={12} readOnly />
-      </label>
-      {documentJson && (
-        <label style={{ display: 'grid', gap: 8 }}>
-          <span>document (JSON)</span>
-          <textarea value={documentJson} rows={10} readOnly />
-        </label>
-      )}
-      <button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading}>
-        {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
-      </button>
-    </section>
+    <Card>
+      <section style={{ display: 'grid', gap: spacing.md }}>
+        <h2>Генерация ТК</h2>
+        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ ТК сгенерирована</p>}
+        {error && <p style={{ color: colors.error }}>{error}</p>}
+        {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
+
+        <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
+
+        {documentJson && <Input type="textarea" label="document (JSON)" value={documentJson} rows={10} readOnly />}
+
+        <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
+          {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
+        </Button>
+      </section>
+    </Card>
   );
 }

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import TabLayout from '../components/TabLayout';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import Input from '../components/ui/Input';
 import { getApiConfig } from '../api/coreClient';
+import { colors, spacing } from '../styles/tokens';
 import type { GSNChecklist, GSNSectionStatus, ScheduleForecast, SignStatus } from '../types/handover';
 
 interface ProjectDocument {
@@ -363,26 +367,26 @@ export default function HandoverPage() {
   const signedCount = documents.filter((doc) => signedDocIds.includes(doc.id) || doc.status === 'signed').length;
 
   return (
-    <section style={{ display: 'grid', gap: 12 }}>
+    <Card><section style={{ display: 'grid', gap: spacing.md }}>
       <h2>Сдача объекта</h2>
 
       <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
         <label style={{ display: 'grid', gap: 4 }}>
           <span>Project ID</span>
-          <input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="UUID проекта" />
+          <Input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="UUID проекта" />
         </label>
         <label style={{ display: 'grid', gap: 4 }}>
           <span>User ID для ЭЦП</span>
-          <input value={userId} onChange={(event) => setUserId(event.target.value)} placeholder="Идентификатор пользователя" />
+          <Input value={userId} onChange={(event) => setUserId(event.target.value)} placeholder="Идентификатор пользователя" />
         </label>
       </div>
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <button type="button" onClick={loadAll} disabled={loading}>
+        <Button type="button" onClick={loadAll} disabled={loading}>
           {loading ? 'Загрузка...' : 'Загрузить данные'}
-        </button>
-        <button type="button" onClick={handleBatchSign} disabled={batchLoading || !documents.length}>
+        </Button>
+        <Button type="button" onClick={handleBatchSign} disabled={batchLoading || !documents.length}>
           {batchLoading ? 'Подписание...' : 'Подписать все (batch)'}
-        </button>
+        </Button>
       </div>
       {error && <p style={{ color: 'crimson', margin: 0 }}>{error}</p>}
 
@@ -393,9 +397,9 @@ export default function HandoverPage() {
             title: 'Готовность ИД',
             content: (
               <section style={{ display: 'grid', gap: 12 }}>
-                <button type="button" onClick={handleGenerateReport}>
+                <Button type="button" onClick={handleGenerateReport}>
                   Сформировать отчёт
-                </button>
+                </Button>
                 <div style={{ display: 'grid', gap: 10 }}>
                   {checklistSections.map((section) => (
                     <article
@@ -464,13 +468,13 @@ export default function HandoverPage() {
                         </span>
                       </div>
                       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                        <button type="button" onClick={() => handleSign(doc)} disabled={status === 'signed'}>
+                        <Button type="button" onClick={() => handleSign(doc)} disabled={status === 'signed'}>
                           Подписать ЭЦП
-                        </button>
+                        </Button>
                         {project?.is_state_contract && status === 'signed' && (
-                          <button type="button" onClick={() => handleIsupSubmit(doc.id)}>
+                          <Button type="button" onClick={() => handleIsupSubmit(doc.id)}>
                             Передать в ИСУП
-                          </button>
+                          </Button>
                         )}
                       </div>
                     </article>
@@ -543,30 +547,30 @@ export default function HandoverPage() {
                   <strong>КС-2 в XML для 1С</strong>
                   <p style={{ margin: '8px 0' }}>Экспорт акта выполненных работ в формат 1С</p>
                   <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                    <input
+                    <Input
                       placeholder="ID документа КС-2"
                       value={ks2DocId}
                       onChange={(event) => setKs2DocId(event.target.value)}
                       style={{ flex: 1, minWidth: 200 }}
                     />
-                    <button type="button" onClick={handleExportKs2Xml}>
+                    <Button type="button" onClick={handleExportKs2Xml}>
                       Скачать КС-2 XML
-                    </button>
+                    </Button>
                   </div>
                 </article>
                 <article style={{ border: '1px solid #33415555', borderRadius: 12, padding: 12 }}>
                   <strong>М-29 в XML для 1С</strong>
                   <p style={{ margin: '8px 0' }}>Ведомость списания материалов</p>
                   <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                    <input
+                    <Input
                       placeholder="Период (YYYY-MM)"
                       value={m29Period}
                       onChange={(event) => setM29Period(event.target.value)}
                       style={{ flex: 1, minWidth: 140 }}
                     />
-                    <button type="button" onClick={handleExportM29Xml}>
+                    <Button type="button" onClick={handleExportM29Xml}>
                       Скачать М-29 XML
-                    </button>
+                    </Button>
                   </div>
                 </article>
               </section>
@@ -635,6 +639,6 @@ export default function HandoverPage() {
         activeTab={activeTab}
         onChange={setActiveTab}
       />
-    </section>
+    </section></Card>
   );
 }

--- a/desktop/src/pages/SettingsPage.tsx
+++ b/desktop/src/pages/SettingsPage.tsx
@@ -1,6 +1,10 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { Store } from '@tauri-apps/plugin-store';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import { colors, spacing } from '../styles/tokens';
 import { DEFAULT_API_URL, apiFetch, assertOk, normalizeApiUrl } from '../api/coreClient';
 
 type ConnectionStatus = {
@@ -9,11 +13,11 @@ type ConnectionStatus = {
 };
 
 const statusColor: Record<ConnectionStatus['tone'], string> = {
-  idle: '#4b5563',
-  checking: '#2563eb',
-  success: '#15803d',
-  warning: '#b45309',
-  error: '#b91c1c'
+  idle: colors.textSecondary,
+  checking: colors.primary,
+  success: colors.success,
+  warning: colors.warning,
+  error: colors.error
 };
 
 export default function SettingsPage() {
@@ -111,29 +115,27 @@ export default function SettingsPage() {
   };
 
   return (
-    <form onSubmit={onSave} style={{ display: 'grid', gap: 10, maxWidth: 640 }}>
-      <label>
-        API URL
-        <input value={apiUrl} onChange={(e) => setApiUrl(e.target.value)} style={{ width: '100%' }} />
-      </label>
-      <label>
-        API Key
-        <input value={apiKey} onChange={(e) => setApiKey(e.target.value)} style={{ width: '100%' }} />
-      </label>
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <button type="submit">Сохранить</button>
-        <button
-          type="button"
-          onClick={onCheckConnection}
-          disabled={connectionStatus.tone === 'checking'}
-        >
-          {connectionStatus.tone === 'checking' ? 'Проверка...' : 'Проверить соединение'}
-        </button>
-      </div>
-      {saved && <span style={{ color: 'green' }}>Сохранено</span>}
-      <p style={{ color: statusColor[connectionStatus.tone], margin: 0 }}>
-        {connectionStatus.message}
-      </p>
-    </form>
+    <Card>
+      <form onSubmit={onSave} style={{ display: 'grid', gap: spacing.md, maxWidth: 640 }}>
+        <Input label="API URL" value={apiUrl} onChange={(e) => setApiUrl(e.target.value)} />
+        <Input label="API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+        <div style={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
+          <Button type="submit">Сохранить</Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCheckConnection}
+            disabled={connectionStatus.tone === 'checking'}
+            loading={connectionStatus.tone === 'checking'}
+          >
+            {connectionStatus.tone === 'checking' ? 'Проверка...' : 'Проверить соединение'}
+          </Button>
+        </div>
+        {saved && <span style={{ color: colors.success }}>Сохранено</span>}
+        <p style={{ color: statusColor[connectionStatus.tone], margin: 0 }}>
+          {connectionStatus.message}
+        </p>
+      </form>
+    </Card>
   );
 }

--- a/desktop/src/styles/tokens.ts
+++ b/desktop/src/styles/tokens.ts
@@ -1,0 +1,42 @@
+export const colors = {
+  primary: '#2563eb',
+  primaryHover: '#1d4ed8',
+  primaryActive: '#1e40af',
+  success: '#15803d',
+  warning: '#b45309',
+  error: '#b91c1c',
+  textPrimary: '#111827',
+  textSecondary: '#6b7280',
+  textMuted: '#9ca3af',
+  bgPage: '#f9fafb',
+  bgCard: '#ffffff',
+  bgSidebar: '#f3f4f6',
+  bgActiveNav: '#dbeafe',
+  border: '#e5e7eb',
+  borderFocus: '#2563eb'
+} as const;
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32
+} as const;
+
+export const radius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16
+} as const;
+
+export const typography = {
+  fontFamily: 'Inter, system-ui, Arial, sans-serif',
+  h1: { fontSize: 24, fontWeight: 700, lineHeight: 1.3 },
+  h2: { fontSize: 20, fontWeight: 600, lineHeight: 1.4 },
+  body: { fontSize: 14, fontWeight: 400, lineHeight: 1.6 },
+  small: { fontSize: 12, fontWeight: 400, lineHeight: 1.5 },
+  label: { fontSize: 13, fontWeight: 500, lineHeight: 1.4 }
+} as const;


### PR DESCRIPTION
### Motivation
- Provide a small, consistent design system for the desktop app UI so pages share tokens and primitives without touching business logic. 
- Replace ad-hoc inline controls with reusable components to make future styling and accessibility improvements easier. 
- Keep dependencies minimal and avoid third-party CSS frameworks while making the look consistent across pages.

### Description
- Added shared design tokens in `desktop/src/styles/tokens.ts` containing `colors`, `spacing`, `radius`, and `typography` for consistent theme values. 
- Introduced UI primitives in `desktop/src/components/ui/`: `Button` (variants, sizes, loading and hover/active states), `Input` (single-line / textarea, label/hint/error, focus state), and `Card` (container with padding/shadow). 
- Updated `Sidebar` to use tokens, added inline SVG icons for all menu items, highlighted active item with a blue left stripe and `bgActiveNav`, set sidebar `minWidth: 240`, and added hover feedback for session history. 
- Applied the design system to the app layout and pages: `App.tsx` uses `bgPage`, global `box-sizing` reset and content-area padding; replaced bare `button`/`input`/`textarea` with `Button`/`Input`, wrapped page content with `Card`, and updated `DocumentForm` to use the new primitives while preserving existing handlers and logic.

### Testing
- Ran the desktop production build with `npm run build` (workdir: `desktop`), which executes `tsc && vite build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34ac2d2cc832f9e2c7f1365a91621)