### PR TITLE
fix(desktop): add tauri ACL permissions for PDF upload flow

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -2,6 +2,15 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default capability",
-  "windows": ["main"],
-  "permissions": ["core:default", "store:default"]
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "core:default",
+    "store:default",
+    "allow-get-api-url",
+    "allow-set-api-url",
+    "allow-pick-pdf-file",
+    "allow-read-pdf-file-bytes"
+  ]
 }

--- a/desktop/src-tauri/gen/schemas/capabilities.json
+++ b/desktop/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default capability","local":true,"windows":["main"],"permissions":["core:default","store:default"]}}
+{"default":{"identifier":"default","description":"Default capability","local":true,"windows":["main"],"permissions":["core:default","store:default","allow-get-api-url","allow-set-api-url","allow-pick-pdf-file","allow-read-pdf-file-bytes"]}}

--- a/desktop/src-tauri/permissions/commands/get_api_url.toml
+++ b/desktop/src-tauri/permissions/commands/get_api_url.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-get-api-url"
+description = "Enables the get_api_url command without any pre-configured scope."
+commands.allow = ["get_api_url"]
+
+[[permission]]
+identifier = "deny-get-api-url"
+description = "Denies the get_api_url command without any pre-configured scope."
+commands.deny = ["get_api_url"]

--- a/desktop/src-tauri/permissions/commands/pick_pdf_file.toml
+++ b/desktop/src-tauri/permissions/commands/pick_pdf_file.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-pick-pdf-file"
+description = "Enables the pick_pdf_file command without any pre-configured scope."
+commands.allow = ["pick_pdf_file"]
+
+[[permission]]
+identifier = "deny-pick-pdf-file"
+description = "Denies the pick_pdf_file command without any pre-configured scope."
+commands.deny = ["pick_pdf_file"]

--- a/desktop/src-tauri/permissions/commands/read_pdf_file_bytes.toml
+++ b/desktop/src-tauri/permissions/commands/read_pdf_file_bytes.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-read-pdf-file-bytes"
+description = "Enables the read_pdf_file_bytes command without any pre-configured scope."
+commands.allow = ["read_pdf_file_bytes"]
+
+[[permission]]
+identifier = "deny-read-pdf-file-bytes"
+description = "Denies the read_pdf_file_bytes command without any pre-configured scope."
+commands.deny = ["read_pdf_file_bytes"]

--- a/desktop/src-tauri/permissions/commands/set_api_url.toml
+++ b/desktop/src-tauri/permissions/commands/set_api_url.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-set-api-url"
+description = "Enables the set_api_url command without any pre-configured scope."
+commands.allow = ["set_api_url"]
+
+[[permission]]
+identifier = "deny-set-api-url"
+description = "Denies the set_api_url command without any pre-configured scope."
+commands.deny = ["set_api_url"]

--- a/desktop/src-tauri/permissions/default.toml
+++ b/desktop/src-tauri/permissions/default.toml
@@ -1,0 +1,9 @@
+[[set]]
+identifier = "default"
+description = "Default permissions for the app commands used by the desktop UI."
+permissions = [
+  "allow-get-api-url",
+  "allow-set-api-url",
+  "allow-pick-pdf-file",
+  "allow-read-pdf-file-bytes"
+]


### PR DESCRIPTION
### Motivation
- Release desktop builds blocked calls for file selection and reading because the Tauri capability/ACL did not expose app commands used by the PDF upload flow.  
- The change adds explicit allow rules so the `main` window can invoke the native file picker and read selected file bytes in packaged/release builds.

### Description
- Added command permission manifests under `desktop/src-tauri/permissions/commands/` for `pick_pdf_file`, `read_pdf_file_bytes`, `get_api_url`, and `set_api_url`.  
- Introduced an app-level permission set in `desktop/src-tauri/permissions/default.toml` grouping the new command permissions.  
- Updated `desktop/src-tauri/capabilities/default.json` and the committed generated file `desktop/src-tauri/gen/schemas/capabilities.json` to include the new permission identifiers (`allow-pick-pdf-file`, `allow-read-pdf-file-bytes`, `allow-get-api-url`, `allow-set-api-url`).  
- Changes were committed to the repo so packaged Tauri builds will include the ACL entries.

### Testing
- Ran `cargo check` in `desktop/src-tauri`; the build check failed due to a missing system dependency (`glib-2.0` / `pkg-config`) in the container environment and not because of ACL changes.  
- No other automated tests were present or run for these ACL/config changes in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47e7f27bc832fb971e3a3d5f65573)