### PR TITLE
Refine desktop app layout width and theme memoization

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -10,6 +10,14 @@ import { useServerStatusStore } from './store/serverStatusStore';
 
 const normalizePath = (path: string) => path.replace(/\/$/, '') || '/';
 
+const APP_THEME_BASE = {
+  minHeight: '100vh',
+  fontFamily: typography.fontFamily,
+  display: 'flex',
+  background: colors.bgPage,
+  overflow: 'hidden'
+} as const;
+
 export default function App() {
   const [currentPath, setCurrentPath] = useState(() => normalizePath(window.location.pathname));
   const branding = useBrandingStore((state) => state.branding);
@@ -98,12 +106,8 @@ export default function App() {
 
   const appTheme = useMemo(
     () => ({
-      minHeight: '100vh',
-      fontFamily: typography.fontFamily,
-      display: 'flex',
-      gap: spacing.lg,
+      ...APP_THEME_BASE,
       borderTop: `4px solid ${branding?.primary_color ?? '#2563eb'}`,
-      background: colors.bgPage
     }),
     [branding?.primary_color]
   );
@@ -113,8 +117,10 @@ export default function App() {
       <style>{`*, *::before, *::after { box-sizing: border-box; } body { margin: 0; }`}</style>
       <main style={appTheme}>
         <Sidebar currentPath={currentPath} onNavigate={navigate} />
-        <section style={{ flex: 1, padding: spacing.lg, paddingBottom: 36 }}>
-          {resolveRoute(currentPath, () => navigate('/'))}
+        <section style={{ flex: 1, padding: spacing.lg, paddingBottom: spacing.xxl }}>
+          <div className="page-content" style={{ maxWidth: 920, width: '100%' }}>
+            {resolveRoute(currentPath, () => navigate('/'))}
+          </div>
         </section>
       </main>
       <StatusBar />


### PR DESCRIPTION
### Motivation
- Restrict the main content area so pages do not stretch wider than a readable width and to prevent horizontal scrolling. 
- Reduce unnecessary re-creation of the root theme object so only branding-dependent styles trigger recalculation.

### Description
- Wrap routed page output in a `.page-content` container with `style={{ maxWidth: 920, width: '100%' }}` to cap content width.
- Replace hardcoded `paddingBottom: 36` with the design token `paddingBottom: spacing.xxl` on the main `<section>`.
- Extract static root layout properties into an `APP_THEME_BASE` constant outside the component and keep only `borderTop` (dependent on `branding?.primary_color`) inside `useMemo` to avoid recreating the full object.
- Remove `gap: spacing.lg` from the root theme and add `overflow: 'hidden'` to the root layout to prevent horizontal scroll while keeping sidebar/content separation via the sidebar border.

### Testing
- Built the desktop app with `cd desktop && npm run build`, which completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45ae86b90832f8dec9d8fef6d17b3)