### PR TITLE
desktop: add client-side validation for TK/KS/Letter with inline field errors

### DIFF
--- a/desktop/src/components/DocumentForm.tsx
+++ b/desktop/src/components/DocumentForm.tsx
@@ -16,9 +16,11 @@ export interface DocumentField {
 interface DocumentFormProps {
   fields: DocumentField[];
   onSubmit: (data: Record<string, string>) => void;
+  onValuesChange?: (data: Record<string, string>) => void;
   isLoading: boolean;
   error?: string;
   disabledOnLoading?: boolean;
+  fieldErrors?: Record<string, string>;
 }
 
 const makeInitialValues = (fields: DocumentField[]): Record<string, string> =>
@@ -30,9 +32,11 @@ const makeInitialValues = (fields: DocumentField[]): Record<string, string> =>
 export default function DocumentForm({
   fields,
   onSubmit,
+  onValuesChange,
   isLoading,
   error,
-  disabledOnLoading = true
+  disabledOnLoading = true,
+  fieldErrors = {}
 }: DocumentFormProps) {
   const initialValues = useMemo(() => makeInitialValues(fields), [fields]);
   const [values, setValues] = useState<Record<string, string>>(initialValues);
@@ -41,6 +45,10 @@ export default function DocumentForm({
     setValues(initialValues);
   }, [initialValues]);
 
+
+  useEffect(() => {
+    onValuesChange?.(values);
+  }, [onValuesChange, values]);
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     onSubmit(values);
@@ -56,6 +64,7 @@ export default function DocumentForm({
         <div key={field.name}>
           {field.type === 'textarea' ? (
             <Input
+              error={fieldErrors[field.name]}
               type="textarea"
               rows={6}
               value={values[field.name] ?? ''}
@@ -93,9 +102,13 @@ export default function DocumentForm({
                   </option>
                 ))}
               </select>
+              {fieldErrors[field.name] && (
+                <span style={{ color: colors.error, fontSize: typography.small.fontSize }}>{fieldErrors[field.name]}</span>
+              )}
             </label>
           ) : (
             <Input
+              error={fieldErrors[field.name]}
               type={field.type}
               value={values[field.name] ?? ''}
               onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}

--- a/desktop/src/lib/validation.ts
+++ b/desktop/src/lib/validation.ts
@@ -1,0 +1,155 @@
+import type { KSWorkItem } from '../api/coreClient';
+
+export interface TKValidationInput {
+  work_type: string;
+  object_name: string;
+  volume: number;
+  unit: string;
+}
+
+export interface KSValidationInput {
+  object_name: string;
+  contract_number: string;
+  period_from: string;
+  period_to: string;
+  work_items: KSWorkItem[];
+}
+
+export interface LetterValidationInput {
+  addressee: string;
+  subject: string;
+  body_points: string[];
+}
+
+export interface ValidationResult {
+  fieldErrors: Record<string, string>;
+  isValid: boolean;
+}
+
+const DATE_ISO_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DATE_RU_PATTERN = /^(\d{2})\.(\d{2})\.(\d{4})$/;
+
+function toIsoDate(value: string): string | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+
+  if (DATE_ISO_PATTERN.test(normalized)) {
+    const parsed = new Date(`${normalized}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return normalized;
+  }
+
+  const ruMatch = normalized.match(DATE_RU_PATTERN);
+  if (!ruMatch) {
+    return null;
+  }
+
+  const [, dayStr, monthStr, yearStr] = ruMatch;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    parsedDate.getUTCFullYear() !== year ||
+    parsedDate.getUTCMonth() + 1 !== month ||
+    parsedDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return `${yearStr}-${monthStr}-${dayStr}`;
+}
+
+export function validateTK(input: TKValidationInput): ValidationResult {
+  const fieldErrors: Record<string, string> = {};
+
+  if (input.work_type.trim().length < 5) {
+    fieldErrors.work_type = 'Тип работ: минимум 5 символов.';
+  }
+  if (input.object_name.trim().length < 3) {
+    fieldErrors.object_name = 'Название объекта: минимум 3 символа.';
+  }
+  if (!Number.isFinite(input.volume) || input.volume <= 0) {
+    fieldErrors.volume = 'Объём должен быть числом больше 0.';
+  }
+  if (!input.unit.trim()) {
+    fieldErrors.unit = 'Выберите единицу измерения.';
+  }
+
+  return { fieldErrors, isValid: Object.keys(fieldErrors).length === 0 };
+}
+
+export function validateKS(input: KSValidationInput): ValidationResult {
+  const fieldErrors: Record<string, string> = {};
+
+  if (input.object_name.trim().length < 3) {
+    fieldErrors.object_name = 'Название объекта: минимум 3 символа.';
+  }
+  if (input.contract_number.trim().length < 2) {
+    fieldErrors.contract_number = 'Номер договора: минимум 2 символа.';
+  }
+
+  const periodFrom = toIsoDate(input.period_from);
+  const periodTo = toIsoDate(input.period_to);
+
+  if (!input.period_from.trim()) {
+    fieldErrors.period_from = 'Укажите дату начала периода.';
+  } else if (!periodFrom) {
+    fieldErrors.period_from = 'Используйте формат ДД.ММ.ГГГГ или YYYY-MM-DD.';
+  }
+
+  if (!input.period_to.trim()) {
+    fieldErrors.period_to = 'Укажите дату окончания периода.';
+  } else if (!periodTo) {
+    fieldErrors.period_to = 'Используйте формат ДД.ММ.ГГГГ или YYYY-MM-DD.';
+  }
+
+  if (periodFrom && periodTo && periodFrom > periodTo) {
+    fieldErrors.period_to = 'Дата окончания не может быть раньше даты начала.';
+  }
+
+  if (!input.work_items.length) {
+    fieldErrors.work_items = 'Добавьте хотя бы одну работу.';
+  }
+
+  input.work_items.forEach((item, index) => {
+    const row = index + 1;
+    if (item.name.trim().length < 2) {
+      fieldErrors[`work_items.${index}.name`] = `Строка ${row}: минимум 2 символа в наименовании.`;
+    }
+    if (!Number.isFinite(item.volume) || item.volume <= 0) {
+      fieldErrors[`work_items.${index}.volume`] = `Строка ${row}: объём должен быть > 0.`;
+    }
+    if (!Number.isFinite(item.norm_hours) || item.norm_hours <= 0) {
+      fieldErrors[`work_items.${index}.norm_hours`] = `Строка ${row}: нормо-часы должны быть > 0.`;
+    }
+    if (!Number.isFinite(item.price_per_unit) || item.price_per_unit <= 0) {
+      fieldErrors[`work_items.${index}.price_per_unit`] = `Строка ${row}: цена должна быть > 0.`;
+    }
+  });
+
+  return { fieldErrors, isValid: Object.keys(fieldErrors).length === 0 };
+}
+
+export function validateLetter(input: LetterValidationInput): ValidationResult {
+  const fieldErrors: Record<string, string> = {};
+
+  if (input.addressee.trim().length < 3) {
+    fieldErrors.addressee = 'Адресат: минимум 3 символа.';
+  }
+  if (input.subject.trim().length < 5) {
+    fieldErrors.subject = 'Тема: минимум 5 символов.';
+  }
+
+  const cleanedPoints = input.body_points.map((item) => item.trim()).filter(Boolean);
+  if (cleanedPoints.length === 0) {
+    fieldErrors.body = 'Добавьте хотя бы один тезис в содержании письма.';
+  } else if (cleanedPoints.some((item) => item.length < 3)) {
+    fieldErrors.body = 'Каждый тезис должен содержать минимум 3 символа.';
+  }
+
+  return { fieldErrors, isValid: Object.keys(fieldErrors).length === 0 };
+}

--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -15,6 +15,7 @@ import {
   type KSWorkItem
 } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
+import { validateKS } from '../lib/validation';
 
 const unitOptions = ['м²', 'м³', 'пог.м.', 'шт.', 'т', 'кг', 'компл.', 'услуга'] as const;
 
@@ -34,13 +35,6 @@ interface KSFormValues {
   dateTo: string;
 }
 
-interface ValidationErrors {
-  objectName?: string;
-  contractNumber?: string;
-  dateFrom?: string;
-  dateTo?: string;
-  workItems?: string;
-}
 
 function createEmptyWorkRow(): WorkRow {
   return {
@@ -116,7 +110,6 @@ export default function GenerateKSPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState('');
   const [error, setError] = useState('');
-  const [warning, setWarning] = useState('');
   const [importInfo, setImportInfo] = useState('');
   const [sessionId, setSessionId] = useState('');
   const [success, setSuccess] = useState(false);
@@ -124,10 +117,16 @@ export default function GenerateKSPage() {
   const [summary, setSummary] = useState<KSSummary | null>(null);
   const [progress, setProgress] = useState(0);
   const [stage, setStage] = useState<GenerationStage>('queued');
-  const [validationErrors, setValidationErrors] = useState<ValidationErrors>({});
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
   const handleRowChange = (rowId: string, key: keyof Omit<WorkRow, 'id'>, value: string) => {
     setWorkRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, [key]: value } : row)));
+    if (Object.keys(validationErrors).length > 0) {
+      setValidationErrors({});
+    }
+    if (error === 'Исправьте ошибки формы перед отправкой.') {
+      setError('');
+    }
   };
 
   const addRow = () => {
@@ -138,52 +137,18 @@ export default function GenerateKSPage() {
     setWorkRows((prev) => (prev.length > 1 ? prev.filter((row) => row.id !== rowId) : prev));
   };
 
-  const buildWorkItems = (): KSWorkItem[] => {
-    const zeroValueRows: string[] = [];
-    const workItems = workRows
-      .map((row) => ({ ...row, name: row.name.trim() }))
-      .filter((row) => row.name.length > 0)
-      .map((row) => {
-        const volume = Number(row.volume || '0');
-        const normHours = Number(row.normHours || '0');
-        const pricePerUnit = Number(row.pricePerUnit || '0');
-
-        if (
-          Number.isNaN(volume) ||
-          Number.isNaN(normHours) ||
-          Number.isNaN(pricePerUnit) ||
-          volume < 0 ||
-          normHours < 0 ||
-          pricePerUnit < 0
-        ) {
-          throw new Error(`Строка «${row.name}» содержит некорректные числовые значения.`);
-        }
-
-        if (volume === 0 || normHours === 0 || pricePerUnit === 0) {
-          zeroValueRows.push(row.name);
-        }
-
-        return {
-          name: row.name,
-          unit: row.unit,
-          volume,
-          norm_hours: normHours,
-          price_per_unit: pricePerUnit
-        };
-      });
-
-    if (zeroValueRows.length) {
-      setWarning(`Предупреждение: у работ с нулевыми значениями: ${zeroValueRows.join(', ')}.`);
-    } else {
-      setWarning('');
-    }
-
-    return workItems;
+  const buildWorkItems = (rows: WorkRow[] = workRows): KSWorkItem[] => {
+    return rows.map((row) => ({
+      name: row.name.trim(),
+      unit: row.unit,
+      volume: Number(row.volume),
+      norm_hours: Number(row.normHours),
+      price_per_unit: Number(row.pricePerUnit)
+    }));
   };
 
   const handleImportFromClipboard = async () => {
     setError('');
-    setWarning('');
     setImportInfo('');
     try {
       const clipboardText = await navigator.clipboard.readText();
@@ -222,49 +187,7 @@ export default function GenerateKSPage() {
     }
   };
 
-  const validateBeforeSubmit = (): ValidationErrors => {
-    const nextErrors: ValidationErrors = {};
-    const objectName = formValues.objectName.trim();
-    const contractNumber = formValues.contractNumber.trim();
 
-    if (objectName.length < 3) {
-      nextErrors.objectName = 'Название объекта: минимум 3 символа.';
-    }
-    if (contractNumber.length < 2) {
-      nextErrors.contractNumber = 'Номер договора: минимум 2 символа.';
-    }
-
-    if (!formValues.dateFrom.trim()) {
-      nextErrors.dateFrom = 'Укажите дату начала периода.';
-    }
-    if (!formValues.dateTo.trim()) {
-      nextErrors.dateTo = 'Укажите дату окончания периода.';
-    }
-
-    if (!nextErrors.dateFrom && !nextErrors.dateTo) {
-      try {
-        const fromIso = parseDateRU(formValues.dateFrom);
-        const toIso = parseDateRU(formValues.dateTo);
-        if (fromIso > toIso) {
-          nextErrors.dateTo = 'Дата окончания не может быть раньше даты начала.';
-        }
-      } catch {
-        if (!nextErrors.dateFrom) {
-          nextErrors.dateFrom = 'Используйте формат ДД.ММ.ГГГГ или YYYY-MM-DD.';
-        }
-        if (!nextErrors.dateTo) {
-          nextErrors.dateTo = 'Используйте формат ДД.ММ.ГГГГ или YYYY-MM-DD.';
-        }
-      }
-    }
-
-    const validWorkRows = workRows.filter((row) => row.name.trim().length >= 2);
-    if (validWorkRows.length === 0) {
-      nextErrors.workItems = 'Добавьте хотя бы одну работу с названием минимум 2 символа.';
-    }
-
-    return nextErrors;
-  };
 
   const normalizeKSResponse = (response: KSGenerationResponse, payloadHeader: KSHeader): KSSummary => {
     const normalizedKs2Raw = (response.ks2 && typeof response.ks2 === 'object' ? response.ks2 : {}) as Partial<KS2Data>;
@@ -313,16 +236,19 @@ export default function GenerateKSPage() {
     setValidationErrors({});
 
     try {
-      const nextErrors = validateBeforeSubmit();
-      if (Object.keys(nextErrors).length > 0) {
-        setValidationErrors(nextErrors);
+      const workItems = buildWorkItems(workRows);
+
+      const validation = validateKS({
+        object_name: formValues.objectName,
+        contract_number: formValues.contractNumber,
+        period_from: formValues.dateFrom,
+        period_to: formValues.dateTo,
+        work_items: workItems
+      });
+
+      if (!validation.isValid) {
+        setValidationErrors(validation.fieldErrors);
         throw new Error('Исправьте ошибки формы перед отправкой.');
-      }
-
-      const workItems = buildWorkItems();
-
-      if (!workItems.length) {
-        throw new Error('Добавьте хотя бы одну строку работ');
       }
 
       const payloadHeader: KSHeader = {
@@ -407,19 +333,27 @@ export default function GenerateKSPage() {
           <Input
             label="Название объекта"
             value={formValues.objectName}
-            onChange={(event) => setFormValues((prev) => ({ ...prev, objectName: event.target.value }))}
+            onChange={(event) => {
+              setFormValues((prev) => ({ ...prev, objectName: event.target.value }));
+              if (Object.keys(validationErrors).length > 0) setValidationErrors({});
+              if (error === 'Исправьте ошибки формы перед отправкой.') setError('');
+            }}
             disabled={isLoading}
             required
           />
-          {validationErrors.objectName && <p style={{ color: colors.error }}>{validationErrors.objectName}</p>}
+          {validationErrors.object_name && <p style={{ color: colors.error }}>{validationErrors.object_name}</p>}
           <Input
             label="Номер договора"
             value={formValues.contractNumber}
-            onChange={(event) => setFormValues((prev) => ({ ...prev, contractNumber: event.target.value }))}
+            onChange={(event) => {
+              setFormValues((prev) => ({ ...prev, contractNumber: event.target.value }));
+              if (Object.keys(validationErrors).length > 0) setValidationErrors({});
+              if (error === 'Исправьте ошибки формы перед отправкой.') setError('');
+            }}
             disabled={isLoading}
             required
           />
-          {validationErrors.contractNumber && <p style={{ color: colors.error }}>{validationErrors.contractNumber}</p>}
+          {validationErrors.contract_number && <p style={{ color: colors.error }}>{validationErrors.contract_number}</p>}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: spacing.md }}>
             <label style={{ display: 'grid', gap: spacing.xs }}>
               <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
@@ -431,6 +365,8 @@ export default function GenerateKSPage() {
                 onChange={(event) => {
                   const nextValue = event.currentTarget.value.trim();
                   setFormValues((prev) => ({ ...prev, dateFrom: nextValue }));
+                  if (Object.keys(validationErrors).length > 0) setValidationErrors({});
+                  if (error === 'Исправьте ошибки формы перед отправкой.') setError('');
                 }}
                 placeholder="ДД.ММ.ГГГГ или YYYY-MM-DD"
                 required
@@ -447,7 +383,7 @@ export default function GenerateKSPage() {
               <span style={{ color: colors.textSecondary, fontSize: typography.small.fontSize }}>
                 {formatDateRuFromIso(formValues.dateFrom)}
               </span>
-              {validationErrors.dateFrom && <span style={{ color: colors.error }}>{validationErrors.dateFrom}</span>}
+              {validationErrors.period_from && <span style={{ color: colors.error }}>{validationErrors.period_from}</span>}
             </label>
             <label style={{ display: 'grid', gap: spacing.xs }}>
               <span style={{ color: colors.textPrimary, fontSize: typography.label.fontSize, fontWeight: typography.label.fontWeight }}>
@@ -459,6 +395,8 @@ export default function GenerateKSPage() {
                 onChange={(event) => {
                   const nextValue = event.currentTarget.value.trim();
                   setFormValues((prev) => ({ ...prev, dateTo: nextValue }));
+                  if (Object.keys(validationErrors).length > 0) setValidationErrors({});
+                  if (error === 'Исправьте ошибки формы перед отправкой.') setError('');
                 }}
                 placeholder="ДД.ММ.ГГГГ или YYYY-MM-DD"
                 required
@@ -475,7 +413,7 @@ export default function GenerateKSPage() {
               <span style={{ color: colors.textSecondary, fontSize: typography.small.fontSize }}>
                 {formatDateRuFromIso(formValues.dateTo)}
               </span>
-              {validationErrors.dateTo && <span style={{ color: colors.error }}>{validationErrors.dateTo}</span>}
+              {validationErrors.period_to && <span style={{ color: colors.error }}>{validationErrors.period_to}</span>}
             </label>
           </div>
           <div style={{ display: 'grid', gap: spacing.sm }}>
@@ -503,10 +441,11 @@ export default function GenerateKSPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {workRows.map((row) => (
+                  {workRows.map((row, rowIndex) => (
                     <tr key={row.id}>
                       <td style={{ border: `1px solid ${colors.border}`, padding: spacing.xs }}>
                         <Input
+                          error={validationErrors[`work_items.${rowIndex}.name`]}
                           value={row.name}
                           onChange={(event) => handleRowChange(row.id, 'name', event.target.value)}
                           placeholder="Наименование работы"
@@ -538,11 +477,12 @@ export default function GenerateKSPage() {
                         <td key={`${row.id}-${field}`} style={{ border: `1px solid ${colors.border}`, padding: spacing.xs }}>
                           <Input
                             type="number"
-                            min="0"
+                            min="0.01"
                             step="0.01"
                             value={row[field]}
                             onChange={(event) => handleRowChange(row.id, field, event.target.value)}
                             placeholder="0.00"
+                            error={validationErrors[`work_items.${rowIndex}.${field === 'normHours' ? 'norm_hours' : field === 'pricePerUnit' ? 'price_per_unit' : field}`]}
                             disabled={isLoading}
                           />
                         </td>
@@ -572,7 +512,7 @@ export default function GenerateKSPage() {
               </Button>
             </div>
             {importInfo && <p style={{ color: colors.textSecondary }}>{importInfo}</p>}
-            {validationErrors.workItems && <p style={{ color: colors.error }}>{validationErrors.workItems}</p>}
+            {validationErrors.work_items && <p style={{ color: colors.error }}>{validationErrors.work_items}</p>}
           </div>
           <div style={{ display: 'flex', gap: spacing.sm, alignItems: 'center', flexWrap: 'wrap' }}>
             <Button type="submit" loading={isLoading} disabled={isLoading}>
@@ -598,7 +538,6 @@ export default function GenerateKSPage() {
           )}
         </form>
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ КС сгенерирована</p>}
-        {warning && <p style={{ color: colors.warning }}>{warning}</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
         {summary && (

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -6,6 +6,7 @@ import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
 import { downloadLetterDocx, generateLetter, getApiConfig } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
+import { validateLetter } from '../lib/validation';
 
 const letterTypeMap: Record<string, 'запрос' | 'претензия' | 'уведомление' | 'ответ'> = {
   Запрос: 'запрос',
@@ -33,26 +34,40 @@ export default function GenerateLetterPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
   const [downloadLoading, setDownloadLoading] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
   const handleSubmit = async (data: Record<string, string>) => {
+    const bodyPoints = (data.body ?? '')
+      .split('\n')
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    const validation = validateLetter({
+      addressee: data.addressee ?? '',
+      subject: data.subject ?? '',
+      body_points: bodyPoints
+    });
+    setValidationErrors(validation.fieldErrors);
+
+    if (!validation.isValid) {
+      setError('Исправьте ошибки формы перед отправкой.');
+      setSuccess(false);
+      return;
+    }
+
     setIsLoading(true);
     setError('');
     setSuccess(false);
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const bodyPoints = data.body
-        .split('\n')
-        .map((item) => item.trim())
-        .filter(Boolean);
-
       const response = await generateLetter(
         apiUrl,
         apiKey,
         {
           letter_type: letterTypeMap[data.letter_type] ?? 'запрос',
-          addressee: data.addressee,
-          subject: data.subject,
+          addressee: data.addressee?.trim() ?? '',
+          subject: data.subject?.trim() ?? '',
           body_points: bodyPoints
         },
         { timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS }
@@ -105,7 +120,21 @@ export default function GenerateLetterPage() {
     <Card>
       <section style={{ display: 'grid', gap: spacing.md }}>
         <h2>Генерация письма</h2>
-        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        <DocumentForm
+          fields={fields}
+          onSubmit={handleSubmit}
+          onValuesChange={() => {
+            if (Object.keys(validationErrors).length) {
+              setValidationErrors({});
+            }
+            if (error === 'Исправьте ошибки формы перед отправкой.') {
+              setError('');
+            }
+          }}
+          isLoading={isLoading}
+          error={error}
+          fieldErrors={validationErrors}
+        />
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ Письмо сгенерировано</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}

--- a/desktop/src/pages/GenerateTKPage.tsx
+++ b/desktop/src/pages/GenerateTKPage.tsx
@@ -6,6 +6,7 @@ import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
 import { downloadTKDocx, generateTKStream, getApiConfig, type GenerationStage } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
+import { validateTK } from '../lib/validation';
 
 const fields: DocumentField[] = [
   { name: 'work_type', label: 'Тип работ', type: 'text' },
@@ -29,8 +30,24 @@ export default function GenerateTKPage() {
   const [downloadLoading, setDownloadLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [stage, setStage] = useState<GenerationStage>('queued');
+  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
 
   const handleSubmit = async (data: Record<string, string>) => {
+    const normalizedData = {
+      work_type: data.work_type ?? '',
+      object_name: data.object_name ?? '',
+      volume: Number(data.volume),
+      unit: data.unit ?? ''
+    };
+    const validation = validateTK(normalizedData);
+    setValidationErrors(validation.fieldErrors);
+
+    if (!validation.isValid) {
+      setError('Исправьте ошибки формы перед отправкой.');
+      setSuccess(false);
+      return;
+    }
+
     setIsLoading(true);
     setError('');
     setSuccess(false);
@@ -43,10 +60,10 @@ export default function GenerateTKPage() {
         apiUrl,
         apiKey,
         {
-          work_type: data.work_type,
-          object_name: data.object_name,
-          volume: Number(data.volume),
-          unit: data.unit
+          work_type: normalizedData.work_type,
+          object_name: normalizedData.object_name,
+          volume: normalizedData.volume,
+          unit: normalizedData.unit
         },
         (event) => {
           setProgress(event.progress ?? 0);
@@ -102,7 +119,21 @@ export default function GenerateTKPage() {
     <Card>
       <section style={{ display: 'grid', gap: spacing.md }}>
         <h2>Генерация ТК</h2>
-        <DocumentForm fields={fields} onSubmit={handleSubmit} isLoading={isLoading} error={error} />
+        <DocumentForm
+          fields={fields}
+          onSubmit={handleSubmit}
+          onValuesChange={() => {
+            if (Object.keys(validationErrors).length) {
+              setValidationErrors({});
+            }
+            if (error === 'Исправьте ошибки формы перед отправкой.') {
+              setError('');
+            }
+          }}
+          isLoading={isLoading}
+          error={error}
+          fieldErrors={validationErrors}
+        />
         {isLoading && (
           <div style={{ display: 'grid', gap: spacing.xs }}>
             <div style={{ color: colors.textSecondary }}>Текущий шаг: {stage}</div>


### PR DESCRIPTION
### Motivation
- Prevent backend 422/400 errors and give users immediate feedback by validating generation forms on the client before submitting requests.
- Make validation consistent with server-side requirements (minimum lengths, numeric > 0, date formats and ordering) so users can fix problems early.

### Description
- Added a shared validator module `desktop/src/lib/validation.ts` implementing `validateTK`, `validateKS`, and `validateLetter` that return `fieldErrors` and `isValid` for a payload.
- Enhanced `DocumentForm` to accept `fieldErrors` and `onValuesChange` and render per-field inline error messages so errors appear next to the corresponding inputs (`desktop/src/components/DocumentForm.tsx`).
- Updated pages to perform pre-submit validation and block API calls when invalid: `GenerateTKPage` uses `validateTK`, `GenerateLetterPage` uses `validateLetter`, and `GenerateKSPage` uses `validateKS` and shows inline errors per table cell for work rows (files updated under `desktop/src/pages/`).
- Normalized numeric/date handling in KS/TK forms (e.g. number inputs now enforce a positive minimum, KS rows converted to typed `KSWorkItem` before validation) and clear inline errors when the user edits fields.

### Testing
- Built the desktop app to verify TypeScript compilation and bundling with `cd desktop && npm run build`, which completed successfully (Vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e481c2a150832f9895c444a99aec5e)