### PR TITLE
fix(tauri): add missing permissions and harden diagnostics log actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - fix(health): honest LLM status
 - fix(cors): valid credentials+origins
 - fix(bot): correct entrypoint, add /link validation, rate-limit
+- fix(tauri): add missing permissions for logs folder
 
 ### Added
 - feat(kb): split personal vs global knowledge base

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -25,6 +25,22 @@ npm run tauri build
 - `src/` — UI (React + TypeScript)
 - `src-tauri/` — Rust-команды Tauri
 
+## Tauri плагины и permissions
+- Плагины (`src-tauri/Cargo.toml` + `src-tauri/tauri.conf.json`):
+  - `tauri-plugin-store`
+  - `tauri-plugin-log`
+  - `tauri-plugin-shell`
+  - `tauri-plugin-fs`
+  - `tauri-plugin-dialog`
+  - `tauri-plugin-clipboard-manager`
+- Capability `src-tauri/capabilities/default.json` включает:
+  - `core:default`, `store:default`
+  - `shell:allow-open`
+  - `fs:allow-read-dir`
+  - `path:default`
+  - `dialog:allow-message`, `dialog:allow-ask`
+  - Кастомные команды: `allow-get-api-url`, `allow-set-api-url`, `allow-pick-pdf-file`, `allow-read-pdf-file-bytes`, `allow-open-logs-folder`, `allow-copy-last-log-lines`, `allow-get-app-version`
+
 ## Настройки
 Настройки `API URL` и `API Key` сохраняются через `tauri-plugin-store` в:
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -14,6 +14,10 @@ serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
 tauri-plugin-log = "2"
+tauri-plugin-shell = "2"
+tauri-plugin-fs = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-clipboard-manager = "2"
 thiserror = "2"
 rfd = "0.15"
 dirs = "6"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -8,9 +8,17 @@
   "permissions": [
     "core:default",
     "store:default",
+    "shell:allow-open",
+    "fs:allow-read-dir",
+    "path:default",
+    "dialog:allow-message",
+    "dialog:allow-ask",
     "allow-get-api-url",
     "allow-set-api-url",
     "allow-pick-pdf-file",
-    "allow-read-pdf-file-bytes"
+    "allow-read-pdf-file-bytes",
+    "allow-open-logs-folder",
+    "allow-copy-last-log-lines",
+    "allow-get-app-version"
   ]
 }

--- a/desktop/src-tauri/permissions/commands/get_app_version.toml
+++ b/desktop/src-tauri/permissions/commands/get_app_version.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-get-app-version"
+description = "Enables the get_app_version command without any pre-configured scope."
+commands.allow = ["get_app_version"]
+
+[[permission]]
+identifier = "deny-get-app-version"
+description = "Denies the get_app_version command without any pre-configured scope."
+commands.deny = ["get_app_version"]

--- a/desktop/src-tauri/permissions/default.toml
+++ b/desktop/src-tauri/permissions/default.toml
@@ -7,5 +7,6 @@ permissions = [
   "allow-pick-pdf-file",
   "allow-read-pdf-file-bytes",
   "allow-open-logs-folder",
-  "allow-copy-last-log-lines"
+  "allow-copy-last-log-lines",
+  "allow-get-app-version"
 ]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4,6 +4,7 @@ use dirs::config_dir;
 use log::{error, info, warn};
 use std::{fs, path::PathBuf};
 use tauri::Manager;
+use tauri_plugin_shell::ShellExt;
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_store::{StoreExt, JsonValue};
 
@@ -12,7 +13,6 @@ const STORE_FILE: &str = "settings.json";
 const API_URL_KEY: &str = "api_url";
 const API_KEY_KEY: &str = "api_key";
 const DEFAULT_API_URL: &str = "https://vanekpetrov1997.fvds.ru";
