### PR TITLE
desktop: centralize API client with per-request timeouts and improved error handling

### DIFF
--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -1,5 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 import { Store } from '@tauri-apps/plugin-store';
+import {
+  apiRequest,
+  DEFAULT_CHAT_TIMEOUT_MS,
+  DEFAULT_GENERATION_TIMEOUT_MS
+} from '../lib/apiClient';
 import type { ChatRole } from '../store/chatStore';
 
 export interface ChatRequest {
@@ -73,6 +78,11 @@ export interface HealthResponse {
   components: Record<string, { status: string; [key: string]: unknown }>;
 }
 
+export interface ApiCallOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
 export const DEFAULT_API_URL = 'https://vanekpetrov1997.fvds.ru';
 
 const LEGACY_DEFAULT_API_URL = 'http://vanekpetrov1997.fvds.ru';
@@ -91,74 +101,23 @@ export const normalizeApiUrl = (apiUrl: string) => {
   return trimmedUrl;
 };
 
-async function readResponseBody(response: Response): Promise<string> {
-  const fallback = '<пустой ответ>';
-
-  try {
-    const text = await response.text();
-    return text.trim() || fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-export async function formatHttpError(response: Response, endpoint: string): Promise<string> {
-  const responseBody = await readResponseBody(response);
-  const authHint =
-    response.status === 401
-      ? ' Проверьте API Key: он должен совпадать с одним из значений API_KEYS в серверном .env.'
-      : '';
-
-  return `Запрос ${endpoint} завершился ошибкой HTTP ${response.status}.${authHint} Ответ сервера: ${responseBody}`;
-}
-
-export function formatNetworkError(error: unknown, endpoint: string): string {
-  const details = error instanceof Error && error.message ? ` Детали: ${error.message}` : '';
-  return `Не удалось подключиться к API (${endpoint}). Проверьте API URL и доступность /health.${details}`;
-}
-
-export async function assertOk(response: Response, endpoint: string): Promise<void> {
-  if (!response.ok) {
-    throw new Error(await formatHttpError(response, endpoint));
-  }
-}
-
-export async function apiFetch(
-  apiUrl: string,
-  endpoint: string,
-  init?: RequestInit
-): Promise<Response> {
-  try {
-    return await fetch(`${normalizeApiUrl(apiUrl)}${endpoint}`, init);
-  } catch (error) {
-    throw new Error(formatNetworkError(error, endpoint));
-  }
-}
-
 async function postJson<TRequest>(
   apiUrl: string,
   apiKey: string,
   endpoint: string,
-  payload: TRequest
+  payload: TRequest,
+  { timeoutMs = DEFAULT_GENERATION_TIMEOUT_MS, signal }: ApiCallOptions = {}
 ): Promise<GenerateDocumentResponse> {
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => {
-    controller.abort();
-  }, 30_000);
-
-  const response = await apiFetch(apiUrl, endpoint, {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': apiKey.trim()
     },
     body: JSON.stringify(payload),
-    signal: controller.signal
-  }).finally(() => {
-    window.clearTimeout(timeoutId);
+    timeoutMs,
+    signal
   });
-
-  await assertOk(response, endpoint);
 
   return (await response.json()) as GenerateDocumentResponse;
 }
@@ -181,51 +140,59 @@ export async function getApiConfig(): Promise<ApiConfig> {
 export async function sendChatMessage(
   apiUrl: string,
   apiKey: string,
-  payload: ChatRequest
+  payload: ChatRequest,
+  { timeoutMs = DEFAULT_CHAT_TIMEOUT_MS, signal }: ApiCallOptions = {}
 ): Promise<ChatResponse> {
   const endpoint = '/api/chat';
-  const response = await apiFetch(apiUrl, endpoint, {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': apiKey.trim()
     },
-    body: JSON.stringify(payload)
+    body: JSON.stringify(payload),
+    timeoutMs,
+    signal
   });
-
-  await assertOk(response, endpoint);
 
   return (await response.json()) as ChatResponse;
 }
 
-export async function checkHealth(apiUrl: string): Promise<HealthResponse> {
-  const response = await apiFetch(apiUrl, '/health');
-  await assertOk(response, '/health');
+export async function checkHealth(apiUrl: string, { timeoutMs, signal }: ApiCallOptions = {}): Promise<HealthResponse> {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), '/health', {
+    timeoutMs,
+    signal
+  });
   return (await response.json()) as HealthResponse;
 }
 
