### PR TITLE
feat(ui/api): surface typed SSE errors to UI and standardize server SSE error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
 
 ### Changed
 - Docker-образ оптимизирован с 1.5 ГБ до 500 МБ (multi-stage build)
+
+- feat(ui): surface real SSE error reasons

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -23,7 +23,7 @@ from config.settings import settings
 from core.billing import require_quota
 from core.branding import BrandingConfig, get_branding
 from core.cache import RedisCache
-from core.errors import LLMProviderNotConfiguredError
+from core.errors import AppError
 from core.export.onec_exporter import OneCExporter
 from core.llm_router import LLMRouter
 from core.multitenancy import get_tenant_id
@@ -53,6 +53,13 @@ SESSION_STORE: dict[str, dict[str, dict]] = {}
 _cleanup_task: asyncio.Task | None = None
 _cleanup_lock = asyncio.Lock()
 GENERATION_STAGES = ("research", "draft", "critic", "verify", "format")
+ERROR_CODES = {
+    "llm_timeout",
+    "llm_not_configured",
+    "validation_failed",
+    "rag_empty",
+    "internal",
+}
 
 
 def _now_mono() -> float:
@@ -141,9 +148,49 @@ def _http_exception_payload(exc: HTTPException) -> dict[str, str]:
     detail = exc.detail
     if isinstance(detail, dict):
         message = str(detail.get("message", "Ошибка генерации"))
-        code = str(detail.get("code", "generation_error"))
-        return {"stage": "error", "message": message, "code": code}
-    return {"stage": "error", "message": str(detail), "code": "generation_error"}
+        code = str(detail.get("code", "internal"))
+        payload: dict[str, object] = {"stage": "error", "message": message, "code": code}
+        if isinstance(detail.get("details"), dict):
+            payload["details"] = detail["details"]
+        return payload
+    return {"stage": "error", "message": str(detail), "code": "internal"}
+
+
+async def _emit_error(
+    queue,
+    code: str,
+    message: str,
+    details: dict | None = None,
+) -> None:
+    normalized_code = code if code in ERROR_CODES else "internal"
+    payload: dict[str, object] = {"stage": "error", "code": normalized_code, "message": message}
+    if details:
+        payload["details"] = details
+    await queue.put(_sse_event("error", payload))
+
+
+def _exception_to_http(exc: Exception) -> HTTPException:
+    if isinstance(exc, AppError):
+        message = exc.message
+        if exc.code == "llm_not_configured":
+            message = "LLM-провайдер не настроен. Добавьте ключ в Настройках"
+        return HTTPException(
+            status_code=exc.status_code,
+            detail={"message": message, "code": exc.code, "details": getattr(exc, "details", None)},
+        )
+    if isinstance(exc, asyncio.TimeoutError):
+        return HTTPException(
+            status_code=504,
+            detail={
+                "message": "LLM не ответил за 60 сек",
+                "code": "llm_timeout",
+                "details": {"timeout_seconds": 60},
+            },
+        )
+    return HTTPException(
+        status_code=503,
+        detail={"message": "LLM временно недоступен, попробуйте позже", "code": "internal"},
+    )
 
 
 def _is_sse_requested(request: Request, stream: bool) -> bool:
@@ -533,15 +580,7 @@ async def _generate_tk_response(payload: TKRequest) -> TKResponse:
         )
     except Exception as exc:
         logger.exception("generate_tk_llm_error", session_id=session_id, error=str(exc))
-        if isinstance(exc, LLMProviderNotConfiguredError):
-            raise HTTPException(
-                status_code=exc.status_code,
-                detail={"message": exc.message, "code": exc.code},
-            ) from exc
-        raise HTTPException(
-            status_code=503,
-            detail="LLM временно недоступен, попробуйте позже",
-        ) from exc
+        raise _exception_to_http(exc) from exc
 
     state = result.get("state", {}) if isinstance(result, dict) else {}
     docx_bytes = state.get("docx_bytes")
