### PR TITLE
Add design tokens and global desktop styles

### DIFF
--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/desktop/src/styles/global.css
+++ b/desktop/src/styles/global.css
@@ -1,0 +1,55 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+body {
+  font-family: Inter, sans-serif;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #d1d5db;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #9ca3af;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.message-enter {
+  animation: fadeIn 200ms ease forwards;
+}
+
+.page-content {
+  max-width: 860px;
+  width: 100%;
+}

--- a/desktop/src/styles/tokens.ts
+++ b/desktop/src/styles/tokens.ts
@@ -40,3 +40,21 @@ export const typography = {
   small: { fontSize: 12, fontWeight: 400, lineHeight: 1.5 },
   label: { fontSize: 13, fontWeight: 500, lineHeight: 1.4 }
 } as const;
+
+export const shadows = {
+  sm: '0 1px 3px rgba(0,0,0,0.08)',
+  md: '0 4px 12px rgba(0,0,0,0.10)',
+  lg: '0 8px 24px rgba(0,0,0,0.12)'
+} as const;
+
+export const transitions = {
+  fast: '150ms ease',
+  base: '200ms ease',
+  slow: '300ms ease'
+} as const;
+
+export const zIndex = {
+  sidebar: 10,
+  modal: 100,
+  toast: 200
+} as const;


### PR DESCRIPTION
### Motivation
- Provide shared design tokens for shadows, transitions and z-index to standardize UI layering and motion across the desktop app.
- Add global CSS reset and utility styles to ensure consistent base styling, focus rings, scrollbars and simple entrance animation for messages.

### Description
- Added new tokens in `desktop/src/styles/tokens.ts`: `shadows`, `transitions`, and `zIndex`, preserving all existing tokens.
- Created `desktop/src/styles/global.css` with box-sizing reset, `body` font-family set to `Inter`, custom WebKit scrollbar styling, `:focus-visible` ring, `@keyframes fadeIn`, `.message-enter` animation class, and `.page-content` sizing.
- Imported the new global stylesheet in the app entry at `desktop/src/main.tsx` via `import './styles/global.css';`.

### Testing
- Ran `npm run build` in the `desktop/` directory, which runs `tsc && vite build`, and the build completed successfully with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dea883c4832f90cbdaa1abf4f9b1)