### PR TITLE
Add Telegram-desktop session linking and notification polling (MVP)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,7 @@ from api.routes import (
     generate,
     health,
     isup,
+    linking,
     projects,
     rag,
     sign,
@@ -125,6 +126,8 @@ app.include_router(rag.router, prefix="/api/rag", tags=["rag"])
 app.include_router(projects.router, prefix="/api", tags=["projects"])
 app.include_router(analytics.router, prefix="/api", tags=["analytics"])
 app.include_router(compliance.router, prefix="/api", tags=["compliance"])
+app.include_router(linking.router, prefix="/api", tags=["linking"])
+app.include_router(linking.notifications_router, prefix="/api", tags=["notifications"])
 app.include_router(web_push.router)
 app.include_router(web.router, tags=["web"])
 app.mount("/web", StaticFiles(directory="web", html=True), name="web")

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -29,6 +29,7 @@ from core.multitenancy import get_tenant_id
 from core.orchestrator import Orchestrator
 from core.pdf_exporter import PDFExporter
 from core.pdf_parser import PDFParser
+from core.session_bridge import create_document_ready_notification_for_session
 
 router = APIRouter()
 orchestrator = Orchestrator()
@@ -555,6 +556,7 @@ async def _generate_tk_response(payload: TKRequest) -> TKResponse:
         doc_type="tk",
         docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
     )
