### PR TITLE
Add persistent desktop logging (tauri-plugin-log) and Diagnostics page

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -13,9 +13,11 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
+tauri-plugin-log = "2"
 thiserror = "2"
 rfd = "0.15"
 dirs = "6"
+log = "0.4"
 
 [features]
 default = ["custom-protocol"]

--- a/desktop/src-tauri/permissions/commands/copy_last_log_lines.toml
+++ b/desktop/src-tauri/permissions/commands/copy_last_log_lines.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-copy-last-log-lines"
+description = "Enables the copy_last_log_lines command without any pre-configured scope."
+commands.allow = ["copy_last_log_lines"]
+
+[[permission]]
+identifier = "deny-copy-last-log-lines"
+description = "Denies the copy_last_log_lines command without any pre-configured scope."
+commands.deny = ["copy_last_log_lines"]

--- a/desktop/src-tauri/permissions/commands/open_logs_folder.toml
+++ b/desktop/src-tauri/permissions/commands/open_logs_folder.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-open-logs-folder"
+description = "Enables the open_logs_folder command without any pre-configured scope."
+commands.allow = ["open_logs_folder"]
+
+[[permission]]
+identifier = "deny-open-logs-folder"
+description = "Denies the open_logs_folder command without any pre-configured scope."
+commands.deny = ["open_logs_folder"]

--- a/desktop/src-tauri/permissions/default.toml
+++ b/desktop/src-tauri/permissions/default.toml
@@ -5,5 +5,7 @@ permissions = [
   "allow-get-api-url",
   "allow-set-api-url",
   "allow-pick-pdf-file",
-  "allow-read-pdf-file-bytes"
+  "allow-read-pdf-file-bytes",
+  "allow-open-logs-folder",
+  "allow-copy-last-log-lines"
 ]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use dirs::config_dir;
+use log::{error, info, warn};
 use std::{fs, path::PathBuf};
+use tauri::Manager;
+use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::{StoreExt, JsonValue};
 
 const STORE_DIR: &str = "construction-ai";
@@ -9,6 +12,8 @@ const STORE_FILE: &str = "settings.json";
 const API_URL_KEY: &str = "api_url";
 const API_KEY_KEY: &str = "api_key";
 const DEFAULT_API_URL: &str = "https://vanekpetrov1997.fvds.ru";
+const LOGS_DIR_NAME: &str = "logs";
+const LOG_FILE_NAME: &str = "app.log";
 
 fn settings_path() -> PathBuf {
   config_dir()
@@ -34,6 +39,7 @@ fn set_api_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
   let path = settings_path();
   let store = app.store(path).map_err(|e| e.to_string())?;
   store.set(API_URL_KEY, JsonValue::String(url));
+  info!("API URL updated in desktop settings");
   store.save().map_err(|e| e.to_string())
 }
 
@@ -69,6 +75,72 @@ fn read_pdf_file_bytes(path: String) -> Result<Vec<u8>, String> {
   fs::read(path).map_err(|e| e.to_string())
 }
 
