### PR TITLE
feat(compliance): accept project short_id and unify auth dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - feat(kb): split personal vs global knowledge base
 - feat(api): SSE for letter
+- feat(compliance): accept short_id, fix 422→404
 
 ## [0.2.0] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ text
 
 ---
 
+
+## Как получить short_id проекта
+
+- Вызовите `GET /api/projects/mine` (или `GET /api/projects`) с вашим JWT или `X-API-Key`.
+- В каждом объекте проекта поле `short_id` содержит короткий числовой идентификатор проекта.
+- `short_id` можно использовать в compliance-эндпоинтах (`/api/compliance/gsn-checklist/{project_id}`, `/api/compliance/gsn-report/{project_id}`) наравне с UUID.
+
 ## Тарифные планы
 
 | План | Проектов | AI-запросов/мес | Альбомов |

--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,80 @@
+"""Reusable API dependencies."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import Header, HTTPException, Request
+
+from api.routes.auth import decode_jwt_token
+from config.settings import settings
+
+
+@dataclass(frozen=True)
+class CurrentUser:
+    username: str
+    role: str
+    org_id: str = "default"
+
+
+def _ensure_api_keys_table() -> None:
+    db_path = Path(settings.users_db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_keys (
+                api_key TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL
+            )
+            """
+        )
+        connection.commit()
+
+
+def _lookup_api_key_user(api_key: str) -> str | None:
+    _ensure_api_keys_table()
+    with sqlite3.connect(settings.users_db_path) as connection:
+        row = connection.execute(
+            "SELECT user_id FROM api_keys WHERE api_key = ?",
+            (api_key,),
+        ).fetchone()
+    if row is None:
+        return None
+    return str(row[0])
+
+
+async def current_user(
+    request: Request,
+    authorization: str | None = Header(default=None),
+    x_api_key: str | None = Header(default=None),
+) -> CurrentUser:
+    """Resolve authenticated user from JWT first, then API key mapping."""
+    if authorization and authorization.startswith("Bearer "):
+        payload = decode_jwt_token(authorization.removeprefix("Bearer ").strip())
+        return CurrentUser(
+            username=payload["username"],
+            role=payload["role"],
+            org_id=payload.get("org_id", "default"),
+        )
+
+    state_username = getattr(request.state, "username", None)
+    state_role = getattr(request.state, "user_role", None)
+    if state_username and state_role:
+        return CurrentUser(
+            username=str(state_username),
+            role=str(state_role),
+            org_id=str(getattr(request.state, "org_id", "default") or "default"),
+        )
+
+    if not x_api_key or x_api_key not in settings.api_keys:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    username = _lookup_api_key_user(x_api_key)
+    if not username:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    role = "admin" if x_api_key in settings.admin_api_keys else "pto_engineer"
+    return CurrentUser(username=username, role=role, org_id="default")

--- a/api/routes/compliance.py
+++ b/api/routes/compliance.py
@@ -7,14 +7,16 @@ import datetime as dt
 from pathlib import Path
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
+from sqlalchemy import select
 
-from config.settings import settings
+from api.deps import CurrentUser, current_user
 from core.branding import BrandingConfig, get_branding
-from core.compliance.gsn_checklist import GSNReadinessChecker
 from core.multitenancy import get_tenant_id
 from core.projects import Project, get_projects_sessionmaker
+from config.settings import settings
+from core.compliance.gsn_checklist import GSNReadinessChecker
 
 router = APIRouter(prefix="/compliance", tags=["compliance"])
 checker = GSNReadinessChecker()
@@ -59,57 +61,70 @@ def _render_pdf_from_html(html: str) -> bytes:
     return HTML(string=html, base_url=str(Path.cwd())).write_pdf()
 
 
-def _require_project_member(request: Request, project_id: UUID, org_id: str) -> None:
-    username = getattr(request.state, "username", None)
-    if not username:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
+def _resolve_project(project_id: str, org_id: str) -> Project:
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
     with session_local() as session:
-        project = session.get(Project, project_id)
-        if project is None or project.org_id != org_id:
-            raise HTTPException(status_code=404, detail="Project not found")
+        project: Project | None = None
+        try:
+            parsed_uuid = UUID(project_id)
+            project = session.get(Project, parsed_uuid)
+        except ValueError:
+            if project_id.isdigit():
+                project = session.execute(
+                    select(Project).where(Project.short_id == int(project_id))
+                ).scalar_one_or_none()
 
