### PR TITLE
fix(bot): correct Telegram entrypoint, /link validation and Redis rate-limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,11 @@ CHROMA_PERSIST_DIR=./data/chroma
 # REDIS_URL=redis://localhost:6379/0
 
 # ── Telegram Bot ───────────────────────────────
-BOT_TOKEN=xxxxxxxxxxxxxxxxxxxx
+BOT_TOKEN=
+TELEGRAM_ADMIN_IDS=
 CORE_API_URL=http://api:8000
-TELEGRAM_BOT_TOKEN=xxxxxxxxxxxxxxxxxxxx
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBHOOK_URL=
 
 # ── tk-generator (Node.js) ─────────────────────
 TK_GENERATOR_PATH=../tk-generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - fix(health): honest LLM status
 - fix(cors): valid credentials+origins
+- fix(bot): correct entrypoint, add /link validation, rate-limit
 
 ### Added
 - feat(kb): split personal vs global knowledge base

--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,7 @@ from hmac import compare_digest
 from typing import cast
 
 from aiogram.types import Update
+import sqlite3
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
@@ -43,7 +44,7 @@ from api.routes.analyze import router as analyze_router
 from config.settings import settings
 from core.analytics.notifications import AnalyticsNotifier
 from core.database import init_db
-from telegram.bot import create_bot, create_dispatcher
+from telegram.main import create_bot, create_dispatcher
 
 _ = (AGENT_RUNS, PIPELINE_DURATION)
 telegram_router = APIRouter()
@@ -181,6 +182,18 @@ async def telegram_webhook_handler(request: Request) -> dict[str, bool]:
     update = Update.model_validate(payload, context={"bot": bot})
     await dp.feed_update(bot, update)
     return {"ok": True}
+
+
+@telegram_router.get("/api/telegram/health")
+async def telegram_health() -> dict[str, int]:
+    active_sessions = 0
+    try:
+        with sqlite3.connect(settings.sqlite_db_path) as connection:
+            row = connection.execute("SELECT COUNT(*) FROM sessions").fetchone()
+            active_sessions = int(row[0]) if row else 0
+    except sqlite3.Error:
+        active_sessions = 0
+    return {"active_sessions": active_sessions}
 
 
 app.include_router(telegram_router, tags=["telegram"])

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,12 @@
 """Construction AI Core — FastAPI application."""
 
+import sqlite3
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from hmac import compare_digest
 from typing import cast
 
 from aiogram.types import Update
-import sqlite3
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -22,6 +22,11 @@ LLM_TOKENS_USED = Counter(
     "Использовано LLM токенов",
     ["provider", "direction"],  # direction: input/output
 )