-export function generateTK(apiUrl: string, apiKey: string, payload: TKRequest) {
-  return postJson(apiUrl, apiKey, '/api/generate/tk', payload);
+export function generateTK(apiUrl: string, apiKey: string, payload: TKRequest, options?: ApiCallOptions) {
+  return postJson(apiUrl, apiKey, '/api/generate/tk', payload, options);
 }
 
-export function generateLetter(apiUrl: string, apiKey: string, payload: LetterRequest) {
-  return postJson(apiUrl, apiKey, '/api/generate/letter', payload);
+export function generateLetter(apiUrl: string, apiKey: string, payload: LetterRequest, options?: ApiCallOptions) {
+  return postJson(apiUrl, apiKey, '/api/generate/letter', payload, options);
 }
 
-export function generateKS(apiUrl: string, apiKey: string, payload: KSRequest) {
-  return postJson(apiUrl, apiKey, '/api/generate/ks', payload);
+export function generateKS(apiUrl: string, apiKey: string, payload: KSRequest, options?: ApiCallOptions) {
+  return postJson(apiUrl, apiKey, '/api/generate/ks', payload, options);
 }
 
-export async function downloadTKDocx(apiUrl: string, apiKey: string, sessionId: string): Promise<Blob> {
+export async function downloadTKDocx(
+  apiUrl: string,
+  apiKey: string,
+  sessionId: string,
+  { timeoutMs, signal }: ApiCallOptions = {}
+): Promise<Blob> {
   const endpoint = `/api/generate/tk/${encodeURIComponent(sessionId)}/download`;
-  const response = await apiFetch(apiUrl, endpoint, {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
     method: 'GET',
     headers: {
       'X-API-Key': apiKey.trim()
-    }
+    },
+    timeoutMs,
+    signal
   });
-
-  await assertOk(response, endpoint);
 
   return await response.blob();
 }
@@ -233,31 +200,37 @@ export async function downloadTKDocx(apiUrl: string, apiKey: string, sessionId: 
 export async function downloadLetterDocx(
   apiUrl: string,
   apiKey: string,
-  sessionId: string
+  sessionId: string,
+  { timeoutMs, signal }: ApiCallOptions = {}
 ): Promise<Blob> {
   const endpoint = `/api/generate/letter/${encodeURIComponent(sessionId)}/download`;
-  const response = await apiFetch(apiUrl, endpoint, {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
     method: 'GET',
     headers: {
       'X-API-Key': apiKey.trim()
-    }
+    },
+    timeoutMs,
+    signal
   });
-
-  await assertOk(response, endpoint);
 
   return await response.blob();
 }
 
-export async function downloadKSDocx(apiUrl: string, apiKey: string, sessionId: string): Promise<Blob> {
+export async function downloadKSDocx(
+  apiUrl: string,
+  apiKey: string,
+  sessionId: string,
+  { timeoutMs, signal }: ApiCallOptions = {}
+): Promise<Blob> {
   const endpoint = `/api/generate/ks/${encodeURIComponent(sessionId)}/download`;
-  const response = await apiFetch(apiUrl, endpoint, {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
     method: 'GET',
     headers: {
       'X-API-Key': apiKey.trim()
-    }
+    },
+    timeoutMs,
+    signal
   });
-
-  await assertOk(response, endpoint);
 
   return await response.blob();
 }

--- a/desktop/src/lib/apiClient.ts
+++ b/desktop/src/lib/apiClient.ts
@@ -1,0 +1,142 @@
+export const DEFAULT_CHAT_TIMEOUT_MS = 120_000;
+export const DEFAULT_GENERATION_TIMEOUT_MS = 300_000;
+
+export type ApiErrorCode = 'timeout' | 'cancelled' | 'auth' | 'server' | 'http' | 'network';
+
+export class ApiRequestError extends Error {
+  code: ApiErrorCode;
+  endpoint: string;
+  status?: number;
+
+  constructor(message: string, code: ApiErrorCode, endpoint: string, status?: number) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.code = code;
+    this.endpoint = endpoint;
+    this.status = status;
+  }
+}
+
+interface ApiRequestOptions extends Omit<RequestInit, 'signal'> {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+function combineSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (!activeSignals.length) return undefined;
+
+  const controller = new AbortController();
+
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abort();
+      return controller.signal;
+    }
+
+    signal.addEventListener('abort', abort, { once: true });
+  }
+
+  return controller.signal;
+}
+
+async function readResponseBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.trim() || '<пустой ответ>';
+  } catch {
+    return '<пустой ответ>';
+  }
+}
+
+function formatNetworkMessage(endpoint: string, details?: string): string {
+  const suffix = details ? ` Детали: ${details}` : '';
+  return `Ошибка сети при обращении к ${endpoint}: проверьте интернет, API URL и доступность сервера.${suffix}`;
+}
+
+async function toHttpError(response: Response, endpoint: string): Promise<ApiRequestError> {
+  const body = await readResponseBody(response);
+
+  if (response.status === 401 || response.status === 403) {
+    return new ApiRequestError(
+      `Ошибка авторизации (${response.status}) для ${endpoint}. Проверьте API Key в настройках клиента и на сервере.`,
+      'auth',
+      endpoint,
+      response.status
+    );
+  }
+
+  if (response.status >= 500) {
+    return new ApiRequestError(
+      `Ошибка сервера (${response.status}) для ${endpoint}. Попробуйте повторить запрос позже. Ответ: ${body}`,
+      'server',
+      endpoint,
+      response.status
+    );
+  }
+
+  return new ApiRequestError(
+    `HTTP ${response.status} для ${endpoint}. Ответ сервера: ${body}`,
+    'http',
+    endpoint,
+    response.status
+  );
+}
+
+export async function apiRequest(apiUrl: string, endpoint: string, options: ApiRequestOptions = {}): Promise<Response> {
+  const { timeoutMs, signal, ...init } = options;
+  const controller = new AbortController();
+  const mergedSignal = combineSignals(signal, controller.signal);
+
+  let timeoutId: number | null = null;
+  let timedOut = false;
+
+  if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+    timeoutId = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
+  }
+
+  try {
+    const response = await fetch(`${apiUrl}${endpoint}`, {
+      ...init,
+      signal: mergedSignal
+    });
+
+    if (!response.ok) {
+      throw await toHttpError(response, endpoint);
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof ApiRequestError) {
+      throw error;
+    }
+
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      if (timedOut) {
+        throw new ApiRequestError(
+          `Превышено время ожидания ответа (${Math.round((timeoutMs ?? 0) / 1000)} c) для ${endpoint}.`,
+          'timeout',
+          endpoint
+        );
+      }
+
+      throw new ApiRequestError(`Запрос к ${endpoint} был отменён.`, 'cancelled', endpoint);
+    }
+
+    const details = error instanceof Error ? error.message : undefined;
+    throw new ApiRequestError(formatNetworkMessage(endpoint, details), 'network', endpoint);
+  } finally {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+  }
+}

