### PR TITLE
desktop: add Knowledge Base page with PDF upload and document counter

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -37,12 +37,36 @@ fn set_api_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
   store.save().map_err(|e| e.to_string())
 }
 
+#[derive(serde::Serialize)]
+struct PickedPdfFile {
+  path: String,
+  name: String,
+  size: u64
+}
+
 #[tauri::command]
-fn open_file_dialog() -> Option<String> {
-  rfd::FileDialog::new()
+fn pick_pdf_file() -> Option<PickedPdfFile> {
+  let file = rfd::FileDialog::new()
     .add_filter("PDF", &["pdf"])
-    .pick_file()
-    .map(|p| p.display().to_string())
+    .pick_file()?;
+
+  let metadata = fs::metadata(&file).ok()?;
+  let name = file
+    .file_name()
+    .and_then(|n| n.to_str())
+    .map(str::to_string)
+    .unwrap_or_else(|| "document.pdf".to_string());
+
+  Some(PickedPdfFile {
+    path: file.display().to_string(),
+    name,
+    size: metadata.len()
+  })
+}
+
+#[tauri::command]
+fn read_pdf_file_bytes(path: String) -> Result<Vec<u8>, String> {
+  fs::read(path).map_err(|e| e.to_string())
 }
 
 fn ensure_store_defaults(app: &tauri::AppHandle) -> Result<(), String> {
@@ -70,7 +94,7 @@ fn main() {
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
       Ok(())
     })
-    .invoke_handler(tauri::generate_handler![get_api_url, set_api_url, open_file_dialog])
+    .invoke_handler(tauri::generate_handler![get_api_url, set_api_url, pick_pdf_file, read_pdf_file_bytes])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -28,6 +28,7 @@ const TKIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round
 const LetterIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5v10.5H3.75V6.75Zm0 0 8.25 6 8.25-6" /></BaseIcon>;
 const KSIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 5.25h15v13.5h-15V5.25Zm0 4.5h15M10.5 5.25v13.5" /></BaseIcon>;
 const HandoverIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></BaseIcon>;
+const KnowledgeBaseIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M6 4.5h9l3 3v12H6v-15Zm9 0v3h3M8.25 13.5h7.5m-7.5-3h7.5" /></BaseIcon>;
 
 const navItems: NavItem[] = [
   { path: '/', label: 'Чат', icon: <ChatIcon /> },
@@ -35,7 +36,8 @@ const navItems: NavItem[] = [
   { path: '/generate/tk', label: 'Генерация ТК', icon: <TKIcon /> },
   { path: '/generate/letter', label: 'Генерация письма', icon: <LetterIcon /> },
   { path: '/generate/ks', label: 'Генерация КС', icon: <KSIcon /> },
-  { path: '/handover', label: 'Сдача объекта', icon: <HandoverIcon /> }
+  { path: '/handover', label: 'Сдача объекта', icon: <HandoverIcon /> },
+  { path: '/knowledge-base', label: 'База знаний', icon: <KnowledgeBaseIcon /> }
 ];
 
 export default function Sidebar({ currentPath, onNavigate }: SidebarProps) {

--- a/desktop/src/components/StatusBar.tsx
+++ b/desktop/src/components/StatusBar.tsx
@@ -14,10 +14,11 @@ const ROLE_LABELS: Record<ChatRole, string> = {
 
 export default function StatusBar() {
   const role = useChatStore((state) => state.role);
-  const { isOnline, isChecking, serverVersion } = useServerStatusStore((state) => ({
+  const { isOnline, isChecking, serverVersion, documentsCount } = useServerStatusStore((state) => ({
     isOnline: state.isOnline,
     isChecking: state.isChecking,
-    serverVersion: state.serverVersion
+    serverVersion: state.serverVersion,
+    documentsCount: state.documentsCount
   }));
 
   const status = useMemo(() => {
@@ -70,7 +71,7 @@ export default function StatusBar() {
         app v{APP_VERSION} · server v{serverVersion || '—'}
       </div>
 
-      <div style={{ justifySelf: 'end' }}>Роль: {ROLE_LABELS[role]}</div>
+      <div style={{ justifySelf: 'end' }}>Документов: {documentsCount} · Роль: {ROLE_LABELS[role]}</div>
 
       <style>{`@keyframes statusbar-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }`}</style>
     </footer>

--- a/desktop/src/pages/KnowledgeBasePage.tsx
+++ b/desktop/src/pages/KnowledgeBasePage.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import { checkHealth, getApiConfig, type HealthResponse } from '../api/coreClient';
+import { colors, spacing } from '../styles/tokens';
+import { useServerStatusStore } from '../store/serverStatusStore';
+
+type PickedPdfFile = {
+  path: string;
+  name: string;
+  size: number;
+};
+
+type UploadedDocument = {
+  source: string;
+  uploadedAt: string;
+  size: number | null;
+};
+
+type SourcesResponse = {
+  sources: Array<{ source: string; chunks: number }>;
+};
+
+const formatSize = (bytes: number | null) => {
+  if (bytes === null || Number.isNaN(bytes)) {
+    return '—';
+  }
+
+  if (bytes < 1024) {
+    return `${bytes} Б`;
+  }
+
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} КБ`;
+  }
+
+  return `${(kb / 1024).toFixed(2)} МБ`;
+};
+
+export default function KnowledgeBasePage() {
+  const [documents, setDocuments] = useState<UploadedDocument[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUploading, setIsUploading] = useState(false);
+  const [message, setMessage] = useState<string>('');
+  const [messageTone, setMessageTone] = useState<'success' | 'warning' | 'error'>('success');
+
+  const fetchSources = async () => {
+    const { apiUrl, apiKey } = await getApiConfig();
+    const response = await fetch(`${apiUrl.replace(/\/$/, '')}/api/rag/sources`, {
+      method: 'GET',
+      headers: {
+        'X-API-Key': apiKey.trim()
+      },
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Не удалось получить список документов (HTTP ${response.status}).`);
+    }
+
+    const payload = (await response.json()) as SourcesResponse;
+    const nowIso = new Date().toISOString();
+    setDocuments(
+      payload.sources.map((source) => ({
+        source: source.source,
+        uploadedAt: nowIso,
+        size: null
+      }))
+    );
+  };
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      setMessage('');
+      try {
+        await fetchSources();
+      } catch (error) {
+        setMessageTone('error');
+        setMessage(error instanceof Error ? error.message : 'Не удалось загрузить данные KB.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+  }, []);
+
+  const refreshServerStatus = async () => {
+    const health: HealthResponse = await checkHealth((await getApiConfig()).apiUrl);
+    useServerStatusStore.getState().updateFromHealth(health);
+  };
+
+  const onUploadPdf = async () => {
+    setMessage('');
+    setIsUploading(true);
+
+    try {
+      const selected = await invoke<PickedPdfFile | null>('pick_pdf_file');
+      if (!selected) {
+        setMessageTone('warning');
+        setMessage('Загрузка отменена: файл не выбран.');
+        return;
+      }
+
+      const fileBytes = await invoke<number[]>('read_pdf_file_bytes', { path: selected.path });
+      const { apiUrl, apiKey } = await getApiConfig();
+      const formData = new FormData();
+      const fileBlob = new Blob([new Uint8Array(fileBytes)], { type: 'application/pdf' });
+      formData.append('file', fileBlob, selected.name);
+      formData.append('source_name', selected.name);
+
+      const response = await fetch(`${apiUrl.replace(/\/$/, '')}/api/rag/ingest`, {
+        method: 'POST',
+        headers: {
+          'X-API-Key': apiKey.trim()
+        },
+        body: formData,
+        signal: AbortSignal.timeout(60_000)
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Ошибка загрузки PDF (HTTP ${response.status}): ${body}`);
+      }
+
+      const uploadedAt = new Date().toISOString();
+      setDocuments((prev) => {
+        const withoutExisting = prev.filter((doc) => doc.source !== selected.name);
+        return [{ source: selected.name, uploadedAt, size: selected.size }, ...withoutExisting];
+      });
+
+      await Promise.all([fetchSources(), refreshServerStatus()]);
+
+      setMessageTone('success');
+      setMessage(`Файл «${selected.name}» успешно загружен в KB.`);
+    } catch (error) {
+      setMessageTone('error');
+      setMessage(error instanceof Error ? error.message : 'Не удалось загрузить PDF в базу знаний.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const sortedDocuments = useMemo(
+    () => [...documents].sort((a, b) => new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime()),
+    [documents]
+  );
+
+  return (
+    <Card>
+      <div style={{ display: 'grid', gap: spacing.md }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: spacing.sm }}>
+          <h2 style={{ margin: 0 }}>База знаний (KB)</h2>
+          <Button onClick={onUploadPdf} disabled={isUploading} loading={isUploading}>
+            {isUploading ? 'Загрузка...' : 'Загрузить PDF'}
+          </Button>
+        </div>
+
+        {message && (
+          <p
+            style={{
+              margin: 0,
+              color: messageTone === 'success' ? colors.success : messageTone === 'warning' ? colors.warning : colors.error
+            }}
+          >
+            {message}
+          </p>
+        )}
+
+        {isLoading ? (
+          <p style={{ margin: 0 }}>Загрузка списка документов…</p>
+        ) : sortedDocuments.length === 0 ? (
+          <p style={{ margin: 0, color: colors.warning }}>В базе знаний пока нет документов. Загрузите первый PDF.</p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}`, paddingBottom: spacing.xs }}>Имя файла</th>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}`, paddingBottom: spacing.xs }}>Дата загрузки</th>
+                <th style={{ textAlign: 'left', borderBottom: `1px solid ${colors.border}`, paddingBottom: spacing.xs }}>Размер</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedDocuments.map((doc) => (
+                <tr key={doc.source}>
+                  <td style={{ paddingTop: spacing.xs }}>{doc.source}</td>
+                  <td style={{ paddingTop: spacing.xs }}>{new Date(doc.uploadedAt).toLocaleString('ru-RU')}</td>
+                  <td style={{ paddingTop: spacing.xs }}>{formatSize(doc.size)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/desktop/src/pages/SettingsPage.tsx
+++ b/desktop/src/pages/SettingsPage.tsx
@@ -225,7 +225,7 @@ export default function SettingsPage() {
                 const statusIcon = component.status === 'ok' || component.status === 'active' ? '✅' : '⚠️';
                 const details =
                   key === 'rag_engine'
-                    ? `${String(component.chunks_count ?? 0)} документов`
+                    ? `${String(component.sources ?? 0)} документов`
                     : key === 'llm_router' && component.provider
                       ? String(component.provider)
                       : '-';
@@ -242,7 +242,7 @@ export default function SettingsPage() {
               })}
             </tbody>
           </table>
-          {(health.components.rag_engine?.chunks_count as number | undefined) === 0 && (
+          {(health.components.rag_engine?.sources as number | undefined) === 0 && (
             <p style={{ marginBottom: 0, color: colors.warning }}>
               RAG база пуста. Нормативы (СП, ГОСТ) не загружены — качество ответов снижено.
             </p>

--- a/desktop/src/router.tsx
+++ b/desktop/src/router.tsx
@@ -4,6 +4,7 @@ import GenerateKSPage from './pages/GenerateKSPage';
 import GenerateLetterPage from './pages/GenerateLetterPage';
 import GenerateTKPage from './pages/GenerateTKPage';
 import HandoverPage from './pages/HandoverPage';
+import KnowledgeBasePage from './pages/KnowledgeBasePage';
 import SettingsPage from './pages/SettingsPage';
 
 export function resolveRoute(path: string, onNavigateHome: () => void): ReactNode {
@@ -12,6 +13,8 @@ export function resolveRoute(path: string, onNavigateHome: () => void): ReactNod
       return <ChatPage />;
     case '/settings':
       return <SettingsPage />;
+    case '/knowledge-base':
+      return <KnowledgeBasePage />;
     case '/generate/tk':
       return <GenerateTKPage />;
     case '/generate/letter':

--- a/desktop/src/store/serverStatusStore.ts
+++ b/desktop/src/store/serverStatusStore.ts
@@ -6,6 +6,7 @@ export interface ServerStatus {
   lastChecked: string | null;
   serverVersion: string | null;
   isChecking: boolean;
+  documentsCount: number;
 }
 
 interface ServerStatusState extends ServerStatus {
@@ -19,6 +20,7 @@ export const useServerStatusStore = create<ServerStatusState>((set) => ({
   lastChecked: null,
   serverVersion: null,
   isChecking: false,
+  documentsCount: 0,
   setOnline: (value) =>
     set({
       isOnline: value,
@@ -30,6 +32,7 @@ export const useServerStatusStore = create<ServerStatusState>((set) => ({
       isOnline: health.status === 'ok',
       serverVersion: health.version,
       lastChecked: new Date().toISOString(),
-      isChecking: false
+      isChecking: false,
+      documentsCount: Number(health.components.rag_engine?.sources ?? 0)
     })
 }));


### PR DESCRIPTION
### Motivation
- Закрыть пробел в десктопе — нет UI для загрузки PDF в RAG, из-за чего KB всегда выглядит пустой и в статусе показывается 0 документов.

### Description
- Добавлена новая страница и маршрут `KnowledgeBasePage` доступная по `/knowledge-base`, отображающая список источников (имя/дата/размер) и кнопку `Загрузить PDF`.
- Реализована нативная выборка файла и чтение байт в Tauri: добавлены команды `pick_pdf_file` и `read_pdf_file_bytes` в `desktop/src-tauri/src/main.rs`, которые возвращают `{ path, name, size }` и содержимое файла соответственно.
- При загрузке используется существующий серверный endpoint `POST /api/rag/ingest` и список загружается из `GET /api/rag/sources` в `desktop/src/pages/KnowledgeBasePage.tsx`.
- Обновлена навигация (`desktop/src/router.tsx`, `desktop/src/components/Sidebar.tsx`) и глобальный статус: добавлен `documentsCount` в `serverStatusStore` и отображается в `StatusBar`, а в `SettingsPage` исправлён показ количества документов на `rag_engine.sources` вместо `chunks_count`.
- После успешной загрузки PDF страница обновляет список источников и вызывает `checkHealth` чтобы немедленно обновить счётчик документов в статусе.

### Testing
- Успешно собрана фронтенд часть: `cd desktop && npm run build` (TypeScript + Vite) — сборка прошла ✅.
- Проверка Rust/tauri с `cd desktop/src-tauri && cargo check` не прошла в CI/контейнере из-за отсутствующей системной библиотеки `glib-2.0` (pkg-config), что является окруженческой ограничением, а не проблемой кода ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4775724a8832fbe42b3973c1bbe0b)