### PR TITLE
feat(desktop): redesign KS generation page with editable work table

### DIFF
--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -1,23 +1,38 @@
-import { useState } from 'react';
-import DocumentForm, { type DocumentField } from '../components/DocumentForm';
+import { type FormEvent, useState } from 'react';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import Input from '../components/ui/Input';
-import { colors, spacing } from '../styles/tokens';
+import { colors, radius, spacing, typography } from '../styles/tokens';
 import { downloadKSDocx, generateKS, getApiConfig, type KSWorkItem } from '../api/coreClient';
 
-const fields: DocumentField[] = [
-  { name: 'object_name', label: 'Название объекта', type: 'text' },
-  { name: 'contract_number', label: 'Номер договора', type: 'text' },
-  { name: 'date_from', label: 'Период с', type: 'text', placeholder: 'ДД.ММ.ГГГГ' },
-  { name: 'date_to', label: 'Период по', type: 'text', placeholder: 'ДД.ММ.ГГГГ' },
-  {
-    name: 'work_items',
-    label: 'Перечень работ',
-    type: 'textarea',
-    placeholder: 'Наименование|Ед.|Объём|Нормо-часы|Цена\nБетонирование|м³|10|2|5000'
-  }
-];
+const unitOptions = ['м²', 'м³', 'пог.м.', 'шт.', 'т', 'кг', 'компл.', 'услуга'] as const;
+
+interface WorkRow {
+  id: string;
+  name: string;
+  unit: string;
+  volume: string;
+  normHours: string;
+  pricePerUnit: string;
+}
+
+interface KSFormValues {
+  objectName: string;
+  contractNumber: string;
+  dateFrom: string;
+  dateTo: string;
+}
+
+function createEmptyWorkRow(): WorkRow {
+  return {
+    id: crypto.randomUUID(),
+    name: '',
+    unit: unitOptions[0],
+    volume: '',
+    normHours: '',
+    pricePerUnit: ''
+  };
+}
 
 function parseDateRU(val: string): string {
   const normalized = val.trim();
@@ -58,45 +73,146 @@ interface KSSummary {
   total_hours: string;
 }
 
+function formatDateRuFromIso(isoDate: string): string {
+  if (!isoDate) return '—';
+  const parsed = new Date(`${isoDate}T00:00:00`);
+  return Number.isNaN(parsed.getTime()) ? '—' : parsed.toLocaleDateString('ru-RU');
+}
+
 export default function GenerateKSPage() {
+  const [formValues, setFormValues] = useState<KSFormValues>({
+    objectName: '',
+    contractNumber: '',
+    dateFrom: '',
+    dateTo: ''
+  });
+  const [workRows, setWorkRows] = useState<WorkRow[]>([createEmptyWorkRow()]);
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState('');
   const [error, setError] = useState('');
+  const [warning, setWarning] = useState('');
+  const [importInfo, setImportInfo] = useState('');
   const [sessionId, setSessionId] = useState('');
   const [success, setSuccess] = useState(false);
   const [downloadLoading, setDownloadLoading] = useState(false);
   const [summary, setSummary] = useState<KSSummary | null>(null);
 
-  const handleSubmit = async (data: Record<string, string>) => {
-    setIsLoading(true);
-    setError('');
-    setSuccess(false);
-    setSummary(null);
+  const handleRowChange = (rowId: string, key: keyof Omit<WorkRow, 'id'>, value: string) => {
+    setWorkRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, [key]: value } : row)));
+  };
 