+fn app_logs_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+  app
+    .path()
+    .app_data_dir()
+    .map_err(|e| e.to_string())
+    .map(|path| path.join(LOGS_DIR_NAME))
+}
+
+fn app_log_file(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+  app_logs_dir(app).map(|dir| dir.join(LOG_FILE_NAME))
+}
+
+#[tauri::command]
+fn open_logs_folder(app: tauri::AppHandle) -> Result<(), String> {
+  let logs_dir = app_logs_dir(&app)?;
+  fs::create_dir_all(&logs_dir).map_err(|e| e.to_string())?;
+
+  #[cfg(target_os = "windows")]
+  let mut command = {
+    let mut cmd = std::process::Command::new("explorer");
+    cmd.arg(&logs_dir);
+    cmd
+  };
+
+  #[cfg(target_os = "macos")]
+  let mut command = {
+    let mut cmd = std::process::Command::new("open");
+    cmd.arg(&logs_dir);
+    cmd
+  };
+
+  #[cfg(all(unix, not(target_os = "macos")))]
+  let mut command = {
+    let mut cmd = std::process::Command::new("xdg-open");
+    cmd.arg(&logs_dir);
+    cmd
+  };
+
+  command.status().map_err(|e| e.to_string())?;
+  info!("Logs directory opened: {}", logs_dir.display());
+  Ok(())
+}
+
+#[tauri::command]
+fn copy_last_log_lines(app: tauri::AppHandle, lines: Option<usize>) -> Result<String, String> {
+  let log_path = app_log_file(&app)?;
+  let line_limit = lines.unwrap_or(200).max(1);
+
+  if !log_path.exists() {
+    warn!("Log file not found yet: {}", log_path.display());
+    return Ok(String::new());
+  }
+
+  let content = fs::read_to_string(&log_path).map_err(|e| e.to_string())?;
+  let mut log_lines = content.lines().collect::<Vec<_>>();
+  let start = log_lines.len().saturating_sub(line_limit);
+  let tail = log_lines.drain(start..).collect::<Vec<_>>().join("\n");
+
+  info!(
+    "Read {} lines from app log for diagnostics copy action",
+    line_limit
+  );
+
+  Ok(tail)
+}
+
 fn ensure_store_defaults(app: &tauri::AppHandle) -> Result<(), String> {
   let path = settings_path();
   if let Some(parent) = path.parent() {
@@ -86,15 +158,44 @@ fn ensure_store_defaults(app: &tauri::AppHandle) -> Result<(), String> {
   store.save().map_err(|e| e.to_string())
 }
 
+fn ensure_logs_dir(app: &tauri::AppHandle) -> Result<(), String> {
+  let logs_dir = app_logs_dir(app)?;
+  fs::create_dir_all(&logs_dir).map_err(|e| e.to_string())
+}
+
 fn main() {
   tauri::Builder::default()
+    .plugin(
+      tauri_plugin_log::Builder::default()
+        .targets([
+          Target::new(TargetKind::Stdout),
+          Target::new(TargetKind::LogDir {
+            file_name: Some(LOG_FILE_NAME.into())
+          })
+        ])
+        .level(log::LevelFilter::Info)
+        .build()
+    )
     .plugin(tauri_plugin_store::Builder::default().build())
     .setup(|app| {
+      ensure_logs_dir(&app.handle())
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
       ensure_store_defaults(&app.handle())
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+      info!("Desktop app initialized");
       Ok(())
     })
-    .invoke_handler(tauri::generate_handler![get_api_url, set_api_url, pick_pdf_file, read_pdf_file_bytes])
+    .invoke_handler(tauri::generate_handler![
+      get_api_url,
+      set_api_url,
+      pick_pdf_file,
+      read_pdf_file_bytes,
+      open_logs_folder,
+      copy_last_log_lines
+    ])
     .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    .unwrap_or_else(|error| {
+      error!("Error while running tauri application: {}", error);
+      panic!("error while running tauri application: {error}");
+    });
 }

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -29,6 +29,7 @@ const LetterIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="r
 const KSIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 5.25h15v13.5h-15V5.25Zm0 4.5h15M10.5 5.25v13.5" /></BaseIcon>;
 const HandoverIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m6 2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></BaseIcon>;
 const KnowledgeBaseIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M6 4.5h9l3 3v12H6v-15Zm9 0v3h3M8.25 13.5h7.5m-7.5-3h7.5" /></BaseIcon>;
+const DiagnosticsIcon = () => <BaseIcon><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 18.75h15M6.75 15.75v-3m3.75 3v-6m3.75 6V8.25m3.75 7.5V6.75M4.5 4.5h15" /></BaseIcon>;
 
 const navItems: NavItem[] = [
   { path: '/', label: 'Чат', icon: <ChatIcon /> },
@@ -37,7 +38,8 @@ const navItems: NavItem[] = [
   { path: '/generate/letter', label: 'Генерация письма', icon: <LetterIcon /> },
   { path: '/generate/ks', label: 'Генерация КС', icon: <KSIcon /> },
   { path: '/handover', label: 'Сдача объекта', icon: <HandoverIcon /> },
-  { path: '/knowledge-base', label: 'База знаний', icon: <KnowledgeBaseIcon /> }
+  { path: '/knowledge-base', label: 'База знаний', icon: <KnowledgeBaseIcon /> },
+  { path: '/diagnostics', label: 'Диагностика', icon: <DiagnosticsIcon /> }
 ];
 
 export default function Sidebar({ currentPath, onNavigate }: SidebarProps) {

--- a/desktop/src/pages/DiagnosticsPage.tsx
+++ b/desktop/src/pages/DiagnosticsPage.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Store } from '@tauri-apps/plugin-store';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import { checkHealth, DEFAULT_API_URL, normalizeApiUrl, type HealthResponse } from '../api/coreClient';
+import { colors, spacing } from '../styles/tokens';
+
+type HealthTone = 'idle' | 'checking' | 'ok' | 'error';
+
+const toneColor: Record<HealthTone, string> = {
+  idle: colors.textSecondary,
+  checking: colors.primary,
+  ok: colors.success,
+  error: colors.error
+};
+
+export default function DiagnosticsPage() {
+  const [apiUrl, setApiUrl] = useState(DEFAULT_API_URL);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthTone, setHealthTone] = useState<HealthTone>('idle');
+  const [healthMessage, setHealthMessage] = useState('Проверка /health ещё не запускалась.');
+  const [copyMessage, setCopyMessage] = useState('');
+
+  const loadApiUrl = useCallback(async () => {
+    const store = await Store.load('settings.json');
+    const storedUrl = (await store.get<string>('api_url')) || (await invoke<string>('get_api_url')) || DEFAULT_API_URL;
+    const normalized = normalizeApiUrl(storedUrl);
+    setApiUrl(normalized);
+    return normalized;
+  }, []);
+
+  const refreshHealth = useCallback(async () => {
+    setHealthTone('checking');
+    setHealthMessage('Проверяю /health...');
+
+    try {
+      const normalizedUrl = await loadApiUrl();
+      const response = await checkHealth(normalizedUrl);
+      setHealth(response);
+      setHealthTone('ok');
+      setHealthMessage(`Сервер доступен: ${response.status}`);
+    } catch (error) {
+      setHealth(null);
+      setHealthTone('error');
+      setHealthMessage(error instanceof Error ? error.message : 'Ошибка при проверке /health.');
+    }
+  }, [loadApiUrl]);
+
+  useEffect(() => {
+    void refreshHealth();
+  }, [refreshHealth]);
+
+  const onOpenLogsFolder = async () => {
+    try {
+      await invoke('open_logs_folder');
+    } catch (error) {
+      setCopyMessage(error instanceof Error ? error.message : 'Не удалось открыть папку логов.');
+    }
+  };
+
+  const onCopyLastLines = async () => {
+    try {
+      const lines = await invoke<string>('copy_last_log_lines', { lines: 200 });
+      await navigator.clipboard.writeText(lines || 'Лог-файл пока пуст.');
+      setCopyMessage('Скопировано: последние 200 строк app.log');
+    } catch (error) {
+      setCopyMessage(error instanceof Error ? error.message : 'Не удалось скопировать лог.');
+    }
+  };
+
+  return (
+    <Card>
+      <h2 style={{ marginTop: 0 }}>Диагностика</h2>
+      <p style={{ marginTop: 0, color: colors.textSecondary }}>
+        Страница помогает проверить стабильность логирования и доступность API.
+      </p>
+
+      <Card padding="md" style={{ marginBottom: spacing.md }}>
+        <p style={{ margin: 0 }}>
+          <strong>Текущий API URL:</strong> {apiUrl}
+        </p>
+        <p style={{ marginBottom: 0, color: toneColor[healthTone] }}>
+          <strong>/health:</strong> {healthMessage}
+        </p>
+        {health && (
+          <p style={{ marginBottom: 0 }}>
+            Версия сервера: {health.version} · uptime: {Math.round(health.uptime_seconds)}s
+          </p>
+        )}
+      </Card>
+
+      <div style={{ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' }}>
+        <Button type="button" onClick={onOpenLogsFolder}>
+          Открыть папку логов
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCopyLastLines}>
+          Скопировать последние 200 строк
+        </Button>
+        <Button type="button" variant="ghost" onClick={() => void refreshHealth()} loading={healthTone === 'checking'}>
+          {healthTone === 'checking' ? 'Проверка...' : 'Обновить /health'}
+        </Button>
+      </div>
+
+      {copyMessage && (
+        <p style={{ marginTop: spacing.md, marginBottom: 0, color: colors.textSecondary }}>
+          {copyMessage}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/desktop/src/router.tsx
+++ b/desktop/src/router.tsx
@@ -5,6 +5,7 @@ import GenerateLetterPage from './pages/GenerateLetterPage';
 import GenerateTKPage from './pages/GenerateTKPage';
 import HandoverPage from './pages/HandoverPage';
 import KnowledgeBasePage from './pages/KnowledgeBasePage';
+import DiagnosticsPage from './pages/DiagnosticsPage';
 import SettingsPage from './pages/SettingsPage';
 
 export function resolveRoute(path: string, onNavigateHome: () => void): ReactNode {
@@ -23,6 +24,8 @@ export function resolveRoute(path: string, onNavigateHome: () => void): ReactNod
       return <GenerateKSPage />;
     case '/handover':
       return <HandoverPage />;
+    case '/diagnostics':
+      return <DiagnosticsPage />;
     default:
       return (
         <section>


### PR DESCRIPTION
### Motivation
- Ensure stable, persistent logs for the desktop app after release builds to reduce support tech debt.
- Provide a small diagnostics UI to quickly inspect API connectivity and retrieve recent logs for troubleshooting.
- Expose simple OS-native actions to open the logs folder and copy recent log lines for support workflows.

### Description
- Added `tauri-plugin-log` and `log` to `desktop/src-tauri/Cargo.toml` and configured the plugin in `desktop/src-tauri/src/main.rs` to write `Info`-level logs into the Tauri `LogDir` as `app.log` and emit runtime `info/warn/error` messages. 
- Implemented diagnostics Tauri commands in `src-tauri/src/main.rs`: `open_logs_folder` and `copy_last_log_lines`, plus helpers `app_logs_dir`, `app_log_file` and `ensure_logs_dir`, and exported them via `tauri::generate_handler!`. 
- Added permissions for the new commands (`open_logs_folder` and `copy_last_log_lines`) under `desktop/src-tauri/permissions/commands/` and included them in `desktop/src-tauri/permissions/default.toml`. 
- Added a new frontend page `desktop/src/pages/DiagnosticsPage.tsx` with buttons to `Открыть папку логов` and `Скопировать последние 200 строк`, plus display of current API URL and `/health` status; wired the page into routing (`/diagnostics`) and the sidebar (`desktop/src/router.tsx`, `desktop/src/components/Sidebar.tsx`).

### Testing
- Ran `npm run build` inside `desktop/` and the frontend production build completed successfully. 
- Attempted `cargo check` in `desktop/src-tauri/` but it failed due to environment network/proxy errors when fetching crates.io (`CONNECT tunnel failed, response 403`) so Rust dependency resolution could not be verified in this environment. 
- Verified that the new frontend page builds and is routable through the app bundle build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e483a6f520832fb2a7bddef201470b)