-        members = project.members or []
-        if username != project.owner_id and username not in members:
-            raise HTTPException(status_code=403, detail="Access denied")
+        if project is None or project.org_id != org_id:
+            raise HTTPException(status_code=404, detail="project_not_found")
+
+        session.expunge(project)
+        return project
+
+
+def _require_project_member(user: CurrentUser, project: Project) -> None:
+    members = project.members or []
+    if user.username != project.owner_id and user.username not in members:
+        raise HTTPException(status_code=403, detail="Access denied")
 
 
 @router.get("/gsn-checklist/{project_id}")
 async def get_gsn_checklist(
-    project_id: UUID,
-    request: Request,
+    project_id: str,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    _require_project_member(request=request, project_id=project_id, org_id=org_id or "default")
-    return await checker.check_full_project(project_id=str(project_id))
+    project = _resolve_project(project_id=project_id, org_id=org_id or user.org_id or "default")
+    _require_project_member(user=user, project=project)
+    return await checker.check_full_project(project_id=str(project.id))
 
 
 @router.get("/gsn-checklist/{project_id}/section/{section}")
 async def get_gsn_checklist_section(
-    project_id: UUID,
+    project_id: str,
     section: str,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    _require_project_member(request=request, project_id=project_id, org_id=org_id or "default")
+    project = _resolve_project(project_id=project_id, org_id=org_id or user.org_id or "default")
+    _require_project_member(user=user, project=project)
     try:
-        return await checker.check_section(project_id=str(project_id), section=section)
+        return await checker.check_section(project_id=str(project.id), section=section)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post("/gsn-report/{project_id}")
 async def generate_gsn_report(
-    project_id: UUID,
-    request: Request,
+    project_id: str,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> Response:
-    _require_project_member(request=request, project_id=project_id, org_id=org_id or "default")
-    checklist = await checker.check_full_project(project_id=str(project_id))
-    branding = await get_branding(org_id or "default")
+    project = _resolve_project(project_id=project_id, org_id=org_id or user.org_id or "default")
+    _require_project_member(user=user, project=project)
+    checklist = await checker.check_full_project(project_id=str(project.id))
+    branding = await get_branding(org_id or user.org_id or "default")
     html = _render_gsn_report_html(
-        project_id=str(project_id),
+        project_id=str(project.short_id),
         checklist=checklist,
         branding=branding,
     )

--- a/api/routes/compliance.py
+++ b/api/routes/compliance.py
@@ -12,11 +12,11 @@ from fastapi.responses import Response
 from sqlalchemy import select
 
 from api.deps import CurrentUser, current_user
+from config.settings import settings
 from core.branding import BrandingConfig, get_branding
+from core.compliance.gsn_checklist import GSNReadinessChecker
 from core.multitenancy import get_tenant_id
 from core.projects import Project, get_projects_sessionmaker
-from config.settings import settings
-from core.compliance.gsn_checklist import GSNReadinessChecker
 
 router = APIRouter(prefix="/compliance", tags=["compliance"])
 checker = GSNReadinessChecker()

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import desc, func
+from sqlalchemy import desc, text
 
 from api.deps import CurrentUser, current_user
 from config.settings import settings
@@ -38,6 +38,20 @@ class AddDocumentRequest(BaseModel):
 
 class AddCommentRequest(BaseModel):
     text: str = Field(min_length=1)
+
+
+def _allocate_short_id(session) -> int:
+    session.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS project_short_id_seq (
+                id INTEGER PRIMARY KEY AUTOINCREMENT
+            )
+            """
+        )
+    )
+    session.execute(text("INSERT INTO project_short_id_seq DEFAULT VALUES"))
+    return int(session.execute(text("SELECT last_insert_rowid()")).scalar_one())
 
 
 def _serialize_project(project: Project) -> dict:
@@ -83,8 +97,7 @@ async def create_project(
     members = sorted(set(payload.members + [user.username]))
 
     with session_local() as session:
-        max_short_id = session.query(func.coalesce(func.max(Project.short_id), 0)).scalar()
-        next_short_id = int(max_short_id or 0) + 1
+        next_short_id = _allocate_short_id(session)
         project = Project(
             name=payload.name,
             description=payload.description,

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -83,7 +83,10 @@ async def create_project(
     members = sorted(set(payload.members + [user.username]))
 
     with session_local() as session:
-        next_short_id = int(session.query(func.coalesce(func.max(Project.short_id), 0)).scalar() or 0) + 1
+        max_short_id = session.query(
+            func.coalesce(func.max(Project.short_id), 0)
+        ).scalar()
+        next_short_id = int(max_short_id or 0) + 1
         project = Project(
             name=payload.name,
             description=payload.description,
@@ -113,7 +116,11 @@ async def list_projects(
             .order_by(desc(Project.created_at))
             .all()
         )
-        visible = [p for p in projects if user.username == p.owner_id or user.username in (p.members or [])]
+        visible = [
+            project
+            for project in projects
+            if user.username == project.owner_id or user.username in (project.members or [])
+        ]
         return {"projects": [_serialize_project(project) for project in visible]}
 
 

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -83,9 +83,7 @@ async def create_project(
     members = sorted(set(payload.members + [user.username]))
 
     with session_local() as session:
-        max_short_id = session.query(
-            func.coalesce(func.max(Project.short_id), 0)
-        ).scalar()
+        max_short_id = session.query(func.coalesce(func.max(Project.short_id), 0)).scalar()
         next_short_id = int(max_short_id or 0) + 1
         project = Project(
             name=payload.name,

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import datetime as dt
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import desc
+from sqlalchemy import desc, func
 
+from api.deps import CurrentUser, current_user
 from config.settings import settings
 from core.billing import require_quota
 from core.multitenancy import get_tenant_id
@@ -39,19 +40,13 @@ class AddCommentRequest(BaseModel):
     text: str = Field(min_length=1)
 
 
-def _require_username(request: Request) -> str:
-    username = getattr(request.state, "username", None)
-    if not username:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    return str(username)
-
-
 def _serialize_project(project: Project) -> dict:
     members = list(project.members or [])
     if project.owner_id not in members:
         members.append(project.owner_id)
     return {
         "id": str(project.id),
+        "short_id": project.short_id,
         "name": project.name,
         "description": project.description,
         "org_id": project.org_id,
@@ -77,24 +72,25 @@ def _serialize_document(document: ProjectDocument) -> dict:
 @router.post("", status_code=201)
 async def create_project(
     payload: CreateProjectRequest,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
     _quota: None = Depends(require_quota("projects")),
 ) -> dict:
     _ = _quota
-    owner = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
-    members = sorted(set(payload.members + [owner]))
+    members = sorted(set(payload.members + [user.username]))
 
     with session_local() as session:
+        next_short_id = int(session.query(func.coalesce(func.max(Project.short_id), 0)).scalar() or 0) + 1
         project = Project(
             name=payload.name,
             description=payload.description,
             org_id=tenant,
-            owner_id=owner,
+            owner_id=user.username,
             members=members,
+            short_id=next_short_id,
         )
         session.add(project)
         session.commit()
@@ -104,11 +100,10 @@ async def create_project(
 
 @router.get("")
 async def list_projects(
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict[str, list[dict]]:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -118,18 +113,25 @@ async def list_projects(
             .order_by(desc(Project.created_at))
             .all()
         )
-        visible = [p for p in projects if username == p.owner_id or username in (p.members or [])]
+        visible = [p for p in projects if user.username == p.owner_id or user.username in (p.members or [])]
         return {"projects": [_serialize_project(project) for project in visible]}
+
+
+@router.get("/mine")
+async def list_my_projects(
+    user: CurrentUser = Depends(current_user),
+    org_id: str | None = Depends(get_tenant_id),
+) -> dict[str, list[dict]]:
+    return await list_projects(user=user, org_id=org_id)
 
 
 @router.get("/{project_id}")
 async def get_project(
     project_id: UUID,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -137,7 +139,7 @@ async def get_project(
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
         members = project.members or []
-        if username != project.owner_id and username not in members:
+        if user.username != project.owner_id and user.username not in members:
             raise HTTPException(status_code=403, detail="Access denied")
         return _serialize_project(project)
 
@@ -146,18 +148,17 @@ async def get_project(
 async def add_project_member(
     project_id: UUID,
     payload: AddMemberRequest,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
         project = session.get(Project, project_id)
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
-        if username != project.owner_id:
+        if user.username != project.owner_id:
             raise HTTPException(status_code=403, detail="Only owner can add members")
 
         members = set(project.members or [])
@@ -174,11 +175,10 @@ async def add_project_member(
 async def add_project_document(
     project_id: UUID,
     payload: AddDocumentRequest,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -186,14 +186,14 @@ async def add_project_document(
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
         members = project.members or []
-        if username != project.owner_id and username not in members:
+        if user.username != project.owner_id and user.username not in members:
             raise HTTPException(status_code=403, detail="Access denied")
 
         document = ProjectDocument(
             project_id=project.id,
             document_type=payload.document_type,
             session_id=payload.session_id,
-            created_by=username,
+            created_by=user.username,
             title=payload.title,
             version=payload.version,
         )
@@ -206,11 +206,10 @@ async def add_project_document(
 @router.get("/{project_id}/documents")
 async def list_project_documents(
     project_id: UUID,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict[str, list[dict]]:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -218,7 +217,7 @@ async def list_project_documents(
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
         members = project.members or []
-        if username != project.owner_id and username not in members:
+        if user.username != project.owner_id and user.username not in members:
             raise HTTPException(status_code=403, detail="Access denied")
 
         documents = (
@@ -235,11 +234,10 @@ async def add_document_comment(
     project_id: UUID,
     doc_id: UUID,
     payload: AddCommentRequest,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -247,14 +245,14 @@ async def add_document_comment(
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
         members = project.members or []
-        if username != project.owner_id and username not in members:
+        if user.username != project.owner_id and user.username not in members:
             raise HTTPException(status_code=403, detail="Access denied")
 
         document = session.get(ProjectDocument, doc_id)
         if document is None or document.project_id != project.id:
             raise HTTPException(status_code=404, detail="Document not found")
 
-        comment = ProjectComment(document_id=doc_id, author=username, text=payload.text)
+        comment = ProjectComment(document_id=doc_id, author=user.username, text=payload.text)
         session.add(comment)
         session.commit()
         session.refresh(comment)
@@ -270,11 +268,10 @@ async def add_document_comment(
 @router.get("/{project_id}/history")
 async def get_project_history(
     project_id: UUID,
-    request: Request,
+    user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
 ) -> dict[str, list[dict]]:
-    username = _require_username(request)
-    tenant = org_id or "default"
+    tenant = org_id or user.org_id or "default"
     session_local = get_projects_sessionmaker(settings.sqlite_db_path)
 
     with session_local() as session:
@@ -282,7 +279,7 @@ async def get_project_history(
         if project is None or project.org_id != tenant:
             raise HTTPException(status_code=404, detail="Project not found")
         members = project.members or []
-        if username != project.owner_id and username not in members:
+        if user.username != project.owner_id and user.username not in members:
             raise HTTPException(status_code=403, detail="Access denied")
 
         entries: list[dict] = [

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -11,12 +11,26 @@ from sqlalchemy import desc, text
 
 from api.deps import CurrentUser, current_user
 from config.settings import settings
-from core.billing import require_quota
+from core.billing import get_current_plan, usage_counter
 from core.multitenancy import get_tenant_id
 from core.projects import Project, ProjectComment, ProjectDocument, get_projects_sessionmaker
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
+
+
+async def _require_projects_quota(
+    user: CurrentUser = Depends(current_user),
+    org_id: str | None = Depends(get_tenant_id),
+) -> None:
+    tenant = org_id or user.org_id or "default"
+    plan, _valid_until = get_current_plan(tenant)
+    allowed = await usage_counter.consume_quota(tenant, "projects", plan)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Quota exceeded for resource 'projects' on plan '{plan.value}'",
+        )
 
 
 class CreateProjectRequest(BaseModel):
@@ -88,7 +102,7 @@ async def create_project(
     payload: CreateProjectRequest,
     user: CurrentUser = Depends(current_user),
     org_id: str | None = Depends(get_tenant_id),
-    _quota: None = Depends(require_quota("projects")),
+    _quota: None = Depends(_require_projects_quota),
 ) -> dict:
     _ = _quota
     tenant = org_id or user.org_id or "default"

--- a/core/billing.py
+++ b/core/billing.py
@@ -254,6 +254,10 @@ def require_quota(resource: str, plan: PlanTier | None = None):
     ) -> None:
         tenant = org_id or getattr(request.state, "org_id", None)
         if not tenant:
+            api_key = request.headers.get("X-API-Key")
+            if api_key and api_key in settings.api_keys:
+                tenant = "default"
+        if not tenant:
             # For requests without tenant context quota cannot be enforced reliably.
             return
         actual_plan = _resolve_plan(tenant, plan)

--- a/core/billing.py
+++ b/core/billing.py
@@ -254,10 +254,6 @@ def require_quota(resource: str, plan: PlanTier | None = None):
     ) -> None:
         tenant = org_id or getattr(request.state, "org_id", None)
         if not tenant:
-            api_key = request.headers.get("X-API-Key")
-            if api_key and api_key in settings.api_keys:
-                tenant = "default"
-        if not tenant:
             # For requests without tenant context quota cannot be enforced reliably.
             return
         actual_plan = _resolve_plan(tenant, plan)

--- a/core/projects.py
+++ b/core/projects.py
@@ -6,7 +6,7 @@ import datetime as dt
 from pathlib import Path
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, create_engine
+from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, Integer, String, create_engine
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -33,6 +33,7 @@ class Project(Base):
     description: Mapped[str] = mapped_column(String(2000), default="", nullable=False)
     org_id: Mapped[str] = mapped_column(String(255), nullable=False, default="default", index=True)
     owner_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    short_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True, index=True)
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: dt.datetime.now(UTC),

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -154,6 +154,13 @@ export interface MeResponse {
   is_admin: boolean;
 }
 
+export interface MyProjectItem {
+  id: string;
+  short_id: number;
+  name: string;
+}
+
+
 export class ForbiddenError extends Error {
   status = 403;
 
@@ -509,6 +516,24 @@ export async function getMe(
   } catch (error) {
     parseError(error);
   }
+}
+
+
+export async function listMyProjects(
+  apiUrl: string,
+  apiKey: string,
+  { timeoutMs, signal }: ApiCallOptions = {}
+): Promise<MyProjectItem[]> {
+  const response = await apiRequest(normalizeApiUrl(apiUrl), '/api/projects/mine', {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey.trim()
+    },
+    timeoutMs,
+    signal
+  });
+  const payload = (await response.json()) as { projects?: MyProjectItem[] };
+  return Array.isArray(payload.projects) ? payload.projects : [];
 }
 
 export async function checkHealth(apiUrl: string, { timeoutMs, signal }: ApiCallOptions = {}): Promise<HealthResponse> {

--- a/desktop/src/pages/HandoverPage.tsx
+++ b/desktop/src/pages/HandoverPage.tsx
@@ -3,7 +3,7 @@ import TabLayout from '../components/TabLayout';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import Input from '../components/ui/Input';
-import { getApiConfig } from '../api/coreClient';
+import { getApiConfig, listMyProjects, type MyProjectItem } from '../api/coreClient';
 import { colors, spacing } from '../styles/tokens';
 import type { GSNChecklist, GSNSectionStatus, ScheduleForecast, SignStatus } from '../types/handover';
 
@@ -37,6 +37,17 @@ interface AllProjectsRiskItem {
 const sectionOrder = ['AR', 'KZH', 'KM', 'OV', 'VK', 'EM', 'SS', 'APS', 'PS'];
 const signableDocTypes = new Set(['aosr', 'ks2', 'ks3']);
 
+
+const projectIdPattern = /^[A-Za-z0-9-]+$/;
+
+function validateProjectId(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Укажите ID проекта';
+  if (trimmed.length < 1 || trimmed.length > 64) return 'ID проекта должен быть длиной 1-64 символа';
+  if (!projectIdPattern.test(trimmed)) return 'ID проекта может содержать только буквы, цифры и дефис';
+  return null;
+}
+
 function normalizeForecast(payload: Partial<ScheduleForecast>): ScheduleForecast {
   return {
     predicted_completion: String(payload.predicted_completion ?? '—'),
@@ -51,6 +62,7 @@ export default function HandoverPage() {
   const [activeTab, setActiveTab] = useState('readiness');
   const [projectId, setProjectId] = useState('');
   const [userId, setUserId] = useState('');
+  const [myProjects, setMyProjects] = useState<MyProjectItem[]>([]);
   const [checklist, setChecklist] = useState<GSNChecklist | null>(null);
   const [forecast, setForecast] = useState<ScheduleForecast | null>(null);
   const [project, setProject] = useState<ProjectInfo | null>(null);
@@ -70,6 +82,16 @@ export default function HandoverPage() {
     const savedUserId = window.localStorage.getItem('handover_user_id') ?? '';
     setProjectId(savedProjectId);
     setUserId(savedUserId);
+
+    (async () => {
+      try {
+        const { apiUrl, apiKey } = await getApiConfig();
+        const projects = await listMyProjects(apiUrl, apiKey);
+        setMyProjects(projects);
+      } catch {
+        setMyProjects([]);
+      }
+    })();
   }, []);
 
   const fetchJson = async <T,>(endpoint: string, init?: RequestInit): Promise<T> => {
@@ -142,8 +164,9 @@ export default function HandoverPage() {
   };
 
   const loadAll = async () => {
-    if (!projectId.trim()) {
-      setError('Укажите projectId');
+    const projectIdError = validateProjectId(projectId);
+    if (projectIdError) {
+      setError(projectIdError);
       return;
     }
 
@@ -168,8 +191,9 @@ export default function HandoverPage() {
   };
 
   const handleGenerateReport = async () => {
-    if (!projectId.trim()) {
-      setError('Укажите projectId');
+    const projectIdError = validateProjectId(projectId);
+    if (projectIdError) {
+      setError(projectIdError);
       return;
     }
 
@@ -372,8 +396,18 @@ export default function HandoverPage() {
 
       <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
         <label style={{ display: 'grid', gap: 4 }}>
-          <span>Project ID</span>
-          <Input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="UUID проекта" />
+          <span>ID проекта</span>
+          <Input
+            value={projectId}
+            onChange={(event) => setProjectId(event.target.value)}
+            placeholder="UUID или short_id проекта"
+            list="my-projects"
+          />
+          <datalist id="my-projects">
+            {myProjects.map((item) => (
+              <option key={item.id} value={item.id}>{`#${item.short_id} — ${item.name}`}</option>
+            ))}
+          </datalist>
         </label>
         <label style={{ display: 'grid', gap: 4 }}>
           <span>User ID для ЭЦП</span>

--- a/migrations/versions/20260419_add_short_id_to_projects.py
+++ b/migrations/versions/20260419_add_short_id_to_projects.py
@@ -1,0 +1,35 @@
+"""add short_id to projects
+
+Revision ID: 20260419_add_short_id_to_projects
+Revises: 20260417_add_push_subscriptions
+Create Date: 2026-04-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260419_add_short_id_to_projects"
+down_revision = "20260417_add_push_subscriptions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column("short_id", sa.BigInteger(), nullable=True),
+    )
+
+    bind = op.get_bind()
+    bind.execute(sa.text("UPDATE projects SET short_id = rowid WHERE short_id IS NULL"))
+
+    op.create_unique_constraint("uq_projects_short_id", "projects", ["short_id"])
+    op.create_index("ix_projects_short_id", "projects", ["short_id"], unique=False)
+    op.alter_column("projects", "short_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_projects_short_id", table_name="projects")
+    op.drop_constraint("uq_projects_short_id", "projects", type_="unique")
+    op.drop_column("projects", "short_id")

--- a/migrations/versions/20260419_add_short_id_to_projects.py
+++ b/migrations/versions/20260419_add_short_id_to_projects.py
@@ -28,8 +28,23 @@ def upgrade() -> None:
     op.create_index("ix_projects_short_id", "projects", ["short_id"], unique=False)
     op.alter_column("projects", "short_id", nullable=False)
 
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS project_short_id_seq (
+            id INTEGER PRIMARY KEY AUTOINCREMENT
+        )
+        """
+    )
+    max_short_id = bind.execute(sa.text("SELECT COALESCE(MAX(short_id), 0) FROM projects")).scalar()
+    if int(max_short_id or 0) > 0:
+        bind.execute(
+            sa.text("INSERT INTO project_short_id_seq (id) VALUES (:short_id)"),
+            {"short_id": int(max_short_id)},
+        )
+
 
 def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS project_short_id_seq")
     op.drop_index("ix_projects_short_id", table_name="projects")
     op.drop_constraint("uq_projects_short_id", "projects", type_="unique")
     op.drop_column("projects", "short_id")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import sqlite3
+from pathlib import Path
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
@@ -17,6 +19,26 @@ from core.projects import Project, ProjectDocument, get_projects_sessionmaker
 
 UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
 
+
+
+
+def _bind_api_key_user(api_key: str, username: str) -> None:
+    users_db = Path(settings.users_db_path)
+    users_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(users_db) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_keys (
+                api_key TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            "INSERT OR REPLACE INTO api_keys (api_key, user_id) VALUES (?, ?)",
+            (api_key, username),
+        )
+        connection.commit()
 
 def _make_bearer(username: str, role: str = "pto_engineer") -> str:
     payload = {
@@ -40,6 +62,7 @@ def _seed_project_docs(
         session.add(
             Project(
                 id=project_id,
+                short_id=11,
                 name="GSN Project",
                 description="",
                 owner_id=owner,
@@ -176,7 +199,7 @@ def test_gsn_checklist_requires_membership(tmp_path, monkeypatch):
                 headers={"Authorization": f"Bearer {_make_bearer('owner')}"},
             )
             malformed = client.get(
-                "/api/compliance/gsn-checklist/not-a-uuid",
+                "/api/compliance/gsn-checklist/does-not-exist",
                 headers={"Authorization": f"Bearer {_make_bearer('owner')}"},
             )
     finally:
@@ -185,4 +208,36 @@ def test_gsn_checklist_requires_membership(tmp_path, monkeypatch):
 
     assert forbidden.status_code == 403
     assert missing_project.status_code == 404
-    assert malformed.status_code == 422
+    assert malformed.status_code == 404
+    assert malformed.json() == {"detail": "project_not_found"}
+
+
+def test_gsn_checklist_short_id_with_api_key(tmp_path, monkeypatch):
+    old_db_path = settings.sqlite_db_path
+    old_users_db = settings.users_db_path
+    old_keys = settings.api_keys
+
+    settings.sqlite_db_path = str(tmp_path / "compliance_short_id.db")
+    settings.users_db_path = str(tmp_path / "users.db")
+    settings.api_keys = ["desktop-key"]
+
+    project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True, owner="tester")
+    _ = project_id
+    _bind_api_key_user("desktop-key", "tester")
+    monkeypatch.setattr(compliance, "checker", GSNReadinessChecker())
+
+    try:
+        with TestClient(app) as client:
+            ok = client.get("/api/compliance/gsn-checklist/11", headers={"X-API-Key": "desktop-key"})
+            not_found = client.get(
+                "/api/compliance/gsn-checklist/does-not-exist",
+                headers={"X-API-Key": "desktop-key"},
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        settings.users_db_path = old_users_db
+        settings.api_keys = old_keys
+
+    assert ok.status_code == 200
+    assert not_found.status_code == 404
+    assert not_found.json() == {"detail": "project_not_found"}

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -20,8 +20,6 @@ from core.projects import Project, ProjectDocument, get_projects_sessionmaker
 UTC = getattr(dt, "UTC", dt.timezone(dt.timedelta(0)))
 
 
-
-
 def _bind_api_key_user(api_key: str, username: str) -> None:
     users_db = Path(settings.users_db_path)
     users_db.parent.mkdir(parents=True, exist_ok=True)
@@ -39,6 +37,7 @@ def _bind_api_key_user(api_key: str, username: str) -> None:
             (api_key, username),
         )
         connection.commit()
+
 
 def _make_bearer(username: str, role: str = "pto_engineer") -> str:
     payload = {

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -221,14 +221,22 @@ def test_gsn_checklist_short_id_with_api_key(tmp_path, monkeypatch):
     settings.users_db_path = str(tmp_path / "users.db")
     settings.api_keys = ["desktop-key"]
 
-    project_id = _seed_project_docs(settings.sqlite_db_path, section="KZH", include_journals=True, owner="tester")
+    project_id = _seed_project_docs(
+        settings.sqlite_db_path,
+        section="KZH",
+        include_journals=True,
+        owner="tester",
+    )
     _ = project_id
     _bind_api_key_user("desktop-key", "tester")
     monkeypatch.setattr(compliance, "checker", GSNReadinessChecker())
 
     try:
         with TestClient(app) as client:
-            ok = client.get("/api/compliance/gsn-checklist/11", headers={"X-API-Key": "desktop-key"})
+            ok = client.get(
+                "/api/compliance/gsn-checklist/11",
+                headers={"X-API-Key": "desktop-key"},
+            )
             not_found = client.get(
                 "/api/compliance/gsn-checklist/does-not-exist",
                 headers={"X-API-Key": "desktop-key"},

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -41,6 +41,7 @@ def test_create_project(tmp_path):
     data = response.json()
     assert data["name"] == "ЖК Север"
     assert set(data["members"]) == {"ivan", "petr"}
+    assert isinstance(data["short_id"], int)
 
 
 def test_add_member(tmp_path):
@@ -171,3 +172,22 @@ def test_query_param_user_id_does_not_authorize(tmp_path):
 
     assert response.status_code == 401
     assert response.json() == {"detail": "Authentication required"}
+
+
+def test_list_my_projects_alias(tmp_path):
+    old_db_path = _with_temp_db(tmp_path)
+    try:
+        with TestClient(app) as client:
+            client.post(
+                "/api/projects",
+                json={"name": "Mine", "description": "Only mine", "members": []},
+                headers=_auth_headers("owner"),
+            )
+            mine = client.get("/api/projects/mine", headers=_auth_headers("owner"))
+    finally:
+        settings.sqlite_db_path = old_db_path
+        projects_core._ENGINE_CACHE.clear()
+        projects_core._SESSIONMAKER_CACHE.clear()
+
+    assert mine.status_code == 200
+    assert len(mine.json()["projects"]) == 1

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from api.main import app
 from api.routes.auth import _create_token
 from config.settings import settings
+from core import billing as billing_core
 from core import projects as projects_core
 
 
@@ -191,3 +195,57 @@ def test_list_my_projects_alias(tmp_path):
 
     assert mine.status_code == 200
     assert len(mine.json()["projects"]) == 1
+
+
+def _bind_api_key_user(users_db_path: str, api_key: str, username: str) -> None:
+    users_db = Path(users_db_path)
+    users_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(users_db) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_keys (
+                api_key TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            "INSERT OR REPLACE INTO api_keys (api_key, user_id) VALUES (?, ?)",
+            (api_key, username),
+        )
+        connection.commit()
+
+
+def test_api_key_project_creation_consumes_quota(tmp_path, monkeypatch):
+    old_db_path = _with_temp_db(tmp_path)
+    old_users_db = settings.users_db_path
+    old_api_keys = settings.api_keys
+    settings.users_db_path = str(tmp_path / "users.db")
+    settings.api_keys = ["test-key"]
+    _bind_api_key_user(settings.users_db_path, "test-key", "owner")
+
+    called: dict[str, str | None] = {"org_id": None}
+
+    async def _consume_quota(org_id: str, resource: str, plan):
+        _ = resource, plan
+        called["org_id"] = org_id
+        return True
+
+    monkeypatch.setattr(billing_core.usage_counter, "consume_quota", _consume_quota)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/projects",
+                json={"name": "API Key", "description": "Quota", "members": []},
+                headers={"X-API-Key": "test-key"},
+            )
+    finally:
+        settings.sqlite_db_path = old_db_path
+        settings.users_db_path = old_users_db
+        settings.api_keys = old_api_keys
+        projects_core._ENGINE_CACHE.clear()
+        projects_core._SESSIONMAKER_CACHE.clear()
+
+    assert response.status_code == 201
+    assert called["org_id"] == "default"


### PR DESCRIPTION
### Motivation
- Allow compliance endpoints to accept both UUID and short numeric project identifiers so desktop users can use legacy short IDs.  
- Unify authentication handling so JWT is preferred but `X-API-Key` can be used via lookup to `api_keys.user_id`, avoiding 401/422 differences.  
- Improve desktop UX for Handover by validating input and replacing free-text with an autocomplete of the user’s projects.

### Description
- Added a reusable auth dependency `current_user()` in `api/deps.py` that prefers JWT (`Authorization: Bearer`) and falls back to `X-API-Key` mapped to a `user_id` in a local `api_keys` table.  
- Introduced `short_id` column on `Project` (`core/projects.py`) and a reversible Alembic migration `migrations/versions/20260419_add_short_id_to_projects.py` to add, backfill and index the column.  
- Updated project creation to allocate an incremental `short_id`, included `short_id` in serialized project payloads, and added `GET /api/projects/mine` in `api/routes/projects.py`.  
- Changed compliance routes (`api/routes/compliance.py`) to accept `project_id: str`, added `_resolve_project()` to resolve UUID or numeric `short_id`, return `404 {

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b6388b74832fa1834bb4880badd1)