### PR TITLE
feat(desktop): добавить нижний StatusBar с опросом состояния сервера

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { getApiConfig } from './api/coreClient';
+import { checkHealth, getApiConfig } from './api/coreClient';
 import Sidebar from './components/Sidebar';
+import StatusBar from './components/StatusBar';
 import { resolveRoute } from './router';
 import { colors, spacing, typography } from './styles/tokens';
 import type { BrandingConfig } from './store/brandingStore';
 import { useBrandingStore } from './store/brandingStore';
+import { useServerStatusStore } from './store/serverStatusStore';
 
 const normalizePath = (path: string) => path.replace(/\/$/, '') || '/';
 
@@ -50,6 +52,40 @@ export default function App() {
     };
   }, [setBranding]);
 
+  useEffect(() => {
+    let isDisposed = false;
+    const { setChecking, setOnline, updateFromHealth } = useServerStatusStore.getState();
+
+    const refreshServerStatus = async () => {
+      setChecking(true);
+
+      try {
+        const { apiUrl } = await getApiConfig();
+        const health = await checkHealth(apiUrl);
+        if (isDisposed) {
+          return;
+        }
+        updateFromHealth(health);
+      } catch (_error) {
+        if (isDisposed) {
+          return;
+        }
+        setChecking(false);
+        setOnline(false);
+      }
+    };
+
+    void refreshServerStatus();
+    const intervalId = window.setInterval(() => {
+      void refreshServerStatus();
+    }, 60_000);
+
+    return () => {
+      isDisposed = true;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
   const navigate = (path: string) => {
     const nextPath = normalizePath(path);
     if (nextPath === currentPath) {
@@ -77,8 +113,11 @@ export default function App() {
       <style>{`*, *::before, *::after { box-sizing: border-box; } body { margin: 0; }`}</style>
       <main style={appTheme}>
         <Sidebar currentPath={currentPath} onNavigate={navigate} />
-        <section style={{ flex: 1, padding: spacing.lg }}>{resolveRoute(currentPath, () => navigate('/'))}</section>
+        <section style={{ flex: 1, padding: spacing.lg, paddingBottom: 36 }}>
+          {resolveRoute(currentPath, () => navigate('/'))}
+        </section>
       </main>
+      <StatusBar />
     </>
   );
 }

--- a/desktop/src/components/StatusBar.tsx
+++ b/desktop/src/components/StatusBar.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import { useChatStore, type ChatRole } from '../store/chatStore';
+import { useServerStatusStore } from '../store/serverStatusStore';
+
+const APP_VERSION =
+  (import.meta as ImportMeta & { env?: { VITE_APP_VERSION?: string } }).env?.VITE_APP_VERSION || '0.5.0';
+
+const ROLE_LABELS: Record<ChatRole, string> = {
+  pto_engineer: 'ПТО-инженер',
+  foreman: 'Прораб',
+  tender_specialist: 'Тендерный специалист',
+  admin: 'Администратор'
+};
+
+export default function StatusBar() {
+  const role = useChatStore((state) => state.role);
+  const { isOnline, isChecking, serverVersion } = useServerStatusStore((state) => ({
+    isOnline: state.isOnline,
+    isChecking: state.isChecking,
+    serverVersion: state.serverVersion
+  }));
+
+  const status = useMemo(() => {
+    if (isChecking) {
+      return { text: 'Проверка...', color: '#f59e0b', blink: true };
+    }
+
+    if (isOnline) {
+      return { text: 'OK', color: '#22c55e', blink: false };
+    }
+
+    return { text: 'Нет связи', color: '#ef4444', blink: false };
+  }, [isChecking, isOnline]);
+
+  return (
+    <footer
+      style={{
+        position: 'fixed',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: 28,
+        background: '#1e293b',
+        color: '#ffffff',
+        fontSize: 11,
+        display: 'grid',
+        gridTemplateColumns: '1fr auto 1fr',
+        alignItems: 'center',
+        padding: '0 12px',
+        zIndex: 1000,
+        borderTop: '1px solid rgba(255, 255, 255, 0.2)'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span
+          style={{
+            color: status.color,
+            fontSize: 12,
+            animation: status.blink ? 'statusbar-blink 1s ease-in-out infinite' : undefined
+          }}
+        >
+          ●
+        </span>
+        <span>
+          Сервер: <strong>{status.text}</strong>
+        </span>
+      </div>
+
+      <div style={{ textAlign: 'center', opacity: 0.9 }}>
+        app v{APP_VERSION} · server v{serverVersion || '—'}
+      </div>
+
+      <div style={{ justifySelf: 'end' }}>Роль: {ROLE_LABELS[role]}</div>
+
+      <style>{`@keyframes statusbar-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }`}</style>
+    </footer>
+  );
+}

--- a/desktop/src/store/serverStatusStore.ts
+++ b/desktop/src/store/serverStatusStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import type { HealthResponse } from '../api/coreClient';
+
+export interface ServerStatus {
+  isOnline: boolean;
+  lastChecked: string | null;
+  serverVersion: string | null;
+  isChecking: boolean;
+}
+
+interface ServerStatusState extends ServerStatus {
+  setOnline: (value: boolean) => void;
+  setChecking: (value: boolean) => void;
+  updateFromHealth: (health: HealthResponse) => void;
+}
+
+export const useServerStatusStore = create<ServerStatusState>((set) => ({
+  isOnline: false,
+  lastChecked: null,
+  serverVersion: null,
+  isChecking: false,
+  setOnline: (value) =>
+    set({
+      isOnline: value,
+      lastChecked: new Date().toISOString()
+    }),
+  setChecking: (value) => set({ isChecking: value }),
+  updateFromHealth: (health) =>
+    set({
+      isOnline: health.status === 'ok',
+      serverVersion: health.version,
+      lastChecked: new Date().toISOString(),
+      isChecking: false
+    })
+}));


### PR DESCRIPTION
### Motivation
- Отобразить везде видимый индикатор доступности серверного API и версии, чтобы пользователи могли быстро видеть состояние соединения. 
- Избежать перекрытия основного контента фиксированной панелью, добавив отступ у main-контента.

### Description
- Добавлен компонент `StatusBar` (`desktop/src/components/StatusBar.tsx`) — фиксированная нижняя панель 28px с тёмным фоном, цветовым индикатором состояния сервера (зелёный/красный/жёлтый с миганием) слева, версиями по центру и ролью пользователя справа. 
- Добавлен Zustand-store `useServerStatusStore` (`desktop/src/store/serverStatusStore.ts`) с интерфейсом `ServerStatus` и экшенами `setOnline`, `setChecking`, `updateFromHealth` для управления состоянием сервера. 
- В `App.tsx` интегрирован `StatusBar`, в `section` добавлен `paddingBottom: 36`, и реализован начальный вызов `checkHealth()` и периодический опрос каждые 60 секунд с `setInterval` и корректным `cleanup`; при ошибке вызывается `setOnline(false)`. 
- Не добавлено новых зависимостей и изменения совместимы со строгим TypeScript (используется существующий `checkHealth` и `getApiConfig` из `api/coreClient`).

### Testing
- Запущена сборка проекта десктопа через `npm run build` в каталоге `desktop/` (включает `tsc` + `vite build`) — сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39abe148c832f8df07eaff330e926)