--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -4,6 +4,7 @@ import Card from '../components/ui/Card';
 import Input from '../components/ui/Input';
 import { colors, radius, spacing, typography } from '../styles/tokens';
 import { downloadKSDocx, generateKS, getApiConfig, type KSWorkItem } from '../api/coreClient';
+import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 
 const unitOptions = ['м²', 'м³', 'пог.м.', 'шт.', 'т', 'кг', 'компл.', 'услуга'] as const;
 
@@ -219,13 +220,18 @@ export default function GenerateKSPage() {
       }
 
       const { apiUrl, apiKey } = await getApiConfig();
-      const response = await generateKS(apiUrl, apiKey, {
-        object_name: formValues.objectName.trim(),
-        contract_number: formValues.contractNumber.trim(),
-        period_from: parseDateRU(formValues.dateFrom),
-        period_to: parseDateRU(formValues.dateTo),
-        work_items: workItems
-      });
+      const response = await generateKS(
+        apiUrl,
+        apiKey,
+        {
+          object_name: formValues.objectName.trim(),
+          contract_number: formValues.contractNumber.trim(),
+          period_from: parseDateRU(formValues.dateFrom),
+          period_to: parseDateRU(formValues.dateTo),
+          work_items: workItems
+        },
+        { timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS }
+      );
 
       setSessionId(String(response.session_id ?? ''));
       setSuccess(true);
