### PR TITLE
Align ChatWindow with design system and improve typing indicator

### DIFF
--- a/desktop/src/components/ChatWindow.tsx
+++ b/desktop/src/components/ChatWindow.tsx
@@ -1,9 +1,12 @@
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import MessageBubble from './MessageBubble';
+import Input from './ui/Input';
+import Button from './ui/Button';
 import { useChatStore } from '../store/chatStore';
 import { sendChatMessage } from '../api/coreClient';
 import type { ChatResponseMeta } from '../api/coreClient';
 import { Store } from '@tauri-apps/plugin-store';
+import { colors, radius, spacing } from '../styles/tokens';
 
 export default function ChatWindow() {
   const [text, setText] = useState('');
@@ -68,36 +71,42 @@ export default function ChatWindow() {
   };
 
   return (
-    <section style={{ display: 'flex', flexDirection: 'column', gap: 10, flex: 1 }}>
+    <section style={{ display: 'flex', flexDirection: 'column', gap: spacing.sm, flex: 1 }}>
       <div
         ref={containerRef}
         style={{
-          height: 460,
+          flex: 1,
+          minHeight: 300,
+          maxHeight: 'calc(100vh - 260px)',
           overflowY: 'auto',
-          border: '1px solid #ddd',
-          borderRadius: 12,
-          padding: 10,
+          border: `1px solid ${colors.border}`,
+          borderRadius: radius.lg,
+          padding: spacing.md,
           display: 'flex',
           flexDirection: 'column',
-          gap: 8
+          gap: spacing.sm
         }}
       >
         {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} metadata={message.metadata} />
+          <MessageBubble key={message.id} message={message} metadata={message.metadata} className="message-enter" />
         ))}
-        {isTyping && <div style={{ color: '#777' }}>Assistant печатает…</div>}
+        {isTyping && (
+          <div style={{ display: 'flex', gap: 4, padding: '8px 12px', color: '#6b7280', fontSize: 13 }}>
+            <span style={{ animation: 'fadeIn 0.6s ease infinite alternate' }}>●</span>
+            <span style={{ animation: 'fadeIn 0.6s ease 0.2s infinite alternate' }}>●</span>
+            <span style={{ animation: 'fadeIn 0.6s ease 0.4s infinite alternate' }}>●</span>
+            <span style={{ marginLeft: 6 }}>Ассистент думает…</span>
+          </div>
+        )}
       </div>
 
-      <form onSubmit={onSubmit} style={{ display: 'flex', gap: 8 }}>
-        <input
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="Введите сообщение"
-          style={{ flex: 1, padding: '8px 10px' }}
-        />
-        <button type="submit">Отправить</button>
-      </form>
-      {error && <div style={{ color: '#b00020' }}>{error}</div>}
+      <div style={{ borderTop: `1px solid ${colors.border}`, paddingTop: spacing.md, marginTop: spacing.sm }}>
+        <form onSubmit={onSubmit} style={{ display: 'flex', gap: spacing.sm, alignItems: 'center' }}>
+          <Input value={text} onChange={(e) => setText(e.target.value)} placeholder="Введите сообщение" style={{ flex: 1 }} />
+          <Button type="submit">Отправить</Button>
+        </form>
+      </div>
+      {error && <div style={{ color: colors.error }}>{error}</div>}
     </section>
   );
 }

--- a/desktop/src/components/MessageBubble.tsx
+++ b/desktop/src/components/MessageBubble.tsx
@@ -8,6 +8,7 @@ export interface MessageMetadata {
 interface Props {
   message: ChatMessage;
   metadata?: MessageMetadata;
+  className?: string;
 }
 
 function getConfidenceBadge(confidence?: number) {
@@ -26,7 +27,7 @@ function getConfidenceBadge(confidence?: number) {
   return { label: '? Низкая', color: '#9e9e9e' };
 }
 
-export default function MessageBubble({ message, metadata }: Props) {
+export default function MessageBubble({ message, metadata, className }: Props) {
   const isUser = message.role === 'user';
   const effectiveMetadata = metadata ?? message.metadata;
   const agents = effectiveMetadata?.agents ?? [];
@@ -42,6 +43,7 @@ export default function MessageBubble({ message, metadata }: Props) {
 
   return (
     <div
+      className={className}
       style={{
         alignSelf: isUser ? 'flex-end' : 'flex-start',
         background: isUser ? '#d4f6dd' : '#f2f2f2',


### PR DESCRIPTION
### Motivation
- Bring `ChatWindow` visuals and interaction in line with the project design system tokens and components for consistent UI.
- Make the messages area responsive instead of a fixed height and provide a clearer typing/assistant state indicator.

### Description
- Replaced raw form controls with the design-system components `Input` and `Button` and wrapped the form in a divider area using design tokens `colors`, `spacing`, and `radius` from `../styles/tokens`.
- Replaced fixed `height: 460` with responsive sizing: `flex: 1`, `minHeight: 300`, `maxHeight: 'calc(100vh - 260px)'`, and `overflowY: 'auto'` for the messages container.
- Added `className="message-enter"` to each `MessageBubble` for CSS animations and extended `MessageBubble` to accept a `className` prop.
- Improved typing indicator to show three animated dots plus the text `Ассистент думает…` and used design tokens for borders, spacing and error color.

### Testing
- Ran `npm run build` in the `desktop/` package, which completed successfully (TypeScript type-check + Vite production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45dd477dc832fa447878b6d5b8656)