+BOT_MESSAGES_TOTAL = Counter(
+    "bot_messages_total",
+    "Количество обработанных сообщений Telegram-ботом",
+    ["handler"],
+)
 
 __all__ = [
     "Instrumentator",
@@ -29,4 +34,5 @@ __all__ = [
     "PIPELINE_DURATION",
     "ACTIVE_SESSIONS",
     "LLM_TOKENS_USED",
+    "BOT_MESSAGES_TOTAL",
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,14 @@ services:
     build: .
     container_name: construction-ai-telegram-bot
     working_dir: /app
-    command: python -m telegram.bot
+    command: python -m telegram.main
     depends_on:
-      - api
-      - redis
+      api:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     env_file:
       - .env
     environment:
@@ -37,12 +41,29 @@ services:
       - ./data:/app/data
       - ./templates:/app/templates
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import aiogram; print('ok')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   redis:
     image: redis:7-alpine
     command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: construction_ai
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d construction_ai"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/telegram/README.md
+++ b/telegram/README.md
@@ -1,0 +1,39 @@
+# Telegram Bot
+
+## Запуск
+
+```bash
+python -m telegram.main
+```
+
+Docker Compose использует тот же entrypoint: `python -m telegram.main`.
+
+## Команды
+
+- `/start` — старт и выбор роли.
+- `/link <api_key>` — привязка API-ключа (с проверкой через `/api/me`).
+- `/unlink` — отвязка API-ключа.
+- `/whoami` — показать пользователя/роль из API.
+- `/health` — количество активных сессий.
+- `/tk`, `/ks`, `/letter` — генерация документов.
+
+## Переменные окружения
+
+- `BOT_TOKEN` — токен Telegram-бота.
+- `CORE_API_URL` — адрес API (например, `http://api:8000`).
+- `TELEGRAM_WEBHOOK_URL` — URL webhook (опционально, если пусто — polling).
+- `TELEGRAM_WEBHOOK_SECRET` — секрет webhook.
+- `TELEGRAM_ADMIN_IDS` — список Telegram ID администраторов.
+- `REDIS_URL` — Redis для rate-limit и хранения `tg:user:{chat_id}:api_key`.
+
+## Деплой
+
+1. Заполните `.env` (минимум `BOT_TOKEN`, `API_KEYS`, `REDIS_URL`).
+2. Запустите сервисы:
+   ```bash
+   docker compose up -d api redis postgres telegram-bot
+   ```
+3. Проверьте:
+   - `/health` API,
+   - `/api/telegram/health`,
+   - логи `docker compose logs telegram-bot`.

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -1,5 +1,0 @@
-"""Совместимость: запускайте telegram.main."""
-
-from telegram.main import create_bot, create_dispatcher, main
-
-__all__ = ["create_bot", "create_dispatcher", "main"]

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -26,10 +26,9 @@ from aiogram.types import (
     WebAppInfo,
 )
 
-from config.settings import settings
 from api.metrics import BOT_MESSAGES_TOTAL
+from config.settings import settings
 from core.session_bridge import issue_telegram_link_token
-from telegram.middlewares.auth import delete_api_key_for_chat, get_api_key_for_chat, save_api_key_for_chat
 from telegram.keyboards import (
     cancel_keyboard,
     confirm_keyboard,
@@ -38,6 +37,11 @@ from telegram.keyboards import (
     role_keyboard,
     skip_keyboard,
     unit_keyboard,
+)
+from telegram.middlewares.auth import (
+    delete_api_key_for_chat,
+    get_api_key_for_chat,
+    save_api_key_for_chat,
 )
 from telegram.states import AnalyzeForm, KSStates, LetterStates, TKStates, UploadForm
 

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -295,9 +295,14 @@ async def whoami_handler(message: Message) -> None:
 
 @router.message(Command("health"))
 async def health_handler(message: Message) -> None:
+    user_id = _require_user_id(message)
+    api_key = await get_api_key_for_chat(user_id)
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(f"{settings.core_api_url.rstrip('/')}/api/telegram/health")
+            response = await client.get(
+                f"{settings.core_api_url.rstrip('/')}/api/telegram/health",
+                headers={"X-API-Key": api_key or _get_api_key()},
+            )
             response.raise_for_status()
             payload = response.json()
     except httpx.HTTPError:

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import secrets
@@ -26,7 +27,9 @@ from aiogram.types import (
 )
 
 from config.settings import settings
+from api.metrics import BOT_MESSAGES_TOTAL
 from core.session_bridge import issue_telegram_link_token
+from telegram.middlewares.auth import delete_api_key_for_chat, get_api_key_for_chat, save_api_key_for_chat
 from telegram.keyboards import (
     cancel_keyboard,
     confirm_keyboard,
@@ -52,6 +55,7 @@ ROLE_NAMES = {
 }
 
 _PERIOD_RE = re.compile(r"^\d{2}\.\d{2}\.\d{4}\s*-\s*\d{2}\.\d{2}\.\d{4}$")
+_API_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]{16,64}$")
 
 
 def _get_api_key() -> str:
@@ -59,6 +63,17 @@ def _get_api_key() -> str:
     if settings.api_keys:
         return settings.api_keys[0]
     return ""
+
+
+def _friendly_error_by_code(code: str) -> str:
+    mapping = {
+        "llm_not_configured": "LLM не настроен. Обратитесь к администратору",
+        "llm_timeout": "Сервис генерации отвечает слишком долго. Попробуйте позже.",
+        "validation_failed": "Некорректные входные данные. Проверьте поля и попробуйте снова.",
+        "rag_empty": "Недостаточно данных в базе знаний для ответа.",
+        "internal": "Внутренняя ошибка сервиса. Попробуйте позже.",
+    }
+    return mapping.get(code, "Ошибка генерации. Попробуйте позже.")
 
 
 def _get_admin_api_key() -> str:
@@ -136,7 +151,8 @@ async def _call_api_with_typing(
 
     typing_task = asyncio.create_task(_typing_loop())
     try:
-        headers = {"X-API-Key": _get_api_key()}
+        chat_api_key = await get_api_key_for_chat(int(chat_id))
+        headers = {"X-API-Key": chat_api_key or _get_api_key()}
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(
                 f"{settings.core_api_url.rstrip('/')}{path}",
@@ -145,8 +161,16 @@ async def _call_api_with_typing(
             )
             response.raise_for_status()
             return response.json()
-    except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
-        await message.answer(f"Ошибка при обращении к API: {exc}")
+    except httpx.TimeoutException:
+        await message.answer(_friendly_error_by_code("llm_timeout"))
+        return None
+    except httpx.HTTPStatusError as exc:
+        code = "internal"
+        with contextlib.suppress(ValueError):
+            detail = exc.response.json().get("detail", {})
+            if isinstance(detail, Mapping):
+                code = str(detail.get("code", code))
+        await message.answer(_friendly_error_by_code(code))
         return None
     finally:
         typing_task.cancel()
@@ -194,15 +218,88 @@ async def app_handler(message: Message) -> None:
 
 @router.message(Command("link"))
 async def link_handler(message: Message) -> None:
-    """Выдать одноразовый код для привязки Telegram к desktop-сессии."""
+    """Привязка API-ключа через /link <api_key>."""
     user_id = _require_user_id(message)
-    token = issue_telegram_link_token(telegram_user_id=user_id, session_id=str(user_id))
+    text = (message.text or "").strip()
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2:
+        token = issue_telegram_link_token(telegram_user_id=user_id, session_id=str(user_id))
+        await message.answer(
+            "Код для привязки к Desktop (вставьте в настройках):\n"
+            f"`{token}`\n\n"
+            "Или используйте /link <api_key> для API-ключа.",
+            parse_mode="Markdown",
+        )
+        return
+
+    api_key = parts[1].strip()
+    if not _API_KEY_RE.match(api_key):
+        await message.answer("Неверный формат ключа")
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.get(
+                f"{settings.core_api_url.rstrip('/')}/api/me",
+                headers={"X-API-Key": api_key},
+            )
+    except httpx.HTTPError:
+        await message.answer("Не удалось проверить ключ. Попробуйте позже.")
+        return
+
+    if response.status_code == 401:
+        await message.answer("Ключ недействителен")
+        return
+    if response.status_code != 200:
+        await message.answer("Не удалось проверить ключ. Попробуйте позже.")
+        return
+
+    await save_api_key_for_chat(user_id, api_key)
+    await message.answer("Ключ сохранён ✅")
+
+
+@router.message(Command("unlink"))
+async def unlink_handler(message: Message) -> None:
+    user_id = _require_user_id(message)
+    await delete_api_key_for_chat(user_id)
+    await message.answer("Ключ отвязан.")
+
+
+@router.message(Command("whoami"))
+async def whoami_handler(message: Message) -> None:
+    user_id = _require_user_id(message)
+    api_key = await get_api_key_for_chat(user_id)
+    if not api_key:
+        await message.answer("Ключ не привязан. Используйте /link <api_key>.")
+        return
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.get(
+                f"{settings.core_api_url.rstrip('/')}/api/me",
+                headers={"X-API-Key": api_key},
+            )
+            response.raise_for_status()
+            profile = response.json()
+    except httpx.HTTPError:
+        await message.answer("Не удалось получить профиль.")
+        return
     await message.answer(
-        "Код для привязки к Desktop (вставьте в настройках):\n"
-        f"`{token}`\n\n"
-        "После привязки desktop будет получать уведомления о готовых документах.",
-        parse_mode="Markdown",
+        f"Пользователь: {profile.get('username', 'unknown')}\n"
+        f"Роль: {profile.get('role', 'unknown')}"
     )
+
+
+@router.message(Command("health"))
+async def health_handler(message: Message) -> None:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{settings.core_api_url.rstrip('/')}/api/telegram/health")
+            response.raise_for_status()
+            payload = response.json()
+    except httpx.HTTPError:
+        await message.answer("Healthcheck недоступен.")
+        return
+    await message.answer(f"Активных сессий: {payload.get('active_sessions', 0)}")
 
 
 @router.callback_query(F.data.startswith("project_doc:"))
@@ -281,6 +378,7 @@ async def projects_handler(message: Message) -> None:
 
 @router.message(Command("tk"))
 async def tk_start_handler(message: Message, state: FSMContext) -> None:
+    BOT_MESSAGES_TOTAL.labels(handler="tk").inc()
     await state.set_state(TKStates.work_type)
     await message.answer("Введите вид работ:", reply_markup=cancel_keyboard())
 
@@ -380,6 +478,7 @@ async def tk_confirm_yes_handler(callback: CallbackQuery, state: FSMContext) -> 
 
 @router.message(Command("letter"))
 async def letter_start_handler(message: Message, state: FSMContext) -> None:
+    BOT_MESSAGES_TOTAL.labels(handler="letter").inc()
     await state.set_state(LetterStates.letter_type)
     await message.answer(
         "Выберите тип письма:",
@@ -491,6 +590,7 @@ async def letter_confirm_yes_handler(callback: CallbackQuery, state: FSMContext)
 
 @router.message(Command("ks"))
 async def ks_start_handler(message: Message, state: FSMContext) -> None:
+    BOT_MESSAGES_TOTAL.labels(handler="ks").inc()
     await state.set_state(KSStates.object_name)
     await message.answer("Введите наименование объекта:", reply_markup=cancel_keyboard())
 

--- a/telegram/handlers/auth.py
+++ b/telegram/handlers/auth.py
@@ -1,0 +1,5 @@
+"""Auth commands for Telegram bot."""
+
+from telegram.handlers import link_handler, unlink_handler, whoami_handler
+
+__all__ = ["link_handler", "unlink_handler", "whoami_handler"]

--- a/telegram/handlers/generate.py
+++ b/telegram/handlers/generate.py
@@ -1,0 +1,9 @@
+"""Generate handlers exports for compatibility."""
+
+from telegram.handlers import (
+    ks_confirm_yes_handler,
+    letter_confirm_yes_handler,
+    tk_confirm_yes_handler,
+)
+
+__all__ = ["tk_confirm_yes_handler", "letter_confirm_yes_handler", "ks_confirm_yes_handler"]

--- a/telegram/main.py
+++ b/telegram/main.py
@@ -1,6 +1,7 @@
 """Точка входа Telegram-бота на aiogram 3."""
 
 import asyncio
+import contextlib
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
@@ -9,10 +10,16 @@ from aiogram.enums import ParseMode
 from config.settings import settings
 from telegram.handlers import router
 from telegram.handlers.handover import router as handover_router
+from telegram.middlewares.auth import TelegramAuthMiddleware
+from telegram.middlewares.rate_limit import TelegramRateLimitMiddleware
 
 
 def create_dispatcher() -> Dispatcher:
     dp = Dispatcher()
+    dp.message.middleware(TelegramRateLimitMiddleware())
+    dp.callback_query.middleware(TelegramRateLimitMiddleware())
+    dp.message.middleware(TelegramAuthMiddleware())
+    dp.callback_query.middleware(TelegramAuthMiddleware())
     dp.include_router(router)
     dp.include_router(handover_router)
     return dp
@@ -31,18 +38,22 @@ async def main() -> None:
 
     bot = create_bot()
     dp = create_dispatcher()
-    if not settings.telegram_webhook_url:
-        await dp.start_polling(bot)
-        return
+    try:
+        if not settings.telegram_webhook_url:
+            await dp.start_polling(bot)
+            return
 
-    if settings.telegram_webhook_secret:
-        await bot.set_webhook(
-            settings.telegram_webhook_url,
-            secret_token=settings.telegram_webhook_secret,
-        )
-    else:
-        await bot.set_webhook(settings.telegram_webhook_url)
-    await asyncio.Event().wait()
+        if settings.telegram_webhook_secret:
+            await bot.set_webhook(
+                settings.telegram_webhook_url,
+                secret_token=settings.telegram_webhook_secret,
+            )
+        else:
+            await bot.set_webhook(settings.telegram_webhook_url)
+        await asyncio.Event().wait()
+    finally:
+        with contextlib.suppress(Exception):
+            await bot.session.close()
 
 
 if __name__ == "__main__":

--- a/telegram/middlewares/__init__.py
+++ b/telegram/middlewares/__init__.py
@@ -1,0 +1,6 @@
+"""Middlewares for Telegram bot."""
+
+from telegram.middlewares.auth import TelegramAuthMiddleware
+from telegram.middlewares.rate_limit import TelegramRateLimitMiddleware
+
+__all__ = ["TelegramAuthMiddleware", "TelegramRateLimitMiddleware"]

--- a/telegram/middlewares/auth.py
+++ b/telegram/middlewares/auth.py
@@ -1,0 +1,71 @@
+"""Telegram auth middleware: attaches user API key from Redis."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from typing import Any
+
+from aiogram import BaseMiddleware
+
+from config.settings import settings
+
+USER_API_KEY_TTL_SECONDS = 90 * 24 * 60 * 60
+
+
+class TelegramAuthMiddleware(BaseMiddleware):
+    """Inject chat-scoped api_key into handler data."""
+
+    async def __call__(self, handler, event, data):  # type: ignore[override]
+        chat = getattr(event, "chat", None)
+        if chat is None:
+            return await handler(event, data)
+
+        api_key = await get_api_key_for_chat(int(chat.id))
+        if api_key:
+            data["api_key"] = api_key
+        return await handler(event, data)
+
+
+def _redis_client() -> Any | None:
+    if importlib.util.find_spec("redis") is None:
+        return None
+    redis_asyncio = importlib.import_module("redis.asyncio")
+    return redis_asyncio.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+async def get_api_key_for_chat(chat_id: int) -> str:
+    """Resolve chat api key from Redis or fallback to static API key."""
+    key_name = f"tg:user:{chat_id}:api_key"
+    client = _redis_client()
+    if client is not None:
+        try:
+            value = await client.get(key_name)
+            if value:
+                return str(value)
+        finally:
+            await client.close()
+    if settings.api_keys:
+        return settings.api_keys[0]
+    return ""
+
+
+async def save_api_key_for_chat(chat_id: int, api_key: str) -> None:
+    """Persist chat api key with 90-day TTL."""
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        await client.set(f"tg:user:{chat_id}:api_key", api_key, ex=USER_API_KEY_TTL_SECONDS)
+    finally:
+        await client.close()
+
+
+async def delete_api_key_for_chat(chat_id: int) -> None:
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        await client.delete(f"tg:user:{chat_id}:api_key")
+    finally:
+        await client.close()

--- a/telegram/middlewares/rate_limit.py
+++ b/telegram/middlewares/rate_limit.py
@@ -1,0 +1,59 @@
+"""Rate limit middleware for Telegram handlers."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import math
+from typing import Any
+
+from aiogram import BaseMiddleware
+
+from config.settings import settings
+
+RATE_LIMIT_MAX = 10
+RATE_LIMIT_WINDOW_SECONDS = 60
+
+
+class TelegramRateLimitMiddleware(BaseMiddleware):
+    """Enforces 10 req/min per chat_id."""
+
+    async def __call__(self, handler, event, data):  # type: ignore[override]
+        chat = getattr(event, "chat", None)
+        if chat is None:
+            return await handler(event, data)
+
+        allowed, retry_after = await check_rate_limit(int(chat.id))
+        if not allowed:
+            message = getattr(event, "answer", None)
+            if callable(message):
+                await event.answer(f"Слишком часто, попробуйте через {retry_after} сек")
+            return None
+        return await handler(event, data)
+
+
+def _redis_client() -> Any | None:
+    if importlib.util.find_spec("redis") is None:
+        return None
+    redis_asyncio = importlib.import_module("redis.asyncio")
+    return redis_asyncio.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+async def check_rate_limit(chat_id: int) -> tuple[bool, int]:
+    """Return (is_allowed, retry_after_seconds)."""
+    key = f"tg:rate_limit:{chat_id}"
+    client = _redis_client()
+    if client is None:
+        return True, 0
+
+    try:
+        count = await client.incr(key)
+        if count == 1:
+            await client.expire(key, RATE_LIMIT_WINDOW_SECONDS)
+        if count <= RATE_LIMIT_MAX:
+            return True, 0
+        ttl = await client.ttl(key)
+        retry_after = max(1, math.ceil(float(ttl if ttl and ttl > 0 else RATE_LIMIT_WINDOW_SECONDS)))
+        return False, retry_after
+    finally:
+        await client.close()

--- a/telegram/middlewares/rate_limit.py
+++ b/telegram/middlewares/rate_limit.py
@@ -19,7 +19,7 @@ class TelegramRateLimitMiddleware(BaseMiddleware):
     """Enforces 10 req/min per chat_id."""
 
     async def __call__(self, handler, event, data):  # type: ignore[override]
-        chat = getattr(event, "chat", None)
+        chat = _resolve_event_chat(event)
         if chat is None:
             return await handler(event, data)
 
@@ -30,6 +30,17 @@ class TelegramRateLimitMiddleware(BaseMiddleware):
                 await event.answer(f"Слишком часто, попробуйте через {retry_after} сек")
             return None
         return await handler(event, data)
+
+
+def _resolve_event_chat(event: Any) -> Any | None:
+    chat = getattr(event, "chat", None)
+    if chat is not None:
+        return chat
+
+    message = getattr(event, "message", None)
+    if message is not None:
+        return getattr(message, "chat", None)
+    return None
 
 
 def _redis_client() -> Any | None:

--- a/telegram/middlewares/rate_limit.py
+++ b/telegram/middlewares/rate_limit.py
@@ -53,7 +53,10 @@ async def check_rate_limit(chat_id: int) -> tuple[bool, int]:
         if count <= RATE_LIMIT_MAX:
             return True, 0
         ttl = await client.ttl(key)
-        retry_after = max(1, math.ceil(float(ttl if ttl and ttl > 0 else RATE_LIMIT_WINDOW_SECONDS)))
+        retry_after = max(
+            1,
+            math.ceil(float(ttl if ttl and ttl > 0 else RATE_LIMIT_WINDOW_SECONDS)),
+        )
         return False, retry_after
     finally:
         await client.close()

--- a/tests/test_telegram_handlers.py
+++ b/tests/test_telegram_handlers.py
@@ -43,6 +43,7 @@ def _install_aiogram_stubs() -> None:
 
     aiogram.F = DummyF()
     aiogram.Router = DummyRouter
+    aiogram.BaseMiddleware = object
 
     filters = types.ModuleType("aiogram.filters")
     filters.Command = lambda value: value
@@ -100,6 +101,7 @@ def _install_aiogram_stubs() -> None:
     types_mod.KeyboardButton = _KeyboardButton
     types_mod.ReplyKeyboardMarkup = _ReplyKeyboardMarkup
     types_mod.Document = object
+    types_mod.WebAppInfo = lambda url="": SimpleNamespace(url=url)
 
     sys.modules["aiogram"] = aiogram
     sys.modules["aiogram.filters"] = filters
@@ -394,3 +396,53 @@ def test_project_doc_callback_uses_short_token_mapping():
         "Откройте документ в сессии: very-long-session-id-value",
     )
     callback.answer.assert_awaited_once()
+
+
+def test_link_invalid_key_format_returns_message():
+    _install_aiogram_stubs()
+    handlers = importlib.import_module("telegram.handlers")
+    message = SimpleNamespace(
+        text="/link bad!",
+        from_user=SimpleNamespace(id=55),
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handlers.link_handler(message))
+
+    message.answer.assert_awaited_once_with("Неверный формат ключа")
+
+
+def test_rate_limit_blocks_11th_request(monkeypatch):
+    module = importlib.import_module("telegram.middlewares.rate_limit")
+
+    class FakeRedis:
+        def __init__(self):
+            self.counter = 0
+
+        async def incr(self, _key):
+            self.counter += 1
+            return self.counter
+
+        async def expire(self, _key, _seconds):
+            return True
+
+        async def ttl(self, _key):
+            return 42
+
+        async def close(self):
+            return None
+
+    fake = FakeRedis()
+    monkeypatch.setattr(module, "_redis_client", lambda: fake)
+
+    async def _run():
+        for _ in range(10):
+            allowed, retry_after = await module.check_rate_limit(77)
+            assert allowed is True
+            assert retry_after == 0
+
+        allowed, retry_after = await module.check_rate_limit(77)
+        assert allowed is False
+        assert retry_after == 42
+
+    asyncio.run(_run())

--- a/tests/test_telegram_handlers.py
+++ b/tests/test_telegram_handlers.py
@@ -446,3 +446,65 @@ def test_rate_limit_blocks_11th_request(monkeypatch):
         assert retry_after == 42
 
     asyncio.run(_run())
+
+
+def test_health_handler_sends_api_key_header(monkeypatch):
+    _install_aiogram_stubs()
+    handlers = importlib.import_module("telegram.handlers")
+
+    async def fake_get_api_key_for_chat(_chat_id: int) -> str:
+        return "linked_api_key_123456"
+
+    class DummyResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"active_sessions": 7}
+
+    get_mock = AsyncMock(return_value=DummyResponse())
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return SimpleNamespace(get=get_mock)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(handlers, "get_api_key_for_chat", fake_get_api_key_for_chat)
+    monkeypatch.setattr(handlers.httpx, "AsyncClient", DummyAsyncClient)
+
+    message = SimpleNamespace(
+        text="/health",
+        from_user=SimpleNamespace(id=99),
+        answer=AsyncMock(),
+    )
+
+    asyncio.run(handlers.health_handler(message))
+
+    assert get_mock.await_count == 1
+    assert get_mock.await_args.kwargs["headers"]["X-API-Key"] == "linked_api_key_123456"
+    message.answer.assert_awaited_once_with("Активных сессий: 7")
+
+
+def test_rate_limit_uses_callback_message_chat(monkeypatch):
+    module = importlib.import_module("telegram.middlewares.rate_limit")
+    middleware = module.TelegramRateLimitMiddleware()
+    handler = AsyncMock(return_value="ok")
+
+    check_mock = AsyncMock(return_value=(True, 0))
+    monkeypatch.setattr(module, "check_rate_limit", check_mock)
+
+    callback_event = SimpleNamespace(
+        chat=None,
+        message=SimpleNamespace(chat=SimpleNamespace(id=4242)),
+        answer=AsyncMock(),
+    )
+
+    result = asyncio.run(middleware.__call__(handler, callback_event, {}))
+
+    assert result == "ok"
+    check_mock.assert_awaited_once_with(4242)


### PR DESCRIPTION
### Motivation
- Fix unreliable bot startup caused by incorrect entrypoint and missing health/dependency checks in `docker-compose.yml`.
- Provide a safe way for users to store per-chat API keys and protect the bot from abuse with per-chat rate-limiting.
- Surface friendly messages for SSE/backend error codes and offer a small health endpoint for operational visibility.

### Description
- Updated `docker-compose.yml` to run the bot with `python -m telegram.main`, added a bot `healthcheck`, and made `telegram-bot` depend on `api`, `redis`, and `postgres` with `condition: service_healthy`, and added a `postgres` service.
- Reworked the bot entrypoint in `telegram/main.py` to register middlewares, support graceful shutdown, and removed the legacy `telegram/bot.py` re-export.
- Implemented Redis-backed middlewares in `telegram/middlewares/auth.py` and `telegram/middlewares/rate_limit.py` to persist `tg:user:{chat_id}:api_key` (TTL 90 days) and enforce 10 requests/min per `chat_id` using `INCR`+`EXPIRE`+`TTL`.
- Added `/link <api_key>` validation and verification against `GET /api/me`, plus `/unlink`, `/whoami`, and `/health` bot commands in `telegram/handlers/__init__.py`, mapped backend `error.code` to user-friendly messages, and incremented the new `bot_messages_total{handler}` metric on generation entrypoints.
- Added `GET /api/telegram/health` endpoint in `api/main.py` to return active session count and registered the new Prometheus metric `bot_messages_total` in `api/metrics.py`; updated `.env.example`, `telegram/README.md`, `CHANGELOG.md`, and added small compatibility exports in `telegram/handlers/auth.py` and `telegram/handlers/generate.py`.

### Testing
- Ran unit tests `pytest tests/test_telegram_handlers.py -q`, which passed: `11 passed`.
- Attempted `docker compose config` and `docker compose up -d bot && docker compose logs bot --tail=50`, but the Docker CLI is unavailable in this environment so compose validation/run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b1af08e8832f8b1bd3b3fe03e142)