+  const addRow = () => {
+    setWorkRows((prev) => [...prev, createEmptyWorkRow()]);
+  };
+
+  const removeRow = (rowId: string) => {
+    setWorkRows((prev) => (prev.length > 1 ? prev.filter((row) => row.id !== rowId) : prev));
+  };
+
+  const buildWorkItems = (): KSWorkItem[] => {
+    const zeroValueRows: string[] = [];
+    const workItems = workRows
+      .map((row) => ({ ...row, name: row.name.trim() }))
+      .filter((row) => row.name.length > 0)
+      .map((row) => {
+        const volume = Number(row.volume || '0');
+        const normHours = Number(row.normHours || '0');
+        const pricePerUnit = Number(row.pricePerUnit || '0');
+
+        if (
+          Number.isNaN(volume) ||
+          Number.isNaN(normHours) ||
+          Number.isNaN(pricePerUnit) ||
+          volume < 0 ||
+          normHours < 0 ||
+          pricePerUnit < 0
+        ) {
+          throw new Error(`Строка «${row.name}» содержит некорректные числовые значения.`);
+        }
+
+        if (volume === 0 || normHours === 0 || pricePerUnit === 0) {
+          zeroValueRows.push(row.name);
+        }
+
+        return {
+          name: row.name,
+          unit: row.unit,
+          volume,
+          norm_hours: normHours,
+          price_per_unit: pricePerUnit
+        };
+      });
+
+    if (zeroValueRows.length) {
+      setWarning(`Предупреждение: у работ с нулевыми значениями: ${zeroValueRows.join(', ')}.`);
+    } else {
+      setWarning('');
+    }
+
+    return workItems;
+  };
+
+  const handleImportFromClipboard = async () => {
+    setError('');
+    setWarning('');
+    setImportInfo('');
     try {
-      const workItems: KSWorkItem[] = data.work_items
+      const clipboardText = await navigator.clipboard.readText();
+      const importedRows = clipboardText
         .split('\n')
         .map((line) => line.trim())
         .filter(Boolean)
         .map((line) => {
-          const [name, unit, volume, normHours, pricePerUnit] = line
+          const [name = '', unit = unitOptions[0], volume = '', normHours = '', pricePerUnit = ''] = line
             .split('|')
             .map((part) => part.trim());
 
-          if (!name || !unit || !volume || !normHours || !pricePerUnit) {
-            throw new Error(
-              'Каждая строка work_items должна быть в формате: Наименование|Ед.|Объём|Нормо-часы|Цена'
-            );
+          if (!name) {
+            return null;
           }
 
           return {
+            id: crypto.randomUUID(),
             name,
-            unit,
-            volume: Number(volume),
-            norm_hours: Number(normHours),
-            price_per_unit: Number(pricePerUnit)
-          };
-        });
+            unit: unitOptions.includes(unit as (typeof unitOptions)[number]) ? unit : unitOptions[0],
+            volume,
+            normHours,
+            pricePerUnit
+          } as WorkRow;
+        })
+        .filter((row): row is WorkRow => row !== null);
+
+      if (!importedRows.length) {
+        throw new Error('В буфере обмена не найдено строк формата "Наименование|Ед.|Объём|Нормо-часы|Цена".');
+      }
+
+      setWorkRows(importedRows);
+      setImportInfo(`Импортировано строк: ${importedRows.length}`);
+    } catch (clipboardError) {
+      setError(clipboardError instanceof Error ? clipboardError.message : 'Не удалось импортировать из буфера');
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError('');
+    setSuccess(false);
+    setSummary(null);
+    setImportInfo('');
+
+    try {
+      if (!formValues.objectName.trim()) {
+        throw new Error('Заполните поле "Название объекта"');
+      }
+      if (!formValues.contractNumber.trim()) {
+        throw new Error('Заполните поле "Номер договора"');
+      }
+      if (!formValues.dateFrom || !formValues.dateTo) {
+        throw new Error('Заполните обе даты периода');
+      }
+
+      const workItems = buildWorkItems();
 
       if (!workItems.length) {
         throw new Error('Добавьте хотя бы одну строку работ');
@@ -104,10 +220,10 @@ export default function GenerateKSPage() {
 
       const { apiUrl, apiKey } = await getApiConfig();
       const response = await generateKS(apiUrl, apiKey, {
-        object_name: data.object_name,
-        contract_number: data.contract_number,
-        period_from: parseDateRU(data.date_from),
-        period_to: parseDateRU(data.date_to),
+        object_name: formValues.objectName.trim(),
+        contract_number: formValues.contractNumber.trim(),
+        period_from: parseDateRU(formValues.dateFrom),
+        period_to: parseDateRU(formValues.dateTo),
         work_items: workItems
       });
 
@@ -166,29 +282,194 @@ export default function GenerateKSPage() {
     <Card>
       <section style={{ display: 'grid', gap: spacing.md }}>
         <h2>Генерация КС</h2>
-        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        <form onSubmit={handleSubmit} style={{ display: 'grid', gap: spacing.md, maxWidth: 900 }}>
+          <Input
+            label="Название объекта"
+            value={formValues.objectName}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, objectName: event.target.value }))}
+            disabled={isLoading}
+            required
+          />
+          <Input
+            label="Номер договора"
+            value={formValues.contractNumber}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, contractNumber: event.target.value }))}
+            disabled={isLoading}
+            required
+          />
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: spacing.md }}>
+            <label style={{ display: 'grid', gap: spacing.xs }}>
+              <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
+                Период с
+              </span>
+              <input
+                type="date"
+                value={formValues.dateFrom}
+                onChange={(event) => {
+                  const nextValue = event.currentTarget.valueAsDate
+                    ? event.currentTarget.valueAsDate.toISOString().slice(0, 10)
+                    : event.currentTarget.value;
+                  setFormValues((prev) => ({ ...prev, dateFrom: nextValue }));
+                }}
+                min="1900-01-01"
+                max="2100-12-31"
+                required
+                disabled={isLoading}
+                style={{
+                  width: '100%',
+                  borderRadius: radius.md,
+                  border: `1px solid ${colors.border}`,
+                  padding: `${spacing.sm}px ${spacing.md}px`,
+                  fontFamily: typography.fontFamily,
+                  fontSize: typography.body.fontSize
+                }}
+              />
+              <span style={{ color: colors.textSecondary, fontSize: typography.small.fontSize }}>
+                {formatDateRuFromIso(formValues.dateFrom)}
+              </span>
+            </label>
+            <label style={{ display: 'grid', gap: spacing.xs }}>
+              <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
+                Период по
+              </span>
+              <input
+                type="date"
+                value={formValues.dateTo}
+                onChange={(event) => {
+                  const nextValue = event.currentTarget.valueAsDate
+                    ? event.currentTarget.valueAsDate.toISOString().slice(0, 10)
+                    : event.currentTarget.value;
+                  setFormValues((prev) => ({ ...prev, dateTo: nextValue }));
+                }}
+                min="1900-01-01"
+                max="2100-12-31"
+                required
+                disabled={isLoading}
+                style={{
+                  width: '100%',
+                  borderRadius: radius.md,
+                  border: `1px solid ${colors.border}`,
+                  padding: `${spacing.sm}px ${spacing.md}px`,
+                  fontFamily: typography.fontFamily,
+                  fontSize: typography.body.fontSize
+                }}
+              />
+              <span style={{ color: colors.textSecondary, fontSize: typography.small.fontSize }}>
+                {formatDateRuFromIso(formValues.dateTo)}
+              </span>
+            </label>
+          </div>
+          <div style={{ display: 'grid', gap: spacing.sm }}>
+            <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
+              Перечень работ
+            </span>
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ borderCollapse: 'collapse', width: '100%', minWidth: 860 }}>
+                <thead>
+                  <tr>
+                    {['Наименование работ', 'Ед. изм.', 'Объём', 'Нормо-часы', 'Цена за ед.', ''].map((title) => (
+                      <th
+                        key={title || 'actions'}
+                        style={{
+                          border: `1px solid ${colors.border}`,
+                          padding: spacing.sm,
+                          textAlign: 'left',
+                          backgroundColor: '#f9fafb',
+                          fontSize: typography.small.fontSize
+                        }}
+                      >
+                        {title}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {workRows.map((row) => (
+                    <tr key={row.id}>
+                      <td style={{ border: `1px solid ${colors.border}`, padding: spacing.xs }}>
+                        <Input
+                          value={row.name}
+                          onChange={(event) => handleRowChange(row.id, 'name', event.target.value)}
+                          placeholder="Наименование работы"
+                          disabled={isLoading}
+                        />
+                      </td>
+                      <td style={{ border: `1px solid ${colors.border}`, padding: spacing.xs }}>
+                        <select
+                          value={row.unit}
+                          onChange={(event) => handleRowChange(row.id, 'unit', event.target.value)}
+                          disabled={isLoading}
+                          style={{
+                            width: '100%',
+                            borderRadius: radius.md,
+                            border: `1px solid ${colors.border}`,
+                            padding: `${spacing.sm}px ${spacing.md}px`,
+                            fontFamily: typography.fontFamily,
+                            fontSize: typography.body.fontSize
+                          }}
+                        >
+                          {unitOptions.map((unit) => (
+                            <option key={unit} value={unit}>
+                              {unit}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      {(['volume', 'normHours', 'pricePerUnit'] as const).map((field) => (
+                        <td key={`${row.id}-${field}`} style={{ border: `1px solid ${colors.border}`, padding: spacing.xs }}>
+                          <Input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={row[field]}
+                            onChange={(event) => handleRowChange(row.id, field, event.target.value)}
+                            placeholder="0.00"
+                            disabled={isLoading}
+                          />
+                        </td>
+                      ))}
+                      <td style={{ border: `1px solid ${colors.border}`, padding: spacing.xs, textAlign: 'center' }}>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => removeRow(row.id)}
+                          disabled={workRows.length === 1 || isLoading}
+                          title={workRows.length === 1 ? 'Должна оставаться минимум одна строка' : 'Удалить строку'}
+                        >
+                          ✕
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div style={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
+              <Button type="button" variant="secondary" onClick={addRow} disabled={isLoading}>
+                + Добавить строку
+              </Button>
+              <Button type="button" variant="secondary" onClick={handleImportFromClipboard} disabled={isLoading}>
+                Импорт из буфера
+              </Button>
+            </div>
+            {importInfo && <p style={{ color: colors.textSecondary }}>{importInfo}</p>}
+          </div>
+          <div style={{ display: 'flex', gap: spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Button type="submit" loading={isLoading} disabled={isLoading}>
+              {isLoading ? 'Сгенерировать...' : 'Сгенерировать'}
+            </Button>
+            {isLoading && <span role="status">⏳ Генерация...</span>}
+          </div>
+        </form>
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ КС сгенерирована</p>}
+        {warning && <p style={{ color: colors.warning }}>{warning}</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
         {summary && (
-          <table style={{ borderCollapse: 'collapse', width: '100%', maxWidth: 700 }}>
-            <thead>
-              <tr>
-                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>ks2 (стоимость)</th>
-                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>ks3 (выполнение)</th>
-                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>total_cost</th>
-                <th style={{ border: `1px solid ${colors.border}`, padding: 8 }}>total_hours</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.ks2 || '—'}</td>
-                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.ks3 || '—'}</td>
-                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.total_cost || '—'}</td>
-                <td style={{ border: `1px solid ${colors.border}`, padding: 8 }}>{summary.total_hours || '—'}</td>
-              </tr>
-            </tbody>
-          </table>
+          <p style={{ color: colors.textPrimary, fontWeight: 600 }}>
+            Итого работ: {workRows.filter((row) => row.name.trim()).length} | Общая стоимость: {summary.total_cost || '0'} руб. | Всего
+            нормо-часов: {summary.total_hours || '0'} ч.
+          </p>
         )}
         <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
         <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>


### PR DESCRIPTION
### Motivation
- Replace error-prone `work_items` textarea with a structured, user-friendly editor to reduce input mistakes and simplify data entry. 
- Provide native date inputs and clearer numeric inputs so submitted values are normalized and validated before calling the API.

### Description
- Replaced legacy textarea flow with a dynamic work table in `desktop/src/pages/GenerateKSPage.tsx` and added typed state `workRows` where each row has a unique `id` via `crypto.randomUUID()` and the UI starts with one empty row. 
- Implemented add/remove row controls, a `select` for units (`м², м³, пог.м., шт., т, кг, компл., услуга`), and numeric inputs for `Объём`, `Нормо-часы`, `Цена` using `type="number" min="0" step="0.01"`. 
- Added `buildWorkItems()` to convert `workRows` into `KSWorkItem[]`, skipping rows with empty `name` and setting a UI warning when numeric fields are zero or invalid. 
- Added clipboard import action that parses legacy lines `Наименование|Ед.|Объём|Нормо-часы|Цена` into rows and shows the number of imported rows. 
- Switched period fields to native `<input type="date">`, display localized `ДД.ММ.ГГГГ` via `toLocaleDateString('ru-RU')`, and submit ISO `YYYY-MM-DD` to the API; preserved existing `generateKS` integration, error handling and DOCX download. 
- After generation show a concise totals line: `Итого работ: N | Общая стоимость: X руб. | Всего нормо-часов: Y ч.` based on `response.total_cost` and `response.total_hours`.

### Testing
- Built the desktop app with `cd desktop && npm run build`, which runs `tsc && vite build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e390eeb038832fb7d023e3f9aa1fd1)