-const LOGS_DIR_NAME: &str = "logs";
 const LOG_FILE_NAME: &str = "app.log";
 
 fn settings_path() -> PathBuf {
@@ -78,9 +78,8 @@ fn read_pdf_file_bytes(path: String) -> Result<Vec<u8>, String> {
 fn app_logs_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
   app
     .path()
-    .app_data_dir()
+    .app_log_dir()
     .map_err(|e| e.to_string())
-    .map(|path| path.join(LOGS_DIR_NAME))
 }
 
 fn app_log_file(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -91,29 +90,11 @@ fn app_log_file(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 fn open_logs_folder(app: tauri::AppHandle) -> Result<(), String> {
   let logs_dir = app_logs_dir(&app)?;
   fs::create_dir_all(&logs_dir).map_err(|e| e.to_string())?;
-
-  #[cfg(target_os = "windows")]
-  let mut command = {
-    let mut cmd = std::process::Command::new("explorer");
-    cmd.arg(&logs_dir);
-    cmd
-  };
-
-  #[cfg(target_os = "macos")]
-  let mut command = {
-    let mut cmd = std::process::Command::new("open");
-    cmd.arg(&logs_dir);
-    cmd
-  };
-
-  #[cfg(all(unix, not(target_os = "macos")))]
-  let mut command = {
-    let mut cmd = std::process::Command::new("xdg-open");
-    cmd.arg(&logs_dir);
-    cmd
-  };
-
-  command.status().map_err(|e| e.to_string())?;
+  let logs_url = format!("file://{}", logs_dir.to_string_lossy());
+  app
+    .shell()
+    .open(logs_url, None)
+    .map_err(|e| e.to_string())?;
   info!("Logs directory opened: {}", logs_dir.display());
   Ok(())
 }
@@ -139,6 +120,11 @@ fn copy_last_log_lines(app: tauri::AppHandle, lines: Option<usize>) -> Result<St
   );
 
   Ok(tail)
+}
+
+#[tauri::command]
+fn get_app_version(app: tauri::AppHandle) -> String {
+  app.package_info().version.to_string()
 }
 
 fn ensure_store_defaults(app: &tauri::AppHandle) -> Result<(), String> {
@@ -177,6 +163,10 @@ fn main() {
         .build()
     )
     .plugin(tauri_plugin_store::Builder::default().build())
+    .plugin(tauri_plugin_shell::init())
+    .plugin(tauri_plugin_fs::init())
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_clipboard_manager::init())
     .setup(|app| {
       ensure_logs_dir(&app.handle())
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
@@ -191,7 +181,8 @@ fn main() {
       pick_pdf_file,
       read_pdf_file_bytes,
       open_logs_folder,
-      copy_last_log_lines
+      copy_last_log_lines,
+      get_app_version
     ])
     .run(tauri::generate_context!())
     .unwrap_or_else(|error| {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,6 +22,14 @@
       "csp": null
     }
   },
+  "plugins": {
+    "shell": {
+      "open": true
+    },
+    "fs": {},
+    "dialog": {},
+    "clipboard-manager": {}
+  },
   "bundle": {
     "active": true,
     "targets": ["dmg", "msi", "deb"],

--- a/desktop/src/lib/logger.ts
+++ b/desktop/src/lib/logger.ts
@@ -1,3 +1,5 @@
+import { appLogDir } from '@tauri-apps/api/path';
+
 export type LogLevel = 'info' | 'warn' | 'error';
 
 export function logEvent(level: LogLevel, event: string, payload?: Record<string, unknown>) {
@@ -15,4 +17,8 @@ export function logEvent(level: LogLevel, event: string, payload?: Record<string
 
 export function logError(event: string, payload?: Record<string, unknown>) {
   logEvent('error', event, payload);
+}
+
+export async function getAppLogDir() {
+  return appLogDir();
 }

--- a/desktop/src/pages/DiagnosticsPage.tsx
+++ b/desktop/src/pages/DiagnosticsPage.tsx
@@ -5,6 +5,7 @@ import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import { checkHealth, DEFAULT_API_URL, normalizeApiUrl, type HealthResponse } from '../api/coreClient';
 import { colors, spacing } from '../styles/tokens';
+import { getAppLogDir } from '../lib/logger';
 
 type HealthTone = 'idle' | 'checking' | 'ok' | 'error';
 
@@ -21,6 +22,13 @@ export default function DiagnosticsPage() {
   const [healthTone, setHealthTone] = useState<HealthTone>('idle');
   const [healthMessage, setHealthMessage] = useState('Проверка /health ещё не запускалась.');
   const [copyMessage, setCopyMessage] = useState('');
+
+  const showFriendlyError = useCallback(async (fallback: string, error: unknown) => {
+    const reason = error instanceof Error ? error.message : fallback;
+    const friendlyMessage = `${fallback}\n\n${reason}`;
+    setCopyMessage(friendlyMessage);
+    return friendlyMessage;
+  }, []);
 
   const loadApiUrl = useCallback(async () => {
     const store = await Store.load('settings.json');
@@ -54,8 +62,13 @@ export default function DiagnosticsPage() {
   const onOpenLogsFolder = async () => {
     try {
       await invoke('open_logs_folder');
+      const logsDir = await getAppLogDir();
+      setCopyMessage(`Папка логов открыта: ${logsDir}`);
     } catch (error) {
-      setCopyMessage(error instanceof Error ? error.message : 'Не удалось открыть папку логов.');
+      showFriendlyError(
+        'Не удалось открыть папку логов. Проверьте системные разрешения и настройки sandbox.',
+        error
+      );
     }
   };
 
@@ -65,7 +78,10 @@ export default function DiagnosticsPage() {
       await navigator.clipboard.writeText(lines || 'Лог-файл пока пуст.');
       setCopyMessage('Скопировано: последние 200 строк app.log');
     } catch (error) {
-      setCopyMessage(error instanceof Error ? error.message : 'Не удалось скопировать лог.');
+      showFriendlyError(
+        'Не удалось скопировать лог. Проверьте доступ к буферу обмена и правам приложения.',
+        error
+      );
     }
   };
 


### PR DESCRIPTION
### Motivation
- Исправить ошибку `Permission denied` при нажатии «Открыть папку логов» и обеспечить работу команд диагностики через Tauri-плагины. 
- Явно предоставить все необходимые permissions и зарегистрировать backend-команды, чтобы frontend получал дружественные ошибки вместо unhandled rejection.

### Description
- Добавлены права в `desktop/src-tauri/capabilities/default.json`: `shell:allow-open`, `fs:allow-read-dir`, `path:default`, `dialog:allow-message`, `dialog:allow-ask` и явные `allow-open-logs-folder`, `allow-copy-last-log-lines`, `allow-get-app-version`.
- В `desktop/src-tauri/src/main.rs` путь логов теперь берётся через `app.path().app_log_dir()`, команда `open_logs_folder` открывает каталог через `tauri-plugin-shell` (`ShellExt::open`), добавлена команда `get_app_version`, и зарегистрированы плагины `shell`, `fs`, `dialog`, `clipboard-manager` в `tauri::Builder`.
- В `desktop/src-tauri/Cargo.toml` добавлены зависимости на соответствующие Tauri-плагины; в `desktop/src-tauri/tauri.conf.json` добавлена секция `plugins` с включением `shell`, `fs`, `dialog`, `clipboard-manager`.
- Добавлен ACL-файл `desktop/src-tauri/permissions/commands/get_app_version.toml` и включение команды в `desktop/src-tauri/permissions/default.toml`.
- На фронте (`desktop/src/pages/DiagnosticsPage.tsx`) обернуты вызовы `invoke('open_logs_folder')` и `invoke('copy_last_log_lines')` в `try/catch` с показом дружелюбного сообщения в UI; при успешном открытии показывается путь логов из `getAppLogDir()`.
- В `desktop/src/lib/logger.ts` добавлен helper `getAppLogDir()` на базе `appLogDir()`.
- Обновлены `desktop/README.md` (список плагинов / permissions) и `CHANGELOG.md` (запись `fix(tauri): add missing permissions for logs folder`).

### Testing
- Попытка собрать фронтенд и собрать Tauri-пакет: выполнялась команда `cd desktop && pnpm tauri build --debug`, сборка не прошла в CI-подобном окружении из-за отсутствия доступного `tauri` CLI в текущем pnpm-контексте (ошибка: `tauri: not found`) и ранее возникавших проблем с установкой пакетов в этом окружении; тест зафейлился по инфраструктурной причине.
- Статический анализ Rust: `cd desktop/src-tauri && cargo clippy --all-targets -- -D warnings` не выполнился из-за сетевой ошибки при доступе к `crates.io` (403 при загрузке индекса), поэтому локальные lints не были прогнаны в этом окружении.
- Нет изменений автоматических unit-тестов в проекте; все изменения локально покрываются ручной проверкой кнопок в dev-сборке (интент: после установки окружения/доступа к реестрам кнопка должна открывать проводник и копировать последние строки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bd402908832f84f781f600ffc82e)