### PR TITLE
feat(desktop): improve settings with server health details and default role

### DIFF
--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -65,6 +65,14 @@ export interface ApiConfig {
   apiKey: string;
 }
 
+export interface HealthResponse {
+  status: string;
+  service: string;
+  version: string;
+  uptime_seconds: number;
+  components: Record<string, { status: string; [key: string]: unknown }>;
+}
+
 export const DEFAULT_API_URL = 'https://vanekpetrov1997.fvds.ru';
 
 const LEGACY_DEFAULT_API_URL = 'http://vanekpetrov1997.fvds.ru';
@@ -188,6 +196,12 @@ export async function sendChatMessage(
   await assertOk(response, endpoint);
 
   return (await response.json()) as ChatResponse;
+}
+
+export async function checkHealth(apiUrl: string): Promise<HealthResponse> {
+  const response = await apiFetch(apiUrl, '/health');
+  await assertOk(response, '/health');
+  return (await response.json()) as HealthResponse;
 }
 
 export function generateTK(apiUrl: string, apiKey: string, payload: TKRequest) {

--- a/desktop/src/components/ChatWindow.tsx
+++ b/desktop/src/components/ChatWindow.tsx
@@ -10,6 +10,7 @@ export default function ChatWindow() {
   const [error, setError] = useState<string | null>(null);
   const messages = useChatStore((s) => s.messages);
   const role = useChatStore((s) => s.role);
+  const defaultRole = useChatStore((s) => s.defaultRole);
   const sessionId = useChatStore((s) => s.sessionId);
   const addMessage = useChatStore((s) => s.addMessage);
   const isTyping = useChatStore((s) => s.isTyping);
@@ -44,7 +45,7 @@ export default function ChatWindow() {
 
       const response = await sendChatMessage(apiUrl, apiKey, {
         message: trimmed,
-        role,
+        role: role || defaultRole,
         session_id: sessionId
       });
       const metadata: ChatResponseMeta = {

--- a/desktop/src/pages/SettingsPage.tsx
+++ b/desktop/src/pages/SettingsPage.tsx
@@ -5,7 +5,15 @@ import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
-import { DEFAULT_API_URL, apiFetch, assertOk, normalizeApiUrl } from '../api/coreClient';
+import {
+  DEFAULT_API_URL,
+  apiFetch,
+  assertOk,
+  checkHealth,
+  normalizeApiUrl,
+  type HealthResponse
+} from '../api/coreClient';
+import { useChatStore, type ChatRole } from '../store/chatStore';
 
 type ConnectionStatus = {
   tone: 'idle' | 'checking' | 'success' | 'warning' | 'error';
@@ -20,10 +28,31 @@ const statusColor: Record<ConnectionStatus['tone'], string> = {
   error: colors.error
 };
 
+const ROLE_OPTIONS: Array<{ value: ChatRole; label: string }> = [
+  { value: 'pto_engineer', label: 'ПТО-инженер' },
+  { value: 'foreman', label: 'Прораб' },
+  { value: 'tender_specialist', label: 'Тендерный специалист' },
+  { value: 'admin', label: 'Администратор' }
+];
+
+const COMPONENT_LABELS: Record<string, string> = {
+  database: 'База данных',
+  rag_engine: 'RAG движок',
+  llm_router: 'LLM роутер',
+  telegram_webhook: 'Telegram'
+};
+
+const APP_VERSION =
+  (import.meta as ImportMeta & { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION || '0.5.0';
+
 export default function SettingsPage() {
+  const setDefaultRole = useChatStore((state) => state.setDefaultRole);
   const [apiUrl, setApiUrl] = useState(DEFAULT_API_URL);
   const [apiKey, setApiKey] = useState('');
+  const [defaultRole, setDefaultRoleValue] = useState<ChatRole>('pto_engineer');
   const [saved, setSaved] = useState(false);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [lastCheckedAt, setLastCheckedAt] = useState<string | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
     tone: 'idle',
     message: 'Проверка соединения ещё не выполнялась.'
@@ -36,17 +65,20 @@ export default function SettingsPage() {
         (await store.get<string>('api_url')) || (await invoke<string>('get_api_url')) || DEFAULT_API_URL
       );
       const key = (await store.get<string>('api_key')) || '';
+      const storedDefaultRole = (await store.get<ChatRole>('default_role')) || 'pto_engineer';
       setApiUrl(url);
       setApiKey(key);
+      setDefaultRoleValue(storedDefaultRole);
     };
 
     void load();
   }, []);
 
-  const persistSettings = async (normalizedUrl: string, trimmedKey: string) => {
+  const persistSettings = async (normalizedUrl: string, trimmedKey: string, nextDefaultRole: ChatRole) => {
     const store = await Store.load('settings.json');
     await store.set('api_url', normalizedUrl);
     await store.set('api_key', trimmedKey);
+    await store.set('default_role', nextDefaultRole);
     await store.save();
     await invoke('set_api_url', { url: normalizedUrl });
   };
@@ -57,9 +89,10 @@ export default function SettingsPage() {
     const trimmedKey = apiKey.trim();
 
     try {
-      await persistSettings(normalizedUrl, trimmedKey);
+      await persistSettings(normalizedUrl, trimmedKey, defaultRole);
       setApiUrl(normalizedUrl);
       setApiKey(trimmedKey);
+      setDefaultRole(defaultRole);
       setSaved(true);
       setTimeout(() => setSaved(false), 1500);
     } catch (error) {
@@ -77,8 +110,9 @@ export default function SettingsPage() {
     setConnectionStatus({ tone: 'checking', message: 'Проверяю сервер...' });
 
     try {
-      const healthResponse = await apiFetch(normalizedUrl, '/health');
-      await assertOk(healthResponse, '/health');
+      const healthResponse = await checkHealth(normalizedUrl);
+      setHealth(healthResponse);
+      setLastCheckedAt(new Date().toISOString());
 
       if (!trimmedKey) {
         setConnectionStatus({
@@ -97,8 +131,9 @@ export default function SettingsPage() {
         }
       });
       await assertOk(protectedResponse, '/api/billing/plan');
-      await persistSettings(normalizedUrl, trimmedKey);
+      await persistSettings(normalizedUrl, trimmedKey, defaultRole);
       setApiKey(trimmedKey);
+      setDefaultRole(defaultRole);
       setSaved(true);
       setTimeout(() => setSaved(false), 1500);
 
@@ -107,6 +142,8 @@ export default function SettingsPage() {
         message: 'Сервер доступен, API Key принят. Desktop готов к работе с серверным API.'
       });
     } catch (error) {
+      setHealth(null);
+      setLastCheckedAt(new Date().toISOString());
       setConnectionStatus({
         tone: 'error',
         message: error instanceof Error ? error.message : 'Не удалось проверить соединение с API.'
@@ -119,6 +156,25 @@ export default function SettingsPage() {
       <form onSubmit={onSave} style={{ display: 'grid', gap: spacing.md, maxWidth: 640 }}>
         <Input label="API URL" value={apiUrl} onChange={(e) => setApiUrl(e.target.value)} />
         <Input label="API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+        <label style={{ display: 'grid', gap: spacing.xs }}>
+          <span style={{ color: colors.textPrimary, fontWeight: 500 }}>Имя роли по умолчанию</span>
+          <select
+            value={defaultRole}
+            onChange={(event) => setDefaultRoleValue(event.target.value as ChatRole)}
+            style={{
+              border: `1px solid ${colors.border}`,
+              borderRadius: 8,
+              padding: `${spacing.sm}px ${spacing.md}px`,
+              color: colors.textPrimary
+            }}
+          >
+            {ROLE_OPTIONS.map((roleOption) => (
+              <option key={roleOption.value} value={roleOption.value}>
+                {roleOption.label}
+              </option>
+            ))}
+          </select>
+        </label>
         <div style={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
           <Button type="submit">Сохранить</Button>
           <Button
@@ -136,6 +192,58 @@ export default function SettingsPage() {
           {connectionStatus.message}
         </p>
       </form>
+      {health && (
+        <Card padding="md" style={{ marginTop: spacing.lg }}>
+          <h3 style={{ marginTop: 0, marginBottom: spacing.sm }}>Статус сервера</h3>
+          <p style={{ marginTop: 0 }}>
+            {health.service} — {health.status}
+          </p>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}` }}>Компонент</th>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}` }}>Статус</th>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}` }}>Детали</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(health.components).map(([key, component]) => {
+                const statusIcon = component.status === 'ok' || component.status === 'active' ? '✅' : '⚠️';
+                const details =
+                  key === 'rag_engine'
+                    ? `${String(component.chunks_count ?? 0)} документов`
+                    : key === 'llm_router' && component.provider
+                      ? String(component.provider)
+                      : '-';
+
+                return (
+                  <tr key={key}>
+                    <td style={{ paddingTop: spacing.xs }}>{COMPONENT_LABELS[key] || key}</td>
+                    <td style={{ paddingTop: spacing.xs }}>
+                      {statusIcon} {component.status}
+                    </td>
+                    <td style={{ paddingTop: spacing.xs }}>{details}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {(health.components.rag_engine?.chunks_count as number | undefined) === 0 && (
+            <p style={{ marginBottom: 0, color: colors.warning }}>
+              RAG база пуста. Нормативы (СП, ГОСТ) не загружены — качество ответов снижено.
+            </p>
+          )}
+        </Card>
+      )}
+      <Card padding="md" style={{ marginTop: spacing.lg }}>
+        <h3 style={{ marginTop: 0, marginBottom: spacing.sm }}>Информация</h3>
+        <p style={{ margin: 0 }}>Версия десктоп-приложения: {APP_VERSION}</p>
+        <p style={{ margin: 0 }}>Версия сервера: {health?.version || 'не определена'}</p>
+        <p style={{ margin: 0 }}>
+          Дата последней проверки соединения:{' '}
+          {lastCheckedAt ? new Date(lastCheckedAt).toLocaleString('ru-RU') : 'ещё не выполнялась'}
+        </p>
+      </Card>
     </Card>
   );
 }

--- a/desktop/src/store/chatStore.ts
+++ b/desktop/src/store/chatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { Store } from '@tauri-apps/plugin-store';
 import type { ChatResponseMeta } from '../api/coreClient';
 
 export type ChatRole = 'pto_engineer' | 'foreman' | 'tender_specialist' | 'admin';
@@ -21,10 +22,12 @@ interface ChatSession {
 interface ChatState {
   sessionId: string;
   role: ChatRole;
+  defaultRole: ChatRole;
   messages: ChatMessage[];
   sessions: ChatSession[];
   isTyping: boolean;
   setRole: (role: ChatRole) => void;
+  setDefaultRole: (role: ChatRole) => void;
   addMessage: (message: ChatMessage) => void;
   setTyping: (isTyping: boolean) => void;
   resetSession: () => void;
@@ -34,11 +37,13 @@ const createSessionId = () => crypto.randomUUID();
 
 export const useChatStore = create<ChatState>((set, get) => ({
   sessionId: createSessionId(),
-  role: 'admin',
+  role: 'pto_engineer',
+  defaultRole: 'pto_engineer',
   messages: [],
   sessions: [],
   isTyping: false,
   setRole: (role) => set({ role }),
+  setDefaultRole: (role) => set({ defaultRole: role, role }),
   addMessage: (message) => set({ messages: [...get().messages, message] }),
   setTyping: (isTyping) => set({ isTyping }),
   resetSession: () => {
@@ -57,3 +62,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   }
 }));
+
+void (async () => {
+  const store = await Store.load('settings.json');
+  const defaultRole = await store.get<ChatRole>('default_role');
+
+  if (defaultRole) {
+    useChatStore.setState({ defaultRole, role: defaultRole });
+  }
+})();


### PR DESCRIPTION
### Motivation
- Добавить полноценный healthcheck в `SettingsPage` и показать статус компонентов сервера для быстрого диагностирования состояния приложения.
- Позволить пользователю выбрать и сохранить «Имя роли по умолчанию», чтобы убрать хардкод роли в чатах и унифицировать поведение клиента.

### Description
- Добавлен тип `HealthResponse` и функция `checkHealth(apiUrl)` в `desktop/src/api/coreClient.ts` для типизированного вызова `/health` с использованием `assertOk`.
- Обновлён `desktop/src/pages/SettingsPage.tsx`: добавлен select для `default_role` (варианты: `pto_engineer | foreman | tender_specialist | admin`) с сохранением в `settings.json`, отображение карточки «Статус сервера» после healthcheck с таблицей компонентов, показ деталей (`chunks_count`, `provider`) и предупреждение при пустой RAG-базе, а также секция «Информация» с версией приложения, версией сервера и датой последней проверки.
- Расширен стор `desktop/src/store/chatStore.ts`: добавлено поле `defaultRole`, метод `setDefaultRole`, дефолтное значение `pto_engineer` и инициализация `default_role` из `settings.json` при старте приложения.
- Обновлён `desktop/src/components/ChatWindow.tsx` для использования `defaultRole` из стора как fallback при отправке запроса в `sendChatMessage`.
- Сохранена существующая логика `persistSettings` (теперь она также сохраняет `default_role`) и не добавлены сторонние зависимости; TypeScript остаётся в строгом режиме.

### Testing
- Выполнена сборка фронтенда командой `npm run build` в `desktop/` и сборка прошла успешно (TypeScript/`tsc` + `vite build`).
- Автоматических тестов не добавлялось; сборка артефактов прошла без ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38f5ead90832f942dc5111e4f86ad)