@@ -620,46 +659,52 @@ async def generate_tk(
         return await _generate_tk_response(payload)
 
     async def _stream():
-        yield _sse_event("queued", {"stage": "queued", "progress": 0})
+        yield _sse_event("progress", {"stage": "queued", "progress": 0})
         task = asyncio.create_task(_generate_tk_response(payload))
         stage_index = 0
         while not task.done():
             stage = GENERATION_STAGES[min(stage_index, len(GENERATION_STAGES) - 1)]
             progress = min(90, int(((stage_index + 1) / (len(GENERATION_STAGES) + 1)) * 100))
-            yield _sse_event(stage, {"stage": stage, "progress": progress})
+            yield _sse_event("progress", {"stage": stage, "progress": progress})
             stage_index += 1
             try:
                 await asyncio.wait_for(asyncio.shield(task), timeout=5)
             except TimeoutError:
                 continue
             except HTTPException as exc:
-                yield _sse_event("error", _http_exception_payload(exc))
+                err_payload = _http_exception_payload(exc)
+                queue: asyncio.Queue[str] = asyncio.Queue()
+                await _emit_error(
+                    queue,
+                    code=str(err_payload.get("code", "internal")),
+                    message=str(err_payload.get("message", "Ошибка генерации")),
+                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                )
+                yield await queue.get()
                 return
             except Exception:
-                yield _sse_event(
-                    "error",
-                    {
-                        "stage": "error",
-                        "message": "Unexpected generation error",
-                        "code": "generation_error",
-                    },
-                )
+                queue: asyncio.Queue[str] = asyncio.Queue()
+                await _emit_error(queue, code='internal', message='Unexpected generation error')
+                yield await queue.get()
                 return
 
         try:
             response = await task
         except HTTPException as exc:
-            yield _sse_event("error", _http_exception_payload(exc))
+            err_payload = _http_exception_payload(exc)
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(
+                queue,
+                code=str(err_payload.get("code", "internal")),
+                message=str(err_payload.get("message", "Ошибка генерации")),
+                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+            )
+            yield await queue.get()
             return
         except Exception:
-            yield _sse_event(
-                "error",
-                {
-                    "stage": "error",
-                    "message": "Unexpected generation error",
-                    "code": "generation_error",
-                },
-            )
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            yield await queue.get()
             return
 
         yield _sse_event(
@@ -727,6 +772,7 @@ async def generate_letter_v2(
     payload: LetterRequest,
     request: Request,
     org_id: str | None = Depends(get_tenant_id),
+    stream: bool = Query(False, description="Вернуть прогресс в формате SSE"),
 ):
     """Генерация делового письма через orchestrator."""
     _ = (request, org_id)
@@ -742,55 +788,107 @@ async def generate_letter_v2(
         f"Договор: {contract_number}."
     )
 
-    try:
-        result = await orchestrator.process(
-            message=message,
-            session_id=session_id,
-            role=payload.role,
-            intent="generate_letter",
-            include_legal_expert=payload.include_npa,
-        )
-    except Exception as exc:
-        logger.exception("generate_letter_llm_error", session_id=session_id, error=str(exc))
-        raise HTTPException(
-            status_code=503,
-            detail="LLM временно недоступен, попробуйте позже",
-        ) from exc
+    async def _generate_letter_response() -> LetterResponse:
+        try:
+            result = await orchestrator.process(
+                message=message,
+                session_id=session_id,
+                role=payload.role,
+                intent="generate_letter",
+                include_legal_expert=payload.include_npa,
+            )
+        except Exception as exc:
+            logger.exception("generate_letter_llm_error", session_id=session_id, error=str(exc))
+            raise _exception_to_http(exc) from exc
 
-    state = result.get("state", {}) if isinstance(result, dict) else {}
-    history = state.get("history", []) if isinstance(state, dict) else []
-    document = state.get("docx_payload") or {"content": result.get("reply")}
-    legal_references = _extract_legal_references(history)
-    verification = state.get("verification", {}) if isinstance(state, dict) else {}
-    sha256 = (verification or {}).get("sha256")
-    docx_bytes = state.get("docx_bytes")
-    if isinstance(docx_bytes, bytes):
-        await session_memory.save_document(
-            session_id=session_id,
+        state = result.get("state", {}) if isinstance(result, dict) else {}
+        history = state.get("history", []) if isinstance(state, dict) else []
+        document = state.get("docx_payload") or {"content": result.get("reply")}
+        legal_references = _extract_legal_references(history)
+        verification = state.get("verification", {}) if isinstance(state, dict) else {}
+        sha256 = (verification or {}).get("sha256")
+        docx_bytes = state.get("docx_bytes")
+        if isinstance(docx_bytes, bytes):
+            await session_memory.save_document(
+                session_id=session_id,
+                doc_type="letter",
+                filename=f"letter_{session_id}.docx",
+                docx_bytes=docx_bytes,
+                sha256=sha256,
+            )
+        result_text = str(result.get("reply") or "")
+        if not result_text and isinstance(document, dict):
+            result_text = json.dumps(document, ensure_ascii=False, indent=2)
+        _touch_session(
+            session_id,
+            text=result_text,
             doc_type="letter",
-            filename=f"letter_{session_id}.docx",
-            docx_bytes=docx_bytes,
-            sha256=sha256,
+            docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
         )
-    result_text = str(result.get("reply") or "")
-    if not result_text and isinstance(document, dict):
-        result_text = json.dumps(document, ensure_ascii=False, indent=2)
-    _touch_session(
-        session_id,
-        text=result_text,
-        doc_type="letter",
-        docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
-    )
-    await create_document_ready_notification_for_session(session_id=session_id, doc_type="letter")
+        await create_document_ready_notification_for_session(session_id=session_id, doc_type="letter")
 
-    return LetterResponse(
-        result=result_text,
-        session_id=result["session_id"],
-        document=document,
-        agents_used=result.get("agents_used", []),
-        legal_references=legal_references,
-        confidence=result.get("confidence"),
-    )
+        return LetterResponse(
+            result=result_text,
+            session_id=result["session_id"],
+            document=document,
+            agents_used=result.get("agents_used", []),
+            legal_references=legal_references,
+            confidence=result.get("confidence"),
+        )
+
+    if not _is_sse_requested(request, stream):
+        return await _generate_letter_response()
+
+    async def _stream():
+        yield _sse_event("progress", {"stage": "queued", "progress": 0})
+        task = asyncio.create_task(_generate_letter_response())
+        stage_index = 0
+        while not task.done():
+            stage = GENERATION_STAGES[min(stage_index, len(GENERATION_STAGES) - 1)]
+            progress = min(90, int(((stage_index + 1) / (len(GENERATION_STAGES) + 1)) * 100))
+            yield _sse_event("progress", {"stage": stage, "progress": progress})
+            stage_index += 1
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
+            except TimeoutError:
+                continue
+            except HTTPException as exc:
+                err_payload = _http_exception_payload(exc)
+                queue: asyncio.Queue[str] = asyncio.Queue()
+                await _emit_error(
+                    queue,
+                    code=str(err_payload.get("code", "internal")),
+                    message=str(err_payload.get("message", "Ошибка генерации")),
+                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                )
+                yield await queue.get()
+                return
+            except Exception:
+                queue: asyncio.Queue[str] = asyncio.Queue()
+                await _emit_error(queue, code='internal', message='Unexpected generation error')
+                yield await queue.get()
+                return
+        try:
+            response = await task
+        except HTTPException as exc:
+            err_payload = _http_exception_payload(exc)
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(
+                queue,
+                code=str(err_payload.get("code", "internal")),
+                message=str(err_payload.get("message", "Ошибка генерации")),
+                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+            )
+            yield await queue.get()
+            return
+        except Exception:
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            yield await queue.get()
+            return
+        yield _sse_event("done", {"stage": "done", "progress": 100, "result": response.model_dump()})
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")
 
 
 @router.post(
@@ -965,10 +1063,7 @@ async def _generate_ks_response(payload: KSRequest, tenant: str) -> KSResponse:
         )
     except Exception as exc:
         logger.exception("generate_ks_llm_error", session_id=session_id, error=str(exc))
-        raise HTTPException(
-            status_code=503,
-            detail="LLM временно недоступен, попробуйте позже",
-        ) from exc
+        raise _exception_to_http(exc) from exc
 
     state = result.get("state", {}) if isinstance(result, dict) else {}
     ks2 = state.get("ks2_data", {})
@@ -1078,35 +1173,53 @@ async def generate_ks(
         return await _generate_ks_response(payload, tenant)
 
     async def _stream():
-        yield _sse_event("queued", {"stage": "queued", "progress": 0})
+        yield _sse_event("progress", {"stage": "queued", "progress": 0})
         task = asyncio.create_task(_generate_ks_response(payload, tenant))
         stage_index = 0
         while not task.done():
             stage = GENERATION_STAGES[min(stage_index, len(GENERATION_STAGES) - 1)]
             progress = min(90, int(((stage_index + 1) / (len(GENERATION_STAGES) + 1)) * 100))
-            yield _sse_event(stage, {"stage": stage, "progress": progress})
+            yield _sse_event("progress", {"stage": stage, "progress": progress})
             stage_index += 1
             try:
                 await asyncio.wait_for(asyncio.shield(task), timeout=5)
             except TimeoutError:
                 continue
             except HTTPException as exc:
-                yield _sse_event("error", {"stage": "error", "message": str(exc.detail)})
+                err_payload = _http_exception_payload(exc)
+                queue: asyncio.Queue[str] = asyncio.Queue()
+                await _emit_error(
+                    queue,
+                    code=str(err_payload.get("code", "internal")),
+                    message=str(err_payload.get("message", "Ошибка генерации")),
+                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                )
+                yield await queue.get()
                 return
             except Exception:
                 yield _sse_event(
                     "error",
-                    {"stage": "error", "message": "Unexpected generation error"},
+                    {"stage": "error", "message": "Unexpected generation error", "code": "internal"},
                 )
                 return
 
         try:
             response = await task
         except HTTPException as exc:
-            yield _sse_event("error", {"stage": "error", "message": str(exc.detail)})
+            err_payload = _http_exception_payload(exc)
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(
+                queue,
+                code=str(err_payload.get("code", "internal")),
+                message=str(err_payload.get("message", "Ошибка генерации")),
+                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+            )
+            yield await queue.get()
             return
         except Exception:
-            yield _sse_event("error", {"stage": "error", "message": "Unexpected generation error"})
+            queue: asyncio.Queue[str] = asyncio.Queue()
+            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            yield await queue.get()
             return
 
         yield _sse_event(

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -169,6 +169,11 @@ async def _emit_error(
     await queue.put(_sse_event("error", payload))
 
 
+def _extract_error_details(payload: dict[str, object]) -> dict | None:
+    details = payload.get("details")
+    return details if isinstance(details, dict) else None
+
+
 def _exception_to_http(exc: Exception) -> HTTPException:
     if isinstance(exc, AppError):
         message = exc.message
@@ -678,7 +683,7 @@ async def generate_tk(
                     queue,
                     code=str(err_payload.get("code", "internal")),
                     message=str(err_payload.get("message", "Ошибка генерации")),
-                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                    details=_extract_error_details(err_payload),
                 )
                 yield await queue.get()
                 return
@@ -697,7 +702,7 @@ async def generate_tk(
                 queue,
                 code=str(err_payload.get("code", "internal")),
                 message=str(err_payload.get("message", "Ошибка генерации")),
-                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                details=_extract_error_details(err_payload),
             )
             yield await queue.get()
             return
@@ -825,7 +830,10 @@ async def generate_letter_v2(
             doc_type="letter",
             docx_bytes=docx_bytes if isinstance(docx_bytes, bytes) else None,
         )
-        await create_document_ready_notification_for_session(session_id=session_id, doc_type="letter")
+        await create_document_ready_notification_for_session(
+            session_id=session_id,
+            doc_type="letter",
+        )
 
         return LetterResponse(
             result=result_text,
@@ -859,7 +867,7 @@ async def generate_letter_v2(
                     queue,
                     code=str(err_payload.get("code", "internal")),
                     message=str(err_payload.get("message", "Ошибка генерации")),
-                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                    details=_extract_error_details(err_payload),
                 )
                 yield await queue.get()
                 return
@@ -877,7 +885,7 @@ async def generate_letter_v2(
                 queue,
                 code=str(err_payload.get("code", "internal")),
                 message=str(err_payload.get("message", "Ошибка генерации")),
-                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                details=_extract_error_details(err_payload),
             )
             yield await queue.get()
             return
@@ -886,7 +894,10 @@ async def generate_letter_v2(
             await _emit_error(queue, code='internal', message='Unexpected generation error')
             yield await queue.get()
             return
-        yield _sse_event("done", {"stage": "done", "progress": 100, "result": response.model_dump()})
+        yield _sse_event(
+            "done",
+            {"stage": "done", "progress": 100, "result": response.model_dump()},
+        )
 
     return StreamingResponse(_stream(), media_type="text/event-stream")
 
@@ -1192,14 +1203,18 @@ async def generate_ks(
                     queue,
                     code=str(err_payload.get("code", "internal")),
                     message=str(err_payload.get("message", "Ошибка генерации")),
-                    details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                    details=_extract_error_details(err_payload),
                 )
                 yield await queue.get()
                 return
             except Exception:
                 yield _sse_event(
                     "error",
-                    {"stage": "error", "message": "Unexpected generation error", "code": "internal"},
+                    {
+                        "stage": "error",
+                        "message": "Unexpected generation error",
+                        "code": "internal",
+                    },
                 )
                 return
 
@@ -1212,7 +1227,7 @@ async def generate_ks(
                 queue,
                 code=str(err_payload.get("code", "internal")),
                 message=str(err_payload.get("message", "Ошибка генерации")),
-                details=err_payload.get("details") if isinstance(err_payload.get("details"), dict) else None,
+                details=_extract_error_details(err_payload),
             )
             yield await queue.get()
             return

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -689,7 +689,7 @@ async def generate_tk(
                 return
             except Exception:
                 queue: asyncio.Queue[str] = asyncio.Queue()
-                await _emit_error(queue, code='internal', message='Unexpected generation error')
+                await _emit_error(queue, code="internal", message="Unexpected generation error")
                 yield await queue.get()
                 return
 
@@ -708,7 +708,7 @@ async def generate_tk(
             return
         except Exception:
             queue: asyncio.Queue[str] = asyncio.Queue()
-            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            await _emit_error(queue, code="internal", message="Unexpected generation error")
             yield await queue.get()
             return
 
@@ -873,7 +873,7 @@ async def generate_letter_v2(
                 return
             except Exception:
                 queue: asyncio.Queue[str] = asyncio.Queue()
-                await _emit_error(queue, code='internal', message='Unexpected generation error')
+                await _emit_error(queue, code="internal", message="Unexpected generation error")
                 yield await queue.get()
                 return
         try:
@@ -891,7 +891,7 @@ async def generate_letter_v2(
             return
         except Exception:
             queue: asyncio.Queue[str] = asyncio.Queue()
-            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            await _emit_error(queue, code="internal", message="Unexpected generation error")
             yield await queue.get()
             return
         yield _sse_event(
@@ -1233,7 +1233,7 @@ async def generate_ks(
             return
         except Exception:
             queue: asyncio.Queue[str] = asyncio.Queue()
-            await _emit_error(queue, code='internal', message='Unexpected generation error')
+            await _emit_error(queue, code="internal", message="Unexpected generation error")
             yield await queue.get()
             return
 

--- a/core/errors.py
+++ b/core/errors.py
@@ -10,6 +10,7 @@ class AppError(Exception):
     message: str
     code: str = "app_error"
     status_code: int = 500
+    details: dict | None = None
 
     def __str__(self) -> str:
         return self.message
@@ -26,6 +27,7 @@ class LLMProviderNotConfiguredError(AppError):
             ),
             code="llm_not_configured",
             status_code=503,
+            details={"provider": provider, "missing_setting": missing_setting.upper()},
         )
         self.provider = provider
         self.missing_setting = missing_setting

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -10,6 +10,7 @@ Supervisor-паттерн на LangGraph. Управляет pipeline'ами:
 import json
 import re
 import uuid
+import asyncio
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
@@ -27,6 +28,7 @@ from api.metrics import PIPELINE_DURATION
 from core.llm_router import LLMRouter
 from core.session_memory import SessionMemory
 from core.tk_bridge import TKGeneratorBridge
+from core.errors import AppError, LLMProviderNotConfiguredError
 
 METRICS_PATTERN = re.compile(r"Метрика \w+:\s*\S+\.?\s*", re.UNICODE)
 
@@ -203,6 +205,22 @@ class Orchestrator:
         )
         return re.sub(r"\n{3,}", "\n\n", without_metric_lines).strip()
 
+    def _map_pipeline_exception(self, exc: Exception) -> AppError:
+        if isinstance(exc, LLMProviderNotConfiguredError):
+            return exc
+        if isinstance(exc, asyncio.TimeoutError):
+            return AppError(
+                message="LLM не ответил за 60 сек",
+                code="llm_timeout",
+                status_code=504,
+            )
+        text = str(exc).lower()
+        if "validation" in text:
+            return AppError(message="Ошибка валидации входных данных", code="validation_failed", status_code=422)
+        if "rag" in text and ("empty" in text or "no document" in text):
+            return AppError(message="RAG не вернул релевантных документов", code="rag_empty", status_code=422)
+        return AppError(message="Внутренняя ошибка генерации", code="internal", status_code=503)
+
     async def _run_pipeline(
         self,
         intent: str,
@@ -333,14 +351,17 @@ class Orchestrator:
         intent = intent or await self._detect_intent(message)
 
         if intent != "chat":
-            result = await self._run_pipeline(
-                intent,
-                message,
-                session_id,
-                role,
-                include_legal_expert=include_legal_expert,
-                extra_state=extra_state,
-            )
+            try:
+                result = await self._run_pipeline(
+                    intent,
+                    message,
+                    session_id,
+                    role,
+                    include_legal_expert=include_legal_expert,
+                    extra_state=extra_state,
+                )
+            except Exception as exc:
+                raise self._map_pipeline_exception(exc) from exc
             if result.get("reply"):
                 await self.session_memory.add(
                     session_id, role="assistant", content=str(result["reply"])

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -7,10 +7,10 @@ Supervisor-паттерн на LangGraph. Управляет pipeline'ами:
 - generate_ks: Researcher → Calculator → Author → Critic → Verifier → Formatter
 """
 
+import asyncio
 import json
 import re
 import uuid
-import asyncio
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
@@ -25,10 +25,10 @@ from agents.legal_expert import LegalExpertAgent
 from agents.researcher import ResearcherAgent
 from agents.verifier import VerifierAgent
 from api.metrics import PIPELINE_DURATION
+from core.errors import AppError, LLMProviderNotConfiguredError
 from core.llm_router import LLMRouter
 from core.session_memory import SessionMemory
 from core.tk_bridge import TKGeneratorBridge
-from core.errors import AppError, LLMProviderNotConfiguredError
 
 METRICS_PATTERN = re.compile(r"Метрика \w+:\s*\S+\.?\s*", re.UNICODE)
 
@@ -216,9 +216,17 @@ class Orchestrator:
             )
         text = str(exc).lower()
         if "validation" in text:
-            return AppError(message="Ошибка валидации входных данных", code="validation_failed", status_code=422)
+            return AppError(
+                message="Ошибка валидации входных данных",
+                code="validation_failed",
+                status_code=422,
+            )
         if "rag" in text and ("empty" in text or "no document" in text):
-            return AppError(message="RAG не вернул релевантных документов", code="rag_empty", status_code=422)
+            return AppError(
+                message="RAG не вернул релевантных документов",
+                code="rag_empty",
+                status_code=422,
+            )
         return AppError(message="Внутренняя ошибка генерации", code="internal", status_code=503)
 
     async def _run_pipeline(

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -14,6 +14,7 @@ import uuid
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
+import httpx
 from langgraph.graph import END, START, StateGraph
 
 from agents.analyst import AnalystAgent
@@ -208,7 +209,7 @@ class Orchestrator:
     def _map_pipeline_exception(self, exc: Exception) -> AppError:
         if isinstance(exc, LLMProviderNotConfiguredError):
             return exc
-        if isinstance(exc, asyncio.TimeoutError):
+        if isinstance(exc, (asyncio.TimeoutError, httpx.TimeoutException)):
             return AppError(
                 message="LLM не ответил за 60 сек",
                 code="llm_timeout",

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -7,6 +7,8 @@ import {
   DEFAULT_GENERATION_TIMEOUT_MS
 } from '../lib/apiClient';
 import type { ChatRole } from '../store/chatStore';
+import { logError } from '../lib/logger';
+import { parseSSEEvent } from './sseEvents';
 
 export interface ChatRequest {
   message: string;
@@ -160,6 +162,18 @@ export class ForbiddenError extends Error {
     this.name = 'ForbiddenError';
   }
 }
+export class SSEError extends Error {
+  code: string;
+  details?: Record<string, unknown>;
+
+  constructor(code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'SSEError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
 
 export interface TelegramLinkResponse {
   ok: boolean;
@@ -248,7 +262,6 @@ async function postJsonSSE<TRequest>(
       signal.addEventListener('abort', () => controller.abort(), { once: true });
     }
   }
-  const mergedSignal = controller.signal;
 
   try {
     const response = await fetch(`${normalizeApiUrl(apiUrl)}${endpoint}`, {
@@ -259,7 +272,7 @@ async function postJsonSSE<TRequest>(
         'X-API-Key': apiKey.trim()
       },
       body: JSON.stringify(payload),
-      signal: mergedSignal
+      signal: controller.signal
     });
 
     if (!response.ok || !response.body) {
@@ -277,26 +290,34 @@ async function postJsonSSE<TRequest>(
 
       while (buffer.includes('\n\n')) {
         const splitAt = buffer.indexOf('\n\n');
-        const chunk = buffer.slice(0, splitAt);
+        const rawEvent = buffer.slice(0, splitAt);
         buffer = buffer.slice(splitAt + 2);
-        const lines = chunk.split('\n');
-        const eventLine = lines.find((line) => line.startsWith('event:'));
-        const dataLine = lines.find((line) => line.startsWith('data:'));
-        if (!dataLine) continue;
 
-        const parsed = JSON.parse(dataLine.replace(/^data:\s*/, '')) as Omit<GenerationStreamEvent, 'event'>;
-        const event = (eventLine?.replace(/^event:\s*/, '') ?? parsed.stage) as GenerationStage;
-        const fullEvent: GenerationStreamEvent = { event, ...parsed };
-        onEvent(fullEvent);
-
-        if (event === 'error') {
-          if (parsed.code === 'llm_not_configured') {
-            throw new Error(parsed.message ?? 'LLM-провайдер не настроен в .env');
-          }
-          throw new Error(parsed.message ?? 'Ошибка генерации');
+        const parsedEvent = parseSSEEvent(rawEvent);
+        if (!parsedEvent) {
+          continue;
         }
-        if (event === 'done' && parsed.result) {
-          return parsed.result;
+
+        if (parsedEvent.event === 'error') {
+          logError('sse_error_event', {
+            code: parsedEvent.code,
+            message: parsedEvent.message,
+            details: parsedEvent.details,
+            endpoint
+          });
+          throw new SSEError(parsedEvent.code, parsedEvent.message, parsedEvent.details);
+        }
+
+        const stage = (parsedEvent.stage ?? parsedEvent.event) as GenerationStage;
+        onEvent({
+          event: stage,
+          stage,
+          progress: parsedEvent.progress ?? 0,
+          message: parsedEvent.message
+        });
+
+        if (parsedEvent.event === 'done' && parsedEvent.result) {
+          return parsedEvent.result;
         }
       }
     }
@@ -304,8 +325,9 @@ async function postJsonSSE<TRequest>(
     if (timeoutId !== null) window.clearTimeout(timeoutId);
   }
 
-  throw new Error('Поток генерации завершился без результата');
+  throw new SSEError('internal', 'Поток генерации завершился без результата');
 }
+
 
 export async function getApiConfig(): Promise<ApiConfig> {
   const store = await Store.load('settings.json');
@@ -548,8 +570,14 @@ export function generateTKStream(
   return postJsonSSE(apiUrl, apiKey, '/api/generate/tk?stream=true', payload, onEvent, options);
 }
 
-export function generateLetter(apiUrl: string, apiKey: string, payload: LetterRequest, options?: ApiCallOptions) {
-  return postJson(apiUrl, apiKey, '/api/generate/letter', payload, options);
+export function generateLetter(
+  apiUrl: string,
+  apiKey: string,
+  payload: LetterRequest,
+  onEvent: (event: GenerationStreamEvent) => void,
+  options?: ApiCallOptions
+) {
+  return postJsonSSE(apiUrl, apiKey, '/api/generate/letter?stream=true', payload, onEvent, options);
 }
 
 export function generateKS(apiUrl: string, apiKey: string, payload: KSRequest, options?: ApiCallOptions) {

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -574,6 +574,15 @@ export function generateLetter(
   apiUrl: string,
   apiKey: string,
   payload: LetterRequest,
+  options?: ApiCallOptions
+) {
+  return postJson(apiUrl, apiKey, '/api/generate/letter', payload, options);
+}
+
+export function generateLetterStream(
+  apiUrl: string,
+  apiKey: string,
+  payload: LetterRequest,
   onEvent: (event: GenerationStreamEvent) => void,
   options?: ApiCallOptions
 ) {

--- a/desktop/src/api/sseEvents.ts
+++ b/desktop/src/api/sseEvents.ts
@@ -1,0 +1,95 @@
+import type { GenerateDocumentResponse } from './coreClient';
+
+export type SSEEventName = 'progress' | 'chunk' | 'error' | 'done';
+
+export interface SSEEventBase {
+  event: SSEEventName;
+  progress?: number;
+  stage?: string;
+  message?: string;
+}
+
+export interface SSEProgressEvent extends SSEEventBase {
+  event: 'progress';
+}
+
+export interface SSEChunkEvent extends SSEEventBase {
+  event: 'chunk';
+  chunk?: string;
+}
+
+export interface SSEErrorEvent extends SSEEventBase {
+  event: 'error';
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface SSEDoneEvent extends SSEEventBase {
+  event: 'done';
+  result?: GenerateDocumentResponse;
+}
+
+export type SSEEvent = SSEProgressEvent | SSEChunkEvent | SSEErrorEvent | SSEDoneEvent;
+
+export function parseSSEEvent(raw: string): SSEEvent | null {
+  const lines = raw
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+
+  if (!lines.length) return null;
+
+  const eventLine = lines.find((line) => line.startsWith('event:'));
+  const dataLines = lines.filter((line) => line.startsWith('data:'));
+  if (!eventLine || !dataLines.length) {
+    return null;
+  }
+
+  const eventName = eventLine.replace(/^event:\s*/, '').trim();
+  const dataRaw = dataLines.map((line) => line.replace(/^data:\s*/, '')).join('\n');
+  const payload = JSON.parse(dataRaw) as Record<string, unknown>;
+
+  if (eventName === 'error') {
+    return {
+      event: 'error',
+      code: String(payload.code ?? 'internal'),
+      message: String(payload.message ?? 'Ошибка генерации'),
+      details:
+        payload.details && typeof payload.details === 'object'
+          ? (payload.details as Record<string, unknown>)
+          : undefined,
+      progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+      stage: typeof payload.stage === 'string' ? payload.stage : undefined
+    };
+  }
+
+  if (eventName === 'done') {
+    return {
+      event: 'done',
+      result:
+        payload.result && typeof payload.result === 'object'
+          ? (payload.result as GenerateDocumentResponse)
+          : undefined,
+      progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+      stage: typeof payload.stage === 'string' ? payload.stage : undefined
+    };
+  }
+
+  if (eventName === 'chunk') {
+    return {
+      event: 'chunk',
+      chunk: typeof payload.chunk === 'string' ? payload.chunk : undefined,
+      progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+      stage: typeof payload.stage === 'string' ? payload.stage : undefined,
+      message: typeof payload.message === 'string' ? payload.message : undefined
+    };
+  }
+
+  return {
+    event: 'progress',
+    progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+    stage: typeof payload.stage === 'string' ? payload.stage : eventName,
+    message: typeof payload.message === 'string' ? payload.message : undefined
+  };
+}

--- a/desktop/src/components/ErrorModal.tsx
+++ b/desktop/src/components/ErrorModal.tsx
@@ -1,0 +1,61 @@
+import Button from './ui/Button';
+import { colors, spacing, zIndex } from '../styles/tokens';
+
+interface ErrorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  details?: Record<string, unknown>;
+  trace?: string;
+}
+
+export default function ErrorModal({ isOpen, onClose, title, details, trace }: ErrorModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15, 23, 42, 0.55)',
+        display: 'grid',
+        placeItems: 'center',
+        zIndex: zIndex.modal
+      }}
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        style={{
+          width: 'min(720px, 92vw)',
+          maxHeight: '80vh',
+          overflow: 'auto',
+          background: colors.bgCard,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 12,
+          padding: spacing.lg,
+          boxShadow: '0 20px 45px rgba(2, 6, 23, 0.35)'
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 style={{ marginTop: 0, marginBottom: spacing.sm }}>{title}</h3>
+        <p style={{ color: colors.textSecondary }}>Технические детали ошибки:</p>
+        <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          {JSON.stringify(details ?? {}, null, 2)}
+        </pre>
+        {trace && (
+          <>
+            <p style={{ marginTop: spacing.md, color: colors.textSecondary }}>Trace:</p>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{trace}</pre>
+          </>
+        )}
+        <div style={{ marginTop: spacing.md }}>
+          <Button type="button" onClick={onClose}>
+            Закрыть
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/lib/logger.ts
+++ b/desktop/src/lib/logger.ts
@@ -1,0 +1,18 @@
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export function logEvent(level: LogLevel, event: string, payload?: Record<string, unknown>) {
+  const message = `[desktop] ${event}`;
+  if (level === 'error') {
+    console.error(message, payload ?? {});
+    return;
+  }
+  if (level === 'warn') {
+    console.warn(message, payload ?? {});
+    return;
+  }
+  console.info(message, payload ?? {});
+}
+
+export function logError(event: string, payload?: Record<string, unknown>) {
+  logEvent('error', event, payload);
+}

--- a/desktop/src/pages/GenerateKSPage.tsx
+++ b/desktop/src/pages/GenerateKSPage.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState } from 'react';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
+import ErrorModal from '../components/ErrorModal';
 import Input from '../components/ui/Input';
 import { colors, radius, spacing, typography } from '../styles/tokens';
 import {
@@ -14,6 +15,7 @@ import {
   type KSHeader,
   type KSWorkItem
 } from '../api/coreClient';
+import { SSEError } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 import { validateKS } from '../lib/validation';
 
@@ -118,6 +120,9 @@ export default function GenerateKSPage() {
   const [progress, setProgress] = useState(0);
   const [stage, setStage] = useState<GenerationStage>('queued');
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [toastMessage, setToastMessage] = useState('');
+  const [sseError, setSseError] = useState<SSEError | null>(null);
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
 
   const handleRowChange = (rowId: string, key: keyof Omit<WorkRow, 'id'>, value: string) => {
     setWorkRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, [key]: value } : row)));
@@ -292,7 +297,13 @@ export default function GenerateKSPage() {
           : JSON.stringify(normalizedResult, null, 2)
       );
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации КС');
+      if (submitError instanceof SSEError) {
+        setSseError(submitError);
+        setToastMessage(submitError.message);
+        setError(submitError.message);
+      } else {
+        setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации КС');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -539,6 +550,19 @@ export default function GenerateKSPage() {
         </form>
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ КС сгенерирована</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
+        {toastMessage && (
+          <div style={{ border: `1px solid ${colors.error}`, borderRadius: 8, padding: spacing.sm, display: 'flex', gap: spacing.sm, alignItems: 'center' }}>
+            <span style={{ color: colors.error, fontWeight: 600 }}>{toastMessage}</span>
+            <Button type="button" variant="ghost" onClick={() => setIsErrorModalOpen(true)}>
+              Подробнее
+            </Button>
+            {sseError?.code === 'llm_not_configured' && (
+              <a href="/settings" style={{ color: colors.primary }}>
+                Открыть Settings
+              </a>
+            )}
+          </div>
+        )}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
         {summary && (
           <p style={{ color: colors.textPrimary, fontWeight: 600 }}>
@@ -550,6 +574,13 @@ export default function GenerateKSPage() {
         <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
           {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
         </Button>
+        <ErrorModal
+          isOpen={Boolean(sseError) && isErrorModalOpen}
+          onClose={() => setIsErrorModalOpen(false)}
+          title={sseError?.message ?? 'Детали ошибки'}
+          details={sseError?.details}
+          trace={typeof sseError?.details?.trace === 'string' ? sseError.details.trace : undefined}
+        />
       </section>
     </Card>
   );

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
+import ErrorModal from '../components/ErrorModal';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
-import { downloadLetterDocx, generateLetter, getApiConfig } from '../api/coreClient';
+import { downloadLetterDocx, generateLetter, getApiConfig, SSEError, type GenerationStage } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 import { validateLetter } from '../lib/validation';
 
@@ -35,6 +36,11 @@ export default function GenerateLetterPage() {
   const [success, setSuccess] = useState(false);
   const [downloadLoading, setDownloadLoading] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [progress, setProgress] = useState(0);
+  const [stage, setStage] = useState<GenerationStage>('queued');
+  const [toastMessage, setToastMessage] = useState('');
+  const [sseError, setSseError] = useState<SSEError | null>(null);
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
 
   const handleSubmit = async (data: Record<string, string>) => {
     const bodyPoints = (data.body ?? '')
@@ -58,6 +64,8 @@ export default function GenerateLetterPage() {
     setIsLoading(true);
     setError('');
     setSuccess(false);
+    setProgress(0);
+    setStage('queued');
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
@@ -69,6 +77,10 @@ export default function GenerateLetterPage() {
           addressee: data.addressee?.trim() ?? '',
           subject: data.subject?.trim() ?? '',
           body_points: bodyPoints
+        },
+        (event) => {
+          setProgress(event.progress ?? 0);
+          setStage(event.stage);
         },
         { timeoutMs: DEFAULT_GENERATION_TIMEOUT_MS }
       );
@@ -83,7 +95,13 @@ export default function GenerateLetterPage() {
       setSessionId(String(response.session_id ?? ''));
       setSuccess(true);
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации письма');
+      if (submitError instanceof SSEError) {
+        setSseError(submitError);
+        setToastMessage(submitError.message);
+        setError(submitError.message);
+      } else {
+        setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации письма');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -135,8 +153,22 @@ export default function GenerateLetterPage() {
           error={error}
           fieldErrors={validationErrors}
         />
+        {isLoading && <p style={{ color: colors.textSecondary }}>Текущий шаг: {stage} · {progress}%</p>}
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ Письмо сгенерировано</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
+        {toastMessage && (
+          <div style={{ border: `1px solid ${colors.error}`, borderRadius: 8, padding: spacing.sm, display: 'flex', gap: spacing.sm, alignItems: 'center' }}>
+            <span style={{ color: colors.error, fontWeight: 600 }}>{toastMessage}</span>
+            <Button type="button" variant="ghost" onClick={() => setIsErrorModalOpen(true)}>
+              Подробнее
+            </Button>
+            {sseError?.code === 'llm_not_configured' && (
+              <a href="/settings" style={{ color: colors.primary }}>
+                Открыть Settings
+              </a>
+            )}
+          </div>
+        )}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
 
         <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
@@ -144,6 +176,13 @@ export default function GenerateLetterPage() {
         <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
           {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
         </Button>
+        <ErrorModal
+          isOpen={Boolean(sseError) && isErrorModalOpen}
+          onClose={() => setIsErrorModalOpen(false)}
+          title={sseError?.message ?? 'Детали ошибки'}
+          details={sseError?.details}
+          trace={typeof sseError?.details?.trace === 'string' ? sseError.details.trace : undefined}
+        />
       </section>
     </Card>
   );

--- a/desktop/src/pages/GenerateLetterPage.tsx
+++ b/desktop/src/pages/GenerateLetterPage.tsx
@@ -5,7 +5,13 @@ import Card from '../components/ui/Card';
 import ErrorModal from '../components/ErrorModal';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
-import { downloadLetterDocx, generateLetter, getApiConfig, SSEError, type GenerationStage } from '../api/coreClient';
+import {
+  downloadLetterDocx,
+  generateLetterStream,
+  getApiConfig,
+  SSEError,
+  type GenerationStage
+} from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 import { validateLetter } from '../lib/validation';
 
@@ -69,7 +75,7 @@ export default function GenerateLetterPage() {
 
     try {
       const { apiUrl, apiKey } = await getApiConfig();
-      const response = await generateLetter(
+      const response = await generateLetterStream(
         apiUrl,
         apiKey,
         {

--- a/desktop/src/pages/GenerateTKPage.tsx
+++ b/desktop/src/pages/GenerateTKPage.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import DocumentForm, { type DocumentField } from '../components/DocumentForm';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
+import ErrorModal from '../components/ErrorModal';
 import Input from '../components/ui/Input';
 import { colors, spacing } from '../styles/tokens';
-import { downloadTKDocx, generateTKStream, getApiConfig, type GenerationStage } from '../api/coreClient';
+import { downloadTKDocx, generateTKStream, getApiConfig, SSEError, type GenerationStage } from '../api/coreClient';
 import { DEFAULT_GENERATION_TIMEOUT_MS } from '../lib/apiClient';
 import { validateTK } from '../lib/validation';
 
@@ -31,6 +32,9 @@ export default function GenerateTKPage() {
   const [progress, setProgress] = useState(0);
   const [stage, setStage] = useState<GenerationStage>('queued');
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [toastMessage, setToastMessage] = useState('');
+  const [sseError, setSseError] = useState<SSEError | null>(null);
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
 
   const handleSubmit = async (data: Record<string, string>) => {
     const normalizedData = {
@@ -82,7 +86,13 @@ export default function GenerateTKPage() {
       setSessionId(String(response.session_id ?? ''));
       setSuccess(true);
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации ТК');
+      if (submitError instanceof SSEError) {
+        setSseError(submitError);
+        setToastMessage(submitError.message);
+        setError(submitError.message);
+      } else {
+        setError(submitError instanceof Error ? submitError.message : 'Ошибка генерации ТК');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -144,6 +154,19 @@ export default function GenerateTKPage() {
         )}
         {success && <p style={{ color: colors.success, fontWeight: 600 }}>✓ ТК сгенерирована</p>}
         {error && <p style={{ color: colors.error }}>{error}</p>}
+        {toastMessage && (
+          <div style={{ border: `1px solid ${colors.error}`, borderRadius: 8, padding: spacing.sm, display: 'flex', gap: spacing.sm, alignItems: 'center' }}>
+            <span style={{ color: colors.error, fontWeight: 600 }}>{toastMessage}</span>
+            <Button type="button" variant="ghost" onClick={() => setIsErrorModalOpen(true)}>
+              Подробнее
+            </Button>
+            {sseError?.code === 'llm_not_configured' && (
+              <a href="/settings" style={{ color: colors.primary }}>
+                Открыть Settings
+              </a>
+            )}
+          </div>
+        )}
         {sessionId && <p style={{ color: colors.textSecondary, fontSize: 12 }}>session_id: {sessionId}</p>}
 
         <Input type="textarea" label="Результат" value={result} rows={12} readOnly />
@@ -153,6 +176,13 @@ export default function GenerateTKPage() {
         <Button type="button" onClick={handleDownload} disabled={!sessionId || downloadLoading} loading={downloadLoading}>
           {downloadLoading ? 'Скачивание...' : 'Скачать DOCX'}
         </Button>
+        <ErrorModal
+          isOpen={Boolean(sseError) && isErrorModalOpen}
+          onClose={() => setIsErrorModalOpen(false)}
+          title={sseError?.message ?? 'Детали ошибки'}
+          details={sseError?.details}
+          trace={typeof sseError?.details?.trace === 'string' ? sseError.details.trace : undefined}
+        />
       </section>
     </Card>
   );

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,9 @@
+# Exception → SSE error.code mapping
+
+| Исключение | error.code | Примечание |
+|---|---|---|
+| `LLMProviderNotConfiguredError` | `llm_not_configured` | Провайдер LLM не настроен (нет ключа). |
+| `asyncio.TimeoutError` | `llm_timeout` | Таймаут ответа LLM (60 сек). |
+| Ошибки валидации (`*validation*` в тексте) | `validation_failed` | Невалидный payload/поля формы. |
+| Ошибки RAG без релевантных данных (`rag` + `empty/no document`) | `rag_empty` | Пустой контекст RAG. |
+| Любые прочие исключения | `internal` | Непредвиденная ошибка сервера. |

--- a/tests/test_generate_sse.py
+++ b/tests/test_generate_sse.py
@@ -1,0 +1,37 @@
+"""Тесты SSE-ошибок генерации."""
+
+import asyncio
+
+from api.routes import generate
+from core.errors import LLMProviderNotConfiguredError
+
+
+def test_emit_error_returns_llm_not_configured_payload():
+    """_emit_error формирует корректный SSE payload для llm_not_configured."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    asyncio.run(
+        generate._emit_error(
+            queue,
+            code="llm_not_configured",
+            message="LLM-провайдер не настроен. Добавьте ключ в Настройках",
+            details={"provider": "openai", "missing_setting": "OPENAI_API_KEY"},
+        )
+    )
+
+    payload = asyncio.run(queue.get())
+    assert "event: error" in payload
+    assert '"code": "llm_not_configured"' in payload
+    assert "OPENAI_API_KEY" in payload
+
+
+def test_exception_to_http_maps_llm_provider_not_configured():
+    """LLMProviderNotConfiguredError -> HTTP detail.code=llm_not_configured."""
+    exc = LLMProviderNotConfiguredError(provider="openai", missing_setting="OPENAI_API_KEY")
+
+    mapped = generate._exception_to_http(exc)
+
+    assert mapped.status_code == 503
+    assert mapped.detail["code"] == "llm_not_configured"
+    assert mapped.detail["message"] == "LLM-провайдер не настроен. Добавьте ключ в Настройках"
+    assert mapped.detail["details"]["provider"] == "openai"


### PR DESCRIPTION
### Motivation
- Клиент игнорировал серверные `event: error` и показывал обобщённое сообщение, из‑за чего пользователь не понимал причину сбоя (пустой ключ, таймаут, валидация и т.д.).
- Нужно пробрасывать типизированные причины ошибок из SSE в UI, логировать их и стандартизировать серверную форму ошибок, чтобы UI мог показать «Подробнее» с деталями и трассой.

### Description
- Desktop: переписан `postJsonSSE` в `desktop/src/api/coreClient.ts` с поддержкой парсинга `progress|chunk|error|done`, введён `SSEError` (типизированный `Error`), логирование каждого `event: error` через `desktop/src/lib/logger.ts` и использование нового парсера `desktop/src/api/sseEvents.ts`.
- UI: добавлен компонент `desktop/src/components/ErrorModal.tsx` и обновлены страницы генерации (`GenerateTKPage`, `GenerateKSPage`, `GenerateLetterPage`) для показа toast + кнопки «Подробнее», открытия модалки с `details` и ссылкой на Settings при `llm_not_configured`.
- Server: в `api/routes/generate.py` стандартизирован SSE-ошибочный payload `{code,message,details}`, добавлен хелпер `_emit_error(...)`, централизованная функция `_exception_to_http(...)` и перевод потоков TK/KS/Letter на `event: progress` / `event: error` / `event: done` схему; `/api/generate/letter` получил SSE-режим (`stream=true`).
- Orchestrator/core: в `core/orchestrator.py` добавлен маппинг исключений в коды (`llm_not_configured`, `llm_timeout`, `validation_failed`, `rag_empty`, `internal`) и проброс этих кодов как `AppError`; `core/errors.py` расширён полем `details` и `LLMProviderNotConfiguredError` теперь включает подробности.
- Docs/tests: добавлена таблица маппинга в `docs/errors.md` и тесты `tests/test_generate_sse.py` для `_emit_error` и `_exception_to_http`; внесена запись в `CHANGELOG.md`.

### Testing
- Запущены серверные тесты: `pytest tests/test_generate_sse.py -q` — все тесты прошли (`2 passed`).
- Проверка TypeScript: `cd desktop && pnpm tsc --noEmit` — успешно (компиляция прошла без ошибок).
- Desktop unit runner: `cd desktop && pnpm test -- coreClient` не прошёл в среде из‑за отсутствия корректного `test`-скрипта/интерпретации опций в `package.json` (команда падает в этой репе), поэтому компонентные/юнит тесты фронта не запускались здесь.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a886ad7c832faf02c8ff64e39b5b)