@@ -264,7 +270,9 @@ export default function GenerateKSPage() {
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const blob = await downloadKSDocx(apiUrl, apiKey, sessionId);
+      const blob = await downloadKSDocx(apiUrl, apiKey, sessionId, {
+        timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS
+      });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -5,6 +5,7 @@ import Card from '../components/ui/Card';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
 import { downloadLetterDocx, generateLetter, getApiConfig } from '../api/coreClient';
+import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 
 const letterTypeMap: Record<string, 'запрос' | 'претензия' | 'уведомление' | 'ответ'> = {
   Запрос: 'запрос',
@@ -45,12 +46,17 @@ export default function GenerateLetterPage() {
         .map((item) => item.trim())
         .filter(Boolean);
 
-      const response = await generateLetter(apiUrl, apiKey, {
-        letter_type: letterTypeMap[data.letter_type] ?? 'запрос',
-        addressee: data.addressee,
-        subject: data.subject,
-        body_points: bodyPoints
-      });
+      const response = await generateLetter(
+        apiUrl,
+        apiKey,
+        {
+          letter_type: letterTypeMap[data.letter_type] ?? 'запрос',
+          addressee: data.addressee,
+          subject: data.subject,
+          body_points: bodyPoints
+        },
+        { timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS }
+      );
 
       const normalizedResult =
         response.document ?? response.result ?? response.text ?? response.content ?? '';
@@ -79,7 +85,9 @@ export default function GenerateLetterPage() {
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const blob = await downloadLetterDocx(apiUrl, apiKey, sessionId);
+      const blob = await downloadLetterDocx(apiUrl, apiKey, sessionId, {
+        timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS
+      });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;

--- a/desktop/src/pages/GenerateTKPage.tsx
+++ b/desktop/src/pages/GenerateTKPage.tsx
@@ -5,6 +5,7 @@ import Card from '../components/ui/Card';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
 import { downloadTKDocx, generateTK, getApiConfig } from '../api/coreClient';
+import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 
 const fields: DocumentField[] = [
   { name: 'work_type', label: 'Тип работ', type: 'text' },
@@ -34,12 +35,17 @@ export default function GenerateTKPage() {
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const response = await generateTK(apiUrl, apiKey, {
-        work_type: data.work_type,
-        object_name: data.object_name,
-        volume: Number(data.volume),
-        unit: data.unit
-      });
+      const response = await generateTK(
+        apiUrl,
+        apiKey,
+        {
+          work_type: data.work_type,
+          object_name: data.object_name,
+          volume: Number(data.volume),
+          unit: data.unit
+        },
+        { timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS }
+      );
 
       const normalizedResult =
         response.document ?? response.result ?? response.text ?? response.content ?? '';
@@ -69,7 +75,9 @@ export default function GenerateTKPage() {
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const blob = await downloadTKDocx(apiUrl, apiKey, sessionId);
+      const blob = await downloadTKDocx(apiUrl, apiKey, sessionId, {
+        timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS
+      });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;


### PR DESCRIPTION
### Motivation
- Fix client-side 30s cutoff causing "Не удалось подключиться..." by moving network logic to a single place and enabling longer, configurable timeouts for long generation endpoints.
- Make cancellation and timeout behavior explicit with `AbortController` support and clearer user-facing error messages for auth, server and network failures.

### Description
- Added a unified network module `desktop/src/lib/apiClient.ts` that implements `apiRequest`, `AbortController` signal merging, `timeoutMs` per-request, `ApiRequestError` with categories (`timeout`, `cancelled`, `auth`, `server`, `http`, `network`) and default constants `DEFAULT_CHAT_TIMEOUT_MS`/`DEFAULT_GENERATION_TIMEOUT_MS`.
- Reworked `desktop/src/api/coreClient.ts` to use `apiRequest`, expose `{ timeoutMs?, signal? }` (`ApiCallOptions`) on every API call and set generation APIs to default to the longer generation timeout.
- Updated generation pages to explicitly pass the increased timeout for long operations and downloads: `desktop/src/pages/GenerateTKPage.tsx`, `desktop/src/pages/GenerateKSPage.tsx`, `desktop/src/pages/GenerateLetterPage.tsx` now pass `DEFAULT_GENERATION_TIMEOUT_MS` to generation and DOCX download calls.
- Improved error text so users see distinct messages for timeouts/cancellations, 401/403 auth errors, 5xx server errors, and network connectivity issues.

### Testing
- Ran `npm run build` in `desktop` successfully (`vite` build + `tsc` completed) which verifies the front-end bundle builds. ✅
- Ran `npm run tauri build` which failed in this environment due to missing system dependency `glib-2.0` (`pkg-config` could not find `glib-2.0.pc`), so the native bundle build is blocked by the environment, not by the changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e471444074832fa21f8214de5c34ea)