+    await create_document_ready_notification_for_session(session_id=session_id, doc_type="tk")
 
     return TKResponse(
         result=result_text,
@@ -753,6 +755,7 @@ async def generate_letter_v2(
         doc_type="letter",
         docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
     )
+    await create_document_ready_notification_for_session(session_id=session_id, doc_type="letter")
 
     return LetterResponse(
         result=result_text,
@@ -976,6 +979,7 @@ async def _generate_ks_response(payload: KSRequest, tenant: str) -> KSResponse:
         doc_type="ks",
         docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
     )
+    await create_document_ready_notification_for_session(session_id=session_id, doc_type="ks")
     try:
         await asyncio.to_thread(
             _upsert_generated_doc,

--- a/api/routes/linking.py
+++ b/api/routes/linking.py
@@ -1,0 +1,62 @@
+"""Telegram/Desktop linking and notifications API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from fastapi import APIRouter, HTTPException
+
+from core.session_bridge import (
+    InvalidTelegramLinkTokenError,
+    fetch_and_mark_notifications,
+    parse_telegram_link_token,
+    upsert_telegram_link,
+)
+
+router = APIRouter(prefix="/link", tags=["linking"])
+notifications_router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+class TelegramLinkRequest(BaseModel):
+    code: str = Field(min_length=16)
+    user_id: str = Field(min_length=1, max_length=255)
+    session_id: str = Field(min_length=1, max_length=255)
+
+
+class TelegramLinkResponse(BaseModel):
+    ok: bool
+    telegram_user_id: str
+    user_id: str
+    session_id: str
+
+
+class NotificationsResponse(BaseModel):
+    notifications: list[dict[str, str]]
+
+
+@router.post("/telegram", response_model=TelegramLinkResponse)
+async def link_telegram(payload: TelegramLinkRequest) -> TelegramLinkResponse:
+    """Bind telegram user with desktop user/session using bot-issued code."""
+    try:
+        telegram_user_id, _bot_session_id = parse_telegram_link_token(payload.code)
+    except InvalidTelegramLinkTokenError as exc:
+        raise HTTPException(status_code=400, detail="invalid telegram link code") from exc
+
+    await upsert_telegram_link(
+        telegram_user_id=telegram_user_id,
+        user_id=payload.user_id,
+        session_id=payload.session_id,
+    )
+    return TelegramLinkResponse(
+        ok=True,
+        telegram_user_id=telegram_user_id,
+        user_id=payload.user_id,
+        session_id=payload.session_id,
+    )
+
+
+@notifications_router.get("", response_model=NotificationsResponse)
+async def get_notifications(user_id: str, limit: int = 20) -> NotificationsResponse:
+    """Return unread notifications for desktop polling."""
+    normalized_limit = min(max(limit, 1), 100)
+    notifications = await fetch_and_mark_notifications(user_id=user_id, limit=normalized_limit)
+    return NotificationsResponse(notifications=notifications)

--- a/api/routes/linking.py
+++ b/api/routes/linking.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
 
 from core.session_bridge import (
     InvalidTelegramLinkTokenError,

--- a/core/database.py
+++ b/core/database.py
@@ -85,4 +85,31 @@ async def init_db(db_path: str) -> None:
             );
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS telegram_session_links (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              telegram_user_id TEXT NOT NULL UNIQUE,
+              user_id TEXT NOT NULL,
+              session_id TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            );
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS notifications (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              user_id TEXT NOT NULL,
+              telegram_user_id TEXT,
+              session_id TEXT NOT NULL,
+              event_type TEXT NOT NULL,
+              title TEXT NOT NULL,
+              body TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              is_read INTEGER NOT NULL DEFAULT 0
+            );
+            """
+        )
         await db.commit()

--- a/core/session_bridge.py
+++ b/core/session_bridge.py
@@ -8,7 +8,10 @@ from api.security import JWTError, decode_jwt, encode_jwt
 from config.settings import settings
 from core.database import get_db
 
-UTC = getattr(datetime, "UTC", timezone.utc)
+if hasattr(datetime, "UTC"):
+    UTC = datetime.UTC
+else:  # pragma: no cover
+    UTC = timezone.utc  # noqa: UP017
 
 
 class InvalidTelegramLinkTokenError(ValueError):

--- a/core/session_bridge.py
+++ b/core/session_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 
 from api.security import JWTError, decode_jwt, encode_jwt
@@ -13,6 +14,8 @@ if hasattr(datetime, "UTC"):
 else:  # pragma: no cover
     UTC = timezone.utc  # noqa: UP017
 
+TELEGRAM_LINK_TOKEN_TTL_SECONDS = 10 * 60
+
 
 class InvalidTelegramLinkTokenError(ValueError):
     """Raised when telegram link token cannot be validated."""
@@ -20,10 +23,13 @@ class InvalidTelegramLinkTokenError(ValueError):
 
 def issue_telegram_link_token(telegram_user_id: int, session_id: str) -> str:
     """Create a short-lived token that desktop can exchange via /api/link/telegram."""
+    now = int(time.time())
     payload: dict[str, object] = {
         "kind": "telegram_link",
         "telegram_user_id": str(telegram_user_id),
         "session_id": session_id,
+        "iat": now,
+        "exp": now + TELEGRAM_LINK_TOKEN_TTL_SECONDS,
     }
     return encode_jwt(payload, settings.jwt_secret)
 
@@ -97,10 +103,10 @@ async def create_document_ready_notification_for_session(*, session_id: str, doc
             """
             SELECT telegram_user_id, user_id, session_id
             FROM telegram_session_links
-            WHERE telegram_user_id = ? OR session_id = ?
+            WHERE telegram_user_id = ?
             LIMIT 1
             """,
-            (session_id, session_id),
+            (session_id,),
         )
         row = await cursor.fetchone()
 

--- a/core/session_bridge.py
+++ b/core/session_bridge.py
@@ -1,0 +1,156 @@
+"""Linking between Telegram and desktop sessions + notification storage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from api.security import JWTError, decode_jwt, encode_jwt
+from config.settings import settings
+from core.database import get_db
+
+UTC = getattr(datetime, "UTC", timezone.utc)
+
+
+class InvalidTelegramLinkTokenError(ValueError):
+    """Raised when telegram link token cannot be validated."""
+
+
+def issue_telegram_link_token(telegram_user_id: int, session_id: str) -> str:
+    """Create a short-lived token that desktop can exchange via /api/link/telegram."""
+    payload: dict[str, object] = {
+        "kind": "telegram_link",
+        "telegram_user_id": str(telegram_user_id),
+        "session_id": session_id,
+    }
+    return encode_jwt(payload, settings.jwt_secret)
+
+
+def parse_telegram_link_token(token: str) -> tuple[str, str]:
+    """Validate and decode telegram link token."""
+    try:
+        payload = decode_jwt(token, settings.jwt_secret)
+    except JWTError as exc:
+        raise InvalidTelegramLinkTokenError("invalid token") from exc
+
+    if payload.get("kind") != "telegram_link":
+        raise InvalidTelegramLinkTokenError("unexpected token kind")
+
+    telegram_user_id = str(payload.get("telegram_user_id", "")).strip()
+    session_id = str(payload.get("session_id", "")).strip()
+    if not telegram_user_id or not session_id:
+        raise InvalidTelegramLinkTokenError("token missing required fields")
+    return telegram_user_id, session_id
+
+
+async def upsert_telegram_link(telegram_user_id: str, user_id: str, session_id: str) -> None:
+    """Persist mapping telegram_user_id ↔ desktop user_id ↔ session_id."""
+    now = datetime.now(UTC).isoformat()
+    async with get_db(settings.sqlite_db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO telegram_session_links (
+                telegram_user_id, user_id, session_id, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(telegram_user_id)
+            DO UPDATE SET
+                user_id = excluded.user_id,
+                session_id = excluded.session_id,
+                updated_at = excluded.updated_at
+            """,
+            (telegram_user_id, user_id, session_id, now, now),
+        )
+        await db.commit()
+
+
+async def create_notification(
+    *,
+    user_id: str,
+    telegram_user_id: str | None,
+    session_id: str,
+    event_type: str,
+    title: str,
+    body: str,
+) -> None:
+    """Store a notification for desktop polling."""
+    now = datetime.now(UTC).isoformat()
+    async with get_db(settings.sqlite_db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO notifications (
+                user_id, telegram_user_id, session_id, event_type, title, body, created_at, is_read
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+            """,
+            (user_id, telegram_user_id, session_id, event_type, title, body, now),
+        )
+        await db.commit()
+
+
+async def create_document_ready_notification_for_session(*, session_id: str, doc_type: str) -> None:
+    """Create desktop notification when bot-generated document is ready."""
+    async with get_db(settings.sqlite_db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT telegram_user_id, user_id, session_id
+            FROM telegram_session_links
+            WHERE telegram_user_id = ? OR session_id = ?
+            LIMIT 1
+            """,
+            (session_id, session_id),
+        )
+        row = await cursor.fetchone()
+
+    if row is None:
+        return
+
+    user_id = str(row["user_id"])
+    telegram_user_id = str(row["telegram_user_id"])
+    mapped_session_id = str(row["session_id"])
+    await create_notification(
+        user_id=user_id,
+        telegram_user_id=telegram_user_id,
+        session_id=mapped_session_id,
+        event_type="document_ready",
+        title="Документ готов в Telegram-боте",
+        body=f"Сформирован документ типа '{doc_type}' для связанной сессии.",
+    )
+
+
+async def fetch_and_mark_notifications(user_id: str, limit: int = 20) -> list[dict[str, str]]:
+    """Fetch unread notifications and mark them as read."""
+    async with get_db(settings.sqlite_db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT id, user_id, telegram_user_id, session_id, event_type, title, body, created_at
+            FROM notifications
+            WHERE user_id = ? AND is_read = 0
+            ORDER BY id ASC
+            LIMIT ?
+            """,
+            (user_id, limit),
+        )
+        rows = await cursor.fetchall()
+
+        if rows:
+            notification_ids = [str(int(row["id"])) for row in rows]
+            placeholders = ",".join("?" for _ in notification_ids)
+            await db.execute(
+                f"UPDATE notifications SET is_read = 1 WHERE id IN ({placeholders})",
+                notification_ids,
+            )
+            await db.commit()
+
+    return [
+        {
+            "id": str(int(row["id"])),
+            "user_id": str(row["user_id"]),
+            "telegram_user_id": str(row["telegram_user_id"] or ""),
+            "session_id": str(row["session_id"]),
+            "event_type": str(row["event_type"]),
+            "title": str(row["title"]),
+            "body": str(row["body"]),
+            "created_at": str(row["created_at"]),
+        }
+        for row in rows
+    ]

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { checkHealth, getApiConfig } from './api/coreClient';
+import { checkHealth, fetchNotifications, getApiConfig, type DesktopNotification } from './api/coreClient';
 import Sidebar from './components/Sidebar';
 import StatusBar from './components/StatusBar';
 import { resolveRoute } from './router';
@@ -20,6 +20,7 @@ const APP_THEME_BASE = {
 
 export default function App() {
   const [currentPath, setCurrentPath] = useState(() => normalizePath(window.location.pathname));
+  const [toasts, setToasts] = useState<DesktopNotification[]>([]);
   const branding = useBrandingStore((state) => state.branding);
   const setBranding = useBrandingStore((state) => state.setBranding);
 
@@ -28,6 +29,52 @@ export default function App() {
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
+
+  useEffect(() => {
+    let isDisposed = false;
+
+    const pollNotifications = async () => {
+      try {
+        const { apiUrl, apiKey } = await getApiConfig();
+        const storageKey = 'desktop_user_id';
+        const existingUserId = localStorage.getItem(storageKey);
+        const userId = existingUserId || `desktop-${crypto.randomUUID()}`;
+        if (!existingUserId) {
+          localStorage.setItem(storageKey, userId);
+        }
+        if (!apiKey.trim()) {
+          return;
+        }
+        const notifications = await fetchNotifications(apiUrl, apiKey, userId);
+        if (isDisposed || notifications.length === 0) {
+          return;
+        }
+        setToasts((prev) => [...prev, ...notifications].slice(-5));
+      } catch (_error) {
+        // ignore polling errors in MVP mode
+      }
+    };
+
+    void pollNotifications();
+    const intervalId = window.setInterval(() => {
+      void pollNotifications();
+    }, 15_000);
+
+    return () => {
+      isDisposed = true;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (toasts.length === 0) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setToasts((prev) => prev.slice(1));
+    }, 5000);
+    return () => window.clearTimeout(timer);
+  }, [toasts]);
 
   useEffect(() => {
     let isMounted = true;
@@ -124,6 +171,25 @@ export default function App() {
         </section>
       </main>
       <StatusBar />
+      <div style={{ position: 'fixed', right: spacing.lg, bottom: spacing.xl, zIndex: 1000, display: 'grid', gap: spacing.sm }}>
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            style={{
+              minWidth: 280,
+              maxWidth: 360,
+              background: colors.bgCard,
+              border: `1px solid ${colors.border}`,
+              borderRadius: 10,
+              boxShadow: '0 8px 28px rgba(2, 6, 23, 0.25)',
+              padding: spacing.md
+            }}
+          >
+            <strong style={{ display: 'block', marginBottom: spacing.xs }}>{toast.title}</strong>
+            <span style={{ color: colors.textSecondary, fontSize: 13 }}>{toast.body}</span>
+          </div>
+        ))}
+      </div>
     </>
   );
 }

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -134,6 +134,24 @@ export interface UploadChatDocumentResponse {
   source: string;
 }
 
+export interface TelegramLinkResponse {
+  ok: boolean;
+  telegram_user_id: string;
+  user_id: string;
+  session_id: string;
+}
+
+export interface DesktopNotification {
+  id: string;
+  user_id: string;
+  telegram_user_id: string;
+  session_id: string;
+  event_type: string;
+  title: string;
+  body: string;
+  created_at: string;
+}
+
 export const DEFAULT_API_URL = 'https://vanekpetrov1997.fvds.ru';
 
 const LEGACY_DEFAULT_API_URL = 'http://vanekpetrov1997.fvds.ru';
@@ -317,6 +335,44 @@ export async function checkHealth(apiUrl: string, { timeoutMs, signal }: ApiCall
     signal
   });
   return (await response.json()) as HealthResponse;
+}
+
+export async function linkTelegramAccount(
+  apiUrl: string,
+  apiKey: string,
+  payload: { code: string; user_id: string; session_id: string },
+  { timeoutMs, signal }: ApiCallOptions = {}
+): Promise<TelegramLinkResponse> {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), '/api/link/telegram', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': apiKey.trim()
+    },
+    body: JSON.stringify(payload),
+    timeoutMs,
+    signal
+  });
+  return (await response.json()) as TelegramLinkResponse;
+}
+
+export async function fetchNotifications(
+  apiUrl: string,
+  apiKey: string,
+  userId: string,
+  { timeoutMs, signal }: ApiCallOptions = {}
+): Promise<DesktopNotification[]> {
+  const endpoint = `/api/notifications?user_id=${encodeURIComponent(userId)}`;
+  const response = await apiRequest(normalizeApiUrl(apiUrl), endpoint, {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey.trim()
+    },
+    timeoutMs,
+    signal
+  });
+  const data = (await response.json()) as { notifications?: DesktopNotification[] };
+  return Array.isArray(data.notifications) ? data.notifications : [];
 }
 
 export function generateTK(apiUrl: string, apiKey: string, payload: TKRequest, options?: ApiCallOptions) {

--- a/desktop/src/pages/SettingsPage.tsx
+++ b/desktop/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { colors, spacing } from '../styles/tokens';
 import {
   DEFAULT_API_URL,
   checkHealth,
+  linkTelegramAccount,
   normalizeApiUrl,
   type HealthResponse
 } from '../api/coreClient';
@@ -52,6 +53,8 @@ export default function SettingsPage() {
   const [defaultRole, setDefaultRoleValue] = useState<ChatRole>('pto_engineer');
   const [saved, setSaved] = useState(false);
   const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [telegramCode, setTelegramCode] = useState('');
+  const [linkStatus, setLinkStatus] = useState('');
   const [lastCheckedAt, setLastCheckedAt] = useState<string | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
     tone: 'idle',
@@ -167,6 +170,39 @@ export default function SettingsPage() {
     }
   };
 
+  const onLinkTelegram = async () => {
+    const normalizedUrl = normalizeApiUrl(apiUrl);
+    const trimmedKey = apiKey.trim();
+    const code = telegramCode.trim();
+    if (!code) {
+      setLinkStatus('Введите код из Telegram-бота (/link).');
+      return;
+    }
+    if (!trimmedKey) {
+      setLinkStatus('Сначала заполните API Key.');
+      return;
+    }
+    const storageKey = 'desktop_user_id';
+    const existingUserId = localStorage.getItem(storageKey);
+    const userId = existingUserId || `desktop-${crypto.randomUUID()}`;
+    if (!existingUserId) {
+      localStorage.setItem(storageKey, userId);
+    }
+    const desktopSessionId = useChatStore.getState().sessionId;
+
+    try {
+      await linkTelegramAccount(normalizedUrl, trimmedKey, {
+        code,
+        user_id: userId,
+        session_id: desktopSessionId
+      });
+      setLinkStatus('Telegram успешно привязан. Уведомления теперь будут приходить в desktop.');
+      setTelegramCode('');
+    } catch (error) {
+      setLinkStatus(error instanceof Error ? error.message : 'Не удалось привязать Telegram.');
+    }
+  };
+
   const openKnowledgeBase = () => {
     window.history.pushState({}, '', '/knowledge-base');
     window.dispatchEvent(new PopStateEvent('popstate'));
@@ -177,6 +213,12 @@ export default function SettingsPage() {
       <form onSubmit={onSave} style={{ display: 'grid', gap: spacing.md, maxWidth: 640 }}>
         <Input label="API URL" value={apiUrl} onChange={(e) => setApiUrl(e.target.value)} />
         <Input label="API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+        <Input
+          label="Код привязки из Telegram (/link)"
+          value={telegramCode}
+          onChange={(e) => setTelegramCode(e.target.value)}
+          placeholder="Вставьте токен из бота"
+        />
         <label style={{ display: 'grid', gap: spacing.xs }}>
           <span style={{ color: colors.textPrimary, fontWeight: 500 }}>Имя роли по умолчанию</span>
           <select
@@ -207,11 +249,15 @@ export default function SettingsPage() {
           >
             {connectionStatus.tone === 'checking' ? 'Проверка...' : 'Проверить соединение'}
           </Button>
+          <Button type="button" variant="secondary" onClick={onLinkTelegram}>
+            Привязать Telegram
+          </Button>
         </div>
         {saved && <span style={{ color: colors.success }}>Сохранено ✓</span>}
         <p style={{ color: statusColor[connectionStatus.tone], margin: 0 }}>
           {connectionStatus.message}
         </p>
+        {linkStatus && <p style={{ margin: 0, color: colors.textSecondary }}>{linkStatus}</p>}
 
         {documentsCount === 0 && (
           <Card

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -26,6 +26,7 @@ from aiogram.types import (
 )
 
 from config.settings import settings
+from core.session_bridge import issue_telegram_link_token
 from telegram.keyboards import (
     cancel_keyboard,
     confirm_keyboard,
@@ -189,6 +190,19 @@ async def app_handler(message: Message) -> None:
         ],
     )
     await message.answer("Откройте мини-приложение:", reply_markup=keyboard)
+
+
+@router.message(Command("link"))
+async def link_handler(message: Message) -> None:
+    """Выдать одноразовый код для привязки Telegram к desktop-сессии."""
+    user_id = _require_user_id(message)
+    token = issue_telegram_link_token(telegram_user_id=user_id, session_id=str(user_id))
+    await message.answer(
+        "Код для привязки к Desktop (вставьте в настройках):\n"
+        f"`{token}`\n\n"
+        "После привязки desktop будет получать уведомления о готовых документах.",
+        parse_mode="Markdown",
+    )
 
 
 @router.callback_query(F.data.startswith("project_doc:"))

--- a/tests/test_linking_notifications.py
+++ b/tests/test_linking_notifications.py
@@ -23,7 +23,11 @@ def test_link_telegram_and_fetch_notifications(tmp_path):
         with TestClient(app) as client:
             link_response = client.post(
                 "/api/link/telegram",
-                json={"code": token, "user_id": "desktop-user-1", "session_id": "desktop-session-1"},
+                json={
+                    "code": token,
+                    "user_id": "desktop-user-1",
+                    "session_id": "desktop-session-1",
+                },
                 headers={"X-API-Key": "valid-key"},
             )
             assert link_response.status_code == 200

--- a/tests/test_linking_notifications.py
+++ b/tests/test_linking_notifications.py
@@ -1,6 +1,7 @@
 """Tests for Telegram/Desktop linking and notification polling."""
 
-from unittest.mock import AsyncMock
+import time
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -75,6 +76,110 @@ def test_link_telegram_and_fetch_notifications(tmp_path):
             )
             assert second_fetch.status_code == 200
             assert second_fetch.json()["notifications"] == []
+    finally:
+        settings.api_keys = old_keys
+        settings.sqlite_db_path = old_db_path
+
+
+def test_expired_link_token_rejected(tmp_path):
+    old_keys = settings.api_keys
+    old_db_path = settings.sqlite_db_path
+
+    settings.api_keys = ["valid-key"]
+    settings.sqlite_db_path = str(tmp_path / "expired-link.db")
+
+    token = issue_telegram_link_token(telegram_user_id=123456, session_id="123456")
+
+    try:
+        with TestClient(app) as client:
+            with patch("core.session_bridge.time.time", return_value=time.time() + 3600):
+                link_response = client.post(
+                    "/api/link/telegram",
+                    json={
+                        "code": token,
+                        "user_id": "desktop-user-1",
+                        "session_id": "desktop-session-1",
+                    },
+                    headers={"X-API-Key": "valid-key"},
+                )
+            assert link_response.status_code == 400
+            assert link_response.json()["detail"] == "invalid telegram link code"
+    finally:
+        settings.api_keys = old_keys
+        settings.sqlite_db_path = old_db_path
+
+
+def test_notifications_resolve_by_telegram_user_id_only(tmp_path):
+    old_keys = settings.api_keys
+    old_db_path = settings.sqlite_db_path
+
+    settings.api_keys = ["valid-key"]
+    settings.sqlite_db_path = str(tmp_path / "lookup-strict.db")
+
+    token_user_a = issue_telegram_link_token(telegram_user_id=1111, session_id="1111")
+    token_user_b = issue_telegram_link_token(telegram_user_id=2222, session_id="2222")
+
+    try:
+        with TestClient(app) as client:
+            response_a = client.post(
+                "/api/link/telegram",
+                json={
+                    "code": token_user_a,
+                    "user_id": "desktop-user-a",
+                    "session_id": "desktop-session-a",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert response_a.status_code == 200
+
+            # Conflicting desktop session_id that equals user A telegram id
+            response_b = client.post(
+                "/api/link/telegram",
+                json={
+                    "code": token_user_b,
+                    "user_id": "desktop-user-b",
+                    "session_id": "1111",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert response_b.status_code == 200
+
+            mocked_process = AsyncMock(
+                return_value={
+                    "session_id": "1111",
+                    "reply": "ok",
+                    "agents_used": ["formatter"],
+                    "confidence": 0.9,
+                    "state": {"docx_payload": {"title": "ТК"}},
+                }
+            )
+            generate.orchestrator.process = mocked_process
+
+            generate_response = client.post(
+                "/api/generate/tk",
+                json={
+                    "work_type": "бетонирование",
+                    "object_name": "ЖК",
+                    "volume": 1,
+                    "unit": "м³",
+                    "session_id": "1111",
+                    "role": "pto_engineer",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert generate_response.status_code == 200
+
+            notifications_a = client.get(
+                "/api/notifications?user_id=desktop-user-a",
+                headers={"X-API-Key": "valid-key"},
+            ).json()["notifications"]
+            notifications_b = client.get(
+                "/api/notifications?user_id=desktop-user-b",
+                headers={"X-API-Key": "valid-key"},
+            ).json()["notifications"]
+
+            assert len(notifications_a) == 1
+            assert notifications_b == []
     finally:
         settings.api_keys = old_keys
         settings.sqlite_db_path = old_db_path

--- a/tests/test_linking_notifications.py
+++ b/tests/test_linking_notifications.py
@@ -1,0 +1,76 @@
+"""Tests for Telegram/Desktop linking and notification polling."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes import generate
+from config.settings import settings
+from core.session_bridge import issue_telegram_link_token
+
+
+def test_link_telegram_and_fetch_notifications(tmp_path):
+    old_keys = settings.api_keys
+    old_db_path = settings.sqlite_db_path
+
+    settings.api_keys = ["valid-key"]
+    settings.sqlite_db_path = str(tmp_path / "linking.db")
+
+    token = issue_telegram_link_token(telegram_user_id=123456, session_id="123456")
+
+    try:
+        with TestClient(app) as client:
+            link_response = client.post(
+                "/api/link/telegram",
+                json={"code": token, "user_id": "desktop-user-1", "session_id": "desktop-session-1"},
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert link_response.status_code == 200
+            assert link_response.json()["telegram_user_id"] == "123456"
+
+            mocked_process = AsyncMock(
+                return_value={
+                    "session_id": "123456",
+                    "reply": "ok",
+                    "agents_used": ["formatter"],
+                    "confidence": 0.9,
+                    "state": {"docx_payload": {"title": "ТК"}},
+                }
+            )
+            generate.orchestrator.process = mocked_process
+
+            generate_response = client.post(
+                "/api/generate/tk",
+                json={
+                    "work_type": "бетонирование",
+                    "object_name": "ЖК",
+                    "volume": 1,
+                    "unit": "м³",
+                    "session_id": "123456",
+                    "role": "pto_engineer",
+                },
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert generate_response.status_code == 200
+
+            notifications_response = client.get(
+                "/api/notifications?user_id=desktop-user-1",
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert notifications_response.status_code == 200
+            notifications = notifications_response.json()["notifications"]
+            assert len(notifications) == 1
+            assert notifications[0]["event_type"] == "document_ready"
+            assert notifications[0]["session_id"] == "desktop-session-1"
+
+            # unread notifications are marked as read after first poll
+            second_fetch = client.get(
+                "/api/notifications?user_id=desktop-user-1",
+                headers={"X-API-Key": "valid-key"},
+            )
+            assert second_fetch.status_code == 200
+            assert second_fetch.json()["notifications"] == []
+    finally:
+        settings.api_keys = old_keys
+        settings.sqlite_db_path = old_db_path


### PR DESCRIPTION
### Motivation
- Close architecture gap where Telegram bot and desktop app have no shared session mapping or notification channel.
- Provide an MVP to let desktop users see documents created in the bot and to bind a desktop session to a Telegram user for notifications.

### Description
- Add persistent tables `telegram_session_links` and `notifications` to SQLite initialization in `core/database.py` to store mappings and unread notifications. 
- Implement `core/session_bridge.py` with helpers to issue/parse bot link tokens, upsert the `telegram_user_id ↔ user_id ↔ session_id` mapping, create notifications, and fetch-and-mark-unread notifications. 
- Add API endpoints `POST /api/link/telegram` and `GET /api/notifications?user_id=...` in `api/routes/linking.py` and mount them in `api/main.py`. 
- Publish a notification when a bot-generated document completes by calling `create_document_ready_notification_for_session` from generation flows (`tk`, `letter`, `ks`) in `api/routes/generate.py`. 
- Add Telegram command `/link` that returns a link token for the user to paste into desktop settings, implemented in `telegram/handlers/__init__.py`. 
- Update desktop client code: add `linkTelegramAccount` and `fetchNotifications` in `desktop/src/api/coreClient.ts`, settings UI to paste code and bind (`desktop/src/pages/SettingsPage.tsx`), background polling and toast UI in `desktop/src/App.tsx` to show incoming notifications.
- Add integration test `tests/test_linking_notifications.py` covering link → bot generation → desktop polling → mark-as-read flow.

### Testing
- Ran `pytest -q tests/test_linking_notifications.py tests/test_generate_tk.py` and all tests passed. 
- Ran `pytest -q tests/test_linking_notifications.py` independently and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e486b60424832fbee16729ffd3d87a)