### PR TITLE
feat(chat): markdown rendering, SSE sources, and real ChatRagPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix(tauri): add missing permissions for logs folder
 
 ### Added
+- feat(chat): markdown render + real RAG pipeline
 - feat(kb): split personal vs global knowledge base
 - feat(api): SSE for letter
 - feat(compliance): accept short_id, fix 422→404

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -35,6 +35,7 @@ EXCLUDED_PATHS = {
 PUBLIC_AUTH_PATHS = {"/auth/register", "/auth/login"}
 API_KEY_IDENTITY_PATHS = {
     "/api/me",
+    "/api/chat",
     "/api/rag/chat-upload",
     "/api/rag/my-sources",
 }

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -1,8 +1,10 @@
 """Chat endpoint — основной интерфейс общения с ИИ."""
 
+import json
 import uuid
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from core.billing import require_quota
@@ -18,6 +20,13 @@ class ChatRequest(BaseModel):
     message: str
     session_id: str | None = None
     role: str = "pto_engineer"  # pto_engineer | foreman | tender_specialist | admin
+    message_id: str | None = None
+
+
+class SourceItem(BaseModel):
+    title: str
+    page: int
+    score: float
 
 
 class ChatResponse(BaseModel):
@@ -28,6 +37,12 @@ class ChatResponse(BaseModel):
     agents_used: list[str] = []
     confidence: float | None = None
     conflict_rate: float | None = None
+    sources: list[SourceItem] = []
+    message_id: str | None = None
+
+
+def _sse_event(event: str, payload: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
 @router.post(
@@ -53,6 +68,7 @@ class ChatResponse(BaseModel):
 async def chat(
     payload: ChatRequest,
     request: Request,
+    stream: bool = Query(False, description="Вернуть ответ чата в формате SSE"),
     _quota: None = Depends(require_quota("ai_requests")),
 ):
     """Обработать сообщение пользователя через оркестратор."""
@@ -62,11 +78,39 @@ async def chat(
         message=payload.message,
         session_id=session_id,
         role=payload.role,
+        user_id=str(getattr(request.state, "username", "anonymous")),
     )
+
+    if stream or "text/event-stream" in request.headers.get("Accept", ""):
+        async def _stream():
+            yield _sse_event("progress", {"stage": "retrieval", "progress": 35})
+            for source in list(result.get("sources", [])):
+                yield _sse_event("source", {"source": source})
+            yield _sse_event(
+                "done",
+                {
+                    "stage": "done",
+                    "progress": 100,
+                    "result": {
+                        "reply": str(result.get("reply", "")),
+                        "session_id": str(result.get("session_id", session_id)),
+                        "agents_used": list(result.get("agents_used", [])),
+                        "confidence": result.get("confidence"),
+                        "conflict_rate": result.get("conflict_rate"),
+                        "sources": list(result.get("sources", [])),
+                        "message_id": payload.message_id,
+                    },
+                },
+            )
+
+        return StreamingResponse(_stream(), media_type="text/event-stream")
+
     return ChatResponse(
         reply=str(result.get("reply", "")),
         session_id=str(result.get("session_id", session_id)),
         agents_used=list(result.get("agents_used", [])),
         confidence=result.get("confidence"),
         conflict_rate=result.get("conflict_rate"),
+        sources=list(result.get("sources", [])),
+        message_id=payload.message_id,
     )

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -2,6 +2,7 @@
 
 import json
 import uuid
+from hashlib import sha256
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
@@ -45,6 +46,19 @@ def _sse_event(event: str, payload: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
+def _resolve_chat_user_id(request: Request) -> str:
+    state_username = getattr(request.state, "username", None)
+    if state_username:
+        return str(state_username)
+
+    api_key = request.headers.get("X-API-Key")
+    if api_key:
+        digest = sha256(api_key.encode("utf-8")).hexdigest()
+        return f"api-key:{digest}"
+
+    return "anonymous"
+
+
 @router.post(
     "/chat",
     response_model=ChatResponse,
@@ -78,10 +92,11 @@ async def chat(
         message=payload.message,
         session_id=session_id,
         role=payload.role,
-        user_id=str(getattr(request.state, "username", "anonymous")),
+        user_id=_resolve_chat_user_id(request),
     )
 
     if stream or "text/event-stream" in request.headers.get("Accept", ""):
+
         async def _stream():
             yield _sse_event("progress", {"stage": "retrieval", "progress": 35})
             for source in list(result.get("sources", [])):

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -28,6 +28,8 @@ from agents.verifier import VerifierAgent
 from api.metrics import PIPELINE_DURATION
 from core.errors import AppError, LLMProviderNotConfiguredError
 from core.llm_router import LLMRouter
+from core.pipelines.chat_rag import ChatRagPipeline
+from core.rag_engine import RAGEngine
 from core.session_memory import SessionMemory
 from core.tk_bridge import TKGeneratorBridge
 
@@ -62,6 +64,7 @@ class Orchestrator:
         self.llm_router = LLMRouter()
         self.session_memory = SessionMemory()
         self.tk_bridge = TKGeneratorBridge()
+        self.chat_rag = ChatRagPipeline(rag_engine=RAGEngine(), llm_router=self.llm_router)
         self.agents: dict[str, dict] = {agent["id"]: agent for agent in self.config["agents"]}
 
     def _load_config(self) -> dict:
@@ -334,6 +337,7 @@ class Orchestrator:
         message: str,
         session_id: str | None = None,
         role: str = "pto_engineer",
+        user_id: str = "anonymous",
         intent: str | None = None,
         include_legal_expert: bool = True,
         extra_state: dict[str, Any] | None = None,
@@ -377,21 +381,21 @@ class Orchestrator:
                 )
             return result
 
-        # TODO: Фаза 1 — базовый чат через LLM Router
-        # Пока без полноценного pipeline, просто прямой запрос к LLM
         system_prompt = self._build_system_prompt(role)
 
         try:
-            response = await self.llm_router.query(
-                prompt=message,
-                system_prompt=system_prompt,
+            rag_result = await self.chat_rag.run(
+                message=message,
+                user_id=user_id,
+                role_system_prompt=system_prompt,
             )
-            clean_reply = self._clean_reply(response.text)
+            clean_reply = self._clean_reply(str(rag_result.get("reply", "")))
             await self.session_memory.add(session_id, role="assistant", content=clean_reply)
             return {
                 "reply": clean_reply,
                 "session_id": session_id,
-                "agents_used": ["researcher"],  # базовый режим
+                "agents_used": list(rag_result.get("agents_used", [])),
+                "sources": list(rag_result.get("sources", [])),
                 "confidence": None,
             }
         except Exception as e:

--- a/core/pipelines/__init__.py
+++ b/core/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipelines package."""

--- a/core/pipelines/chat_rag.py
+++ b/core/pipelines/chat_rag.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Sequence, cast
 
 from core.rag_engine import RAGEngine
 
@@ -19,10 +19,11 @@ class ChatRagPipeline:
         where: dict[str, Any] | None,
     ) -> list[dict[str, Any]]:
         embedding = self.rag_engine._embed_texts([query])[0]
+        query_embeddings: list[Sequence[float]] = [cast(Sequence[float], embedding)]
         payload = cast(
             Any,
             self.rag_engine.collection.query(
-                query_embeddings=[embedding],
+                query_embeddings=query_embeddings,
                 n_results=n_results,
                 include=["documents", "metadatas", "distances"],
                 where=where,

--- a/core/pipelines/chat_rag.py
+++ b/core/pipelines/chat_rag.py
@@ -12,7 +12,12 @@ class ChatRagPipeline:
         self.rag_engine = rag_engine
         self.llm_router = llm_router
 
-    def _query(self, query: str, n_results: int, where: dict[str, Any] | None) -> list[dict[str, Any]]:
+    def _query(
+        self,
+        query: str,
+        n_results: int,
+        where: dict[str, Any] | None,
+    ) -> list[dict[str, Any]]:
         embedding = self.rag_engine._embed_texts([query])[0]
         payload = cast(
             Any,
@@ -42,7 +47,13 @@ class ChatRagPipeline:
         return rows
 
     def _has_personal_sources(self, user_id: str) -> bool:
-        payload = cast(Any, self.rag_engine.collection.get(where={"username": user_id}, include=["metadatas"]))
+        payload = cast(
+            Any,
+            self.rag_engine.collection.get(
+                where={"username": user_id},
+                include=["metadatas"],
+            ),
+        )
         metadatas = payload.get("metadatas") or []
         return bool(metadatas)
 
@@ -50,9 +61,11 @@ class ChatRagPipeline:
     def _context_block(chunks: list[dict[str, Any]]) -> str:
         lines: list[str] = []
         for idx, chunk in enumerate(chunks, start=1):
-            lines.append(
-                f"[S{idx}] {chunk['source']} (стр. {chunk['page']}, score={chunk['score']:.3f}):\n{chunk['text']}"
-            )
+            source = chunk["source"]
+            page = chunk["page"]
+            score = chunk["score"]
+            text = chunk["text"]
+            lines.append(f"[S{idx}] {source} (стр. {page}, score={score:.3f}):\n{text}")
         return "\n\n".join(lines)
 
     @staticmethod

--- a/core/pipelines/chat_rag.py
+++ b/core/pipelines/chat_rag.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from core.rag_engine import RAGEngine
+
+
+class ChatRagPipeline:
+    """Базовый RAG pipeline для chat intent."""
+
+    def __init__(self, rag_engine: RAGEngine, llm_router: Any):
+        self.rag_engine = rag_engine
+        self.llm_router = llm_router
+
+    def _query(self, query: str, n_results: int, where: dict[str, Any] | None) -> list[dict[str, Any]]:
+        embedding = self.rag_engine._embed_texts([query])[0]
+        payload = cast(
+            Any,
+            self.rag_engine.collection.query(
+                query_embeddings=[embedding],
+                n_results=n_results,
+                include=["documents", "metadatas", "distances"],
+                where=where,
+            ),
+        )
+        documents = cast(list[list[str]], payload.get("documents") or [[]])
+        metadatas = cast(list[list[dict[str, Any]]], payload.get("metadatas") or [[]])
+        distances = cast(list[list[float]], payload.get("distances") or [[]])
+
+        rows: list[dict[str, Any]] = []
+        for text, meta, distance in zip(documents[0], metadatas[0], distances[0], strict=False):
+            metadata = meta or {}
+            rows.append(
+                {
+                    "text": text,
+                    "source": str(metadata.get("source", "unknown")),
+                    "page": int(metadata.get("page", 0) or 0),
+                    "score": max(0.0, 1.0 - float(distance)),
+                    "username": str(metadata.get("username", "") or ""),
+                }
+            )
+        return rows
+
+    def _has_personal_sources(self, user_id: str) -> bool:
+        payload = cast(Any, self.rag_engine.collection.get(where={"username": user_id}, include=["metadatas"]))
+        metadatas = payload.get("metadatas") or []
+        return bool(metadatas)
+
+    @staticmethod
+    def _context_block(chunks: list[dict[str, Any]]) -> str:
+        lines: list[str] = []
+        for idx, chunk in enumerate(chunks, start=1):
+            lines.append(
+                f"[S{idx}] {chunk['source']} (стр. {chunk['page']}, score={chunk['score']:.3f}):\n{chunk['text']}"
+            )
+        return "\n\n".join(lines)
+
+    @staticmethod
+    def _to_sources(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "title": str(chunk.get("source", "unknown")),
+                "page": int(chunk.get("page", 0) or 0),
+                "score": round(float(chunk.get("score", 0.0)), 4),
+            }
+            for chunk in chunks
+        ]
+
+    async def run(
+        self,
+        *,
+        message: str,
+        user_id: str,
+        role_system_prompt: str,
+        top_k: int = 6,
+    ) -> dict[str, Any]:
+        steps = ["retriever"]
+        chunks: list[dict[str, Any]] = []
+
+        if self._has_personal_sources(user_id):
+            chunks = self._query(message, n_results=top_k, where={"username": user_id})
+
+        if not chunks:
+            # fallback на глобальную базу (документы без username)
+            global_candidates = self._query(message, n_results=top_k * 2, where=None)
+            chunks = [item for item in global_candidates if not item.get("username")][:top_k]
+
+        context_block = self._context_block(chunks[:top_k]) if chunks else ""
+        system_prompt = role_system_prompt
+        if context_block:
+            system_prompt = (
+                f"{role_system_prompt}\n\n"
+                "Используй только подтверждаемые фрагменты из базы знаний ниже. "
+                "Если ответа нет в источниках — так и скажи. Ссылайся в формате [S1], [S2].\n\n"
+                f"Контекст:\n{context_block}"
+            )
+
+        llm_response = await self.llm_router.query(prompt=message, system_prompt=system_prompt)
+        steps.append("responder")
+
+        return {
+            "reply": llm_response.text,
+            "agents_used": steps,
+            "sources": self._to_sources(chunks[:top_k]),
+        }

--- a/core/pipelines/chat_rag.py
+++ b/core/pipelines/chat_rag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence, cast
+from collections.abc import Sequence
+from typing import Any, cast
 
 from core.rag_engine import RAGEngine
 

--- a/core/pipelines/chat_rag.py
+++ b/core/pipelines/chat_rag.py
@@ -79,6 +79,18 @@ class ChatRagPipeline:
             for chunk in chunks
         ]
 
+    def _query_global(self, message: str, top_k: int) -> list[dict[str, Any]]:
+        """Find top_k global chunks even when personal docs dominate nearest neighbors."""
+        requested = max(top_k * 2, 12)
+        max_requested = 120
+
+        while True:
+            candidates = self._query(message, n_results=requested, where=None)
+            global_only = [item for item in candidates if not item.get("username")]
+            if len(global_only) >= top_k or requested >= max_requested:
+                return global_only[:top_k]
+            requested = min(max_requested, requested * 2)
+
     async def run(
         self,
         *,
@@ -95,8 +107,7 @@ class ChatRagPipeline:
 
         if not chunks:
             # fallback на глобальную базу (документы без username)
-            global_candidates = self._query(message, n_results=top_k * 2, where=None)
-            chunks = [item for item in global_candidates if not item.get("username")][:top_k]
+            chunks = self._query_global(message, top_k=top_k)
 
         context_block = self._context_block(chunks[:top_k]) if chunks else ""
         system_prompt = role_system_prompt

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,8 +15,12 @@
   "dependencies": {
     "@tauri-apps/api": "^2.0",
     "@tauri-apps/plugin-store": "^2.0.0",
+    "rehype-highlight": "^7.0.2",
+    "rehype-sanitize": "^6.0.0",
     "react": "^18",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -14,6 +14,13 @@ export interface ChatRequest {
   message: string;
   role: ChatRole;
   session_id: string;
+  message_id?: string;
+}
+
+export interface ChatSource {
+  title: string;
+  page: number;
+  score: number;
 }
 
 export interface ChatResponse {
@@ -22,11 +29,14 @@ export interface ChatResponse {
   agents_used?: string[];
   confidence?: number | null;
   conflict_rate?: number | null;
+  sources?: ChatSource[];
+  message_id?: string;
 }
 
 export interface ChatResponseMeta {
   agents?: string[];
   confidence?: number;
+  sources?: ChatSource[];
 }
 
 export interface TKRequest {
@@ -370,6 +380,73 @@ export async function sendChatMessage(
   });
 
   return (await response.json()) as ChatResponse;
+}
+
+export async function sendChatMessageStream(
+  apiUrl: string,
+  apiKey: string,
+  payload: ChatRequest,
+  onEvent: (event: import('./sseEvents').SSEEvent) => void,
+  { timeoutMs = DEFAULT_CHAT_TIMEOUT_MS, signal }: ApiCallOptions = {}
+): Promise<ChatResponse> {
+  const controller = new AbortController();
+  const timeoutId =
+    typeof timeoutMs === 'number' && timeoutMs > 0 ? window.setTimeout(() => controller.abort(), timeoutMs) : null;
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+  }
+
+  try {
+    const response = await fetch(`${normalizeApiUrl(apiUrl)}/api/chat?stream=true`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        'X-API-Key': apiKey.trim()
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`SSE HTTP error: ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      while (buffer.includes('\n\n')) {
+        const splitAt = buffer.indexOf('\n\n');
+        const rawEvent = buffer.slice(0, splitAt);
+        buffer = buffer.slice(splitAt + 2);
+
+        const parsedEvent = parseSSEEvent(rawEvent);
+        if (!parsedEvent) continue;
+        onEvent(parsedEvent);
+
+        if (parsedEvent.event === 'error') {
+          throw new SSEError(parsedEvent.code, parsedEvent.message, parsedEvent.details);
+        }
+        if (parsedEvent.event === 'done' && parsedEvent.result) {
+          return parsedEvent.result as unknown as ChatResponse;
+        }
+      }
+    }
+  } finally {
+    if (timeoutId !== null) window.clearTimeout(timeoutId);
+  }
+
+  throw new SSEError('internal', 'Поток чата завершился без результата');
 }
 
 export async function uploadChatDocument(

--- a/desktop/src/api/sseEvents.ts
+++ b/desktop/src/api/sseEvents.ts
@@ -1,6 +1,6 @@
 import type { GenerateDocumentResponse } from './coreClient';
 
-export type SSEEventName = 'progress' | 'chunk' | 'error' | 'done';
+export type SSEEventName = 'progress' | 'chunk' | 'error' | 'done' | 'source';
 
 export interface SSEEventBase {
   event: SSEEventName;
@@ -30,7 +30,16 @@ export interface SSEDoneEvent extends SSEEventBase {
   result?: GenerateDocumentResponse;
 }
 
-export type SSEEvent = SSEProgressEvent | SSEChunkEvent | SSEErrorEvent | SSEDoneEvent;
+export interface SSESourceEvent extends SSEEventBase {
+  event: 'source';
+  source?: {
+    title: string;
+    page: number;
+    score: number;
+  };
+}
+
+export type SSEEvent = SSEProgressEvent | SSEChunkEvent | SSEErrorEvent | SSEDoneEvent | SSESourceEvent;
 
 export function parseSSEEvent(raw: string): SSEEvent | null {
   const lines = raw
@@ -84,6 +93,25 @@ export function parseSSEEvent(raw: string): SSEEvent | null {
       stage: typeof payload.stage === 'string' ? payload.stage : undefined,
       message: typeof payload.message === 'string' ? payload.message : undefined
     };
+  }
+
+  if (eventName === 'source') {
+    const source = payload.source;
+    if (
+      source
+      && typeof source === 'object'
+      && typeof (source as Record<string, unknown>).title === 'string'
+    ) {
+      return {
+        event: 'source',
+        source: {
+          title: String((source as Record<string, unknown>).title),
+          page: Number((source as Record<string, unknown>).page ?? 0),
+          score: Number((source as Record<string, unknown>).score ?? 0)
+        }
+      };
+    }
+    return { event: 'source' };
   }
 
   return {

--- a/desktop/src/components/ChatWindow.tsx
+++ b/desktop/src/components/ChatWindow.tsx
@@ -3,7 +3,7 @@ import MessageBubble from './MessageBubble';
 import Input from './ui/Input';
 import Button from './ui/Button';
 import { useChatStore } from '../store/chatStore';
-import { sendChatMessage, uploadChatDocument } from '../api/coreClient';
+import { sendChatMessageStream, uploadChatDocument } from '../api/coreClient';
 import type { ChatResponseMeta } from '../api/coreClient';
 import { Store } from '@tauri-apps/plugin-store';
 import { colors, radius, spacing } from '../styles/tokens';
@@ -16,6 +16,7 @@ export default function ChatWindow() {
   const defaultRole = useChatStore((s) => s.defaultRole);
   const sessionId = useChatStore((s) => s.sessionId);
   const addMessage = useChatStore((s) => s.addMessage);
+  const upsertMessage = useChatStore((s) => s.upsertMessage);
   const isTyping = useChatStore((s) => s.isTyping);
   const setTyping = useChatStore((s) => s.setTyping);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -30,11 +31,12 @@ export default function ChatWindow() {
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
     const trimmed = text.trim();
-    if (!trimmed) return;
+    if (!trimmed || isTyping) return;
 
     setError(null);
+    const messageId = crypto.randomUUID();
     addMessage({
-      id: crypto.randomUUID(),
+      id: messageId,
       role: 'user',
       content: trimmed,
       createdAt: new Date().toISOString()
@@ -47,18 +49,22 @@ export default function ChatWindow() {
       const apiUrl = (await settings.get<string>('api_url')) || 'https://vanekpetrov1997.fvds.ru';
       const apiKey = (await settings.get<string>('api_key')) || '';
 
-      const response = await sendChatMessage(apiUrl, apiKey, {
+      const response = await sendChatMessageStream(apiUrl, apiKey, {
         message: trimmed,
         role: role || defaultRole,
-        session_id: sessionId
+        session_id: sessionId,
+        message_id: messageId
+      }, () => {
+        // source/progress события обрабатываются на сервере и попадают в итоговый done.result
       });
       const metadata: ChatResponseMeta = {
         agents: response.agents_used,
-        confidence: typeof response.confidence === 'number' ? response.confidence : undefined
+        confidence: typeof response.confidence === 'number' ? response.confidence : undefined,
+        sources: response.sources
       };
 
-      addMessage({
-        id: crypto.randomUUID(),
+      upsertMessage({
+        id: response.message_id ? `assistant:${response.message_id}` : `assistant:${messageId}`,
         role: 'assistant',
         content: response.reply,
         createdAt: new Date().toISOString(),

--- a/desktop/src/components/MessageBubble.tsx
+++ b/desktop/src/components/MessageBubble.tsx
@@ -1,9 +1,15 @@
 import type { ChatMessage } from '../store/chatStore';
+import ReactMarkdown from 'react-markdown';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeSanitize from 'rehype-sanitize';
+import remarkGfm from 'remark-gfm';
 import { colors, shadows, spacing } from '../styles/tokens';
+import MessageSources from './MessageSources';
 
 export interface MessageMetadata {
   agents?: string[];
   confidence?: number;
+  sources?: Array<{ title: string; page: number; score: number }>;
 }
 
 interface Props {
@@ -62,7 +68,18 @@ export default function MessageBubble({ message, metadata, className }: Props) {
         }}
       >
         <strong style={{ display: 'block', marginBottom: 4 }}>{isUser ? 'Вы' : isSystem ? 'Система' : 'Assistant'}</strong>
-        <span>{message.content}</span>
+        {isUser ? (
+          <span>{message.content}</span>
+        ) : (
+          <div style={{ lineHeight: 1.5, overflowX: 'auto' }}>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight, rehypeSanitize]}
+            >
+              {message.content}
+            </ReactMarkdown>
+          </div>
+        )}
         {!isUser && !isSystem && (
           <div style={{ marginTop: 8, display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}>
             {agents.map((agent) => (
@@ -105,6 +122,9 @@ export default function MessageBubble({ message, metadata, className }: Props) {
             </button>
           </div>
         )}
+        {!isUser && !isSystem && effectiveMetadata?.sources?.length ? (
+          <MessageSources sources={effectiveMetadata.sources} />
+        ) : null}
       </div>
       <div
         style={{

--- a/desktop/src/components/MessageSources.tsx
+++ b/desktop/src/components/MessageSources.tsx
@@ -1,0 +1,22 @@
+import type { ChatSource } from '../api/coreClient';
+
+interface Props {
+  sources: ChatSource[];
+}
+
+export default function MessageSources({ sources }: Props) {
+  if (!sources.length) return null;
+
+  return (
+    <div style={{ marginTop: 10, borderTop: '1px dashed #d1d5db', paddingTop: 8 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: '#4b5563', marginBottom: 6 }}>Источники</div>
+      <ul style={{ margin: 0, paddingInlineStart: 16, display: 'grid', gap: 4 }}>
+        {sources.slice(0, 3).map((source, index) => (
+          <li key={`${source.title}-${source.page}-${index}`} style={{ fontSize: 12, color: '#374151' }}>
+            {source.title} · стр. {source.page || '—'} · релевантность {(source.score * 100).toFixed(0)}%
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/desktop/src/store/chatStore.ts
+++ b/desktop/src/store/chatStore.ts
@@ -29,6 +29,7 @@ interface ChatState {
   setRole: (role: ChatRole) => void;
   setDefaultRole: (role: ChatRole) => void;
   addMessage: (message: ChatMessage) => void;
+  upsertMessage: (message: ChatMessage) => void;
   setTyping: (isTyping: boolean) => void;
   resetSession: () => void;
 }
@@ -44,7 +45,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isTyping: false,
   setRole: (role) => set({ role }),
   setDefaultRole: (role) => set({ defaultRole: role, role }),
-  addMessage: (message) => set({ messages: [...get().messages, message] }),
+  addMessage: (message) =>
+    set((state) => {
+      if (state.messages.some((item) => item.id === message.id)) {
+        return state;
+      }
+      return { messages: [...state.messages, message] };
+    }),
+  upsertMessage: (message) =>
+    set((state) => {
+      const index = state.messages.findIndex((item) => item.id === message.id);
+      if (index === -1) {
+        return { messages: [...state.messages, message] };
+      }
+      const messages = [...state.messages];
+      messages[index] = message;
+      return { messages };
+    }),
   setTyping: (isTyping) => set({ isTyping }),
   resetSession: () => {
     const prev = get();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## ChatRagPipeline (v4.2)
+
+```mermaid
+flowchart TD
+  A[POST /api/chat] --> B[Orchestrator.process intent=chat]
+  B --> C{Есть my-sources?}
+  C -->|Да| D[Retriever: personal chunks top_k=6]
+  C -->|Нет| E[Retriever: global chunks top_k=6]
+  D --> F[Build system prompt with citations S1..S6]
+  E --> F
+  F --> G[LLM Router]
+  G --> H[Response: reply + agents_used + sources]
+  H --> I[SSE events: progress, source, done]
+```
+
+### Steps
+1. Определение источника retrieval: персональная база пользователя (`username`) или fallback на глобальные документы.
+2. Формирование контекста с цитируемыми фрагментами (`[S1]`, `[S2]`...).
+3. Генерация ответа через LLM Router с ограничением: опираться на контекст.
+4. Возврат `sources: [{title, page, score}]` и `agents_used: ["retriever", "responder"]`.

--- a/tests/test_chat_rag.py
+++ b/tests/test_chat_rag.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from core.pipelines.chat_rag import ChatRagPipeline
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.user_docs = [
+            {
+                "text": "СП 48.13330 устанавливает требования к организации строительства.",
+                "source": "sp_48.pdf",
+                "page": 2,
+                "username": "user-1",
+            }
+        ]
+        self.global_docs = [
+            {
+                "text": "ГОСТ Р 21.1101 описывает требования к проектной документации.",
+                "source": "gost_21.pdf",
+                "page": 7,
+                "username": "",
+            }
+        ]
+
+    def get(self, where=None, include=None):
+        _ = include
+        if where == {"username": "user-1"}:
+            return {"metadatas": [{"username": "user-1"}]}
+        return {"metadatas": []}
+
+    def query(self, query_embeddings=None, n_results=6, include=None, where=None):
+        _ = query_embeddings, include
+        rows = self.user_docs if where == {"username": "user-1"} else self.global_docs
+        rows = rows[:n_results]
+        return {
+            "documents": [[row["text"] for row in rows]],
+            "metadatas": [[{"source": row["source"], "page": row["page"], "username": row["username"]} for row in rows]],
+            "distances": [[0.1 for _ in rows]],
+        }
+
+
+class _FakeRagEngine:
+    def __init__(self):
+        self.collection = _FakeCollection()
+
+    def _embed_texts(self, texts):
+        _ = texts
+        return [[0.01, 0.02, 0.03]]
+
+
+def test_chat_rag_prefers_personal_sources():
+    llm_router = SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text="Ответ [S1]")))
+    pipeline = ChatRagPipeline(rag_engine=_FakeRagEngine(), llm_router=llm_router)
+
+    result = asyncio.run(
+        pipeline.run(
+            message="Что такое СП 48.13330?",
+            user_id="user-1",
+            role_system_prompt="role prompt",
+            top_k=6,
+        )
+    )
+
+    assert result["agents_used"] == ["retriever", "responder"]
+    assert result["sources"]
+    assert result["sources"][0]["title"] == "sp_48.pdf"
+
+
+def test_chat_rag_falls_back_to_global_when_personal_empty():
+    llm_router = SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text="Ответ [S1]")))
+    pipeline = ChatRagPipeline(rag_engine=_FakeRagEngine(), llm_router=llm_router)
+
+    result = asyncio.run(
+        pipeline.run(
+            message="Что такое ГОСТ?",
+            user_id="unknown-user",
+            role_system_prompt="role prompt",
+            top_k=6,
+        )
+    )
+
+    assert result["sources"][0]["title"] == "gost_21.pdf"

--- a/tests/test_chat_rag.py
+++ b/tests/test_chat_rag.py
@@ -36,9 +36,17 @@ class _FakeCollection:
         _ = query_embeddings, include
         rows = self.user_docs if where == {"username": "user-1"} else self.global_docs
         rows = rows[:n_results]
+        metadatas = [
+            {
+                "source": row["source"],
+                "page": row["page"],
+                "username": row["username"],
+            }
+            for row in rows
+        ]
         return {
             "documents": [[row["text"] for row in rows]],
-            "metadatas": [[{"source": row["source"], "page": row["page"], "username": row["username"]} for row in rows]],
+            "metadatas": [metadatas],
             "distances": [[0.1 for _ in rows]],
         }
 

--- a/tests/test_chat_rag.py
+++ b/tests/test_chat_rag.py
@@ -60,6 +60,51 @@ class _FakeRagEngine:
         return [[0.01, 0.02, 0.03]]
 
 
+class _CrowdedGlobalCollection(_FakeCollection):
+    def __init__(self):
+        super().__init__()
+        self.global_docs = [
+            {
+                "text": f"GLOBAL-{idx}",
+                "source": f"global-{idx}.pdf",
+                "page": idx,
+                "username": "",
+            }
+            for idx in range(1, 8)
+        ]
+
+    def query(self, query_embeddings=None, n_results=6, include=None, where=None):
+        _ = query_embeddings, include, where
+        crowded = [
+            {
+                "text": f"PERSONAL-{idx}",
+                "source": f"personal-{idx}.pdf",
+                "page": idx,
+                "username": f"user-{idx}",
+            }
+            for idx in range(1, 32)
+        ]
+        rows = (crowded + self.global_docs)[:n_results]
+        metadatas = [
+            {
+                "source": row["source"],
+                "page": row["page"],
+                "username": row["username"],
+            }
+            for row in rows
+        ]
+        return {
+            "documents": [[row["text"] for row in rows]],
+            "metadatas": [metadatas],
+            "distances": [[0.1 for _ in rows]],
+        }
+
+
+class _CrowdedGlobalRagEngine(_FakeRagEngine):
+    def __init__(self):
+        self.collection = _CrowdedGlobalCollection()
+
+
 def test_chat_rag_prefers_personal_sources():
     llm_router = SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text="Ответ [S1]")))
     pipeline = ChatRagPipeline(rag_engine=_FakeRagEngine(), llm_router=llm_router)
@@ -92,3 +137,20 @@ def test_chat_rag_falls_back_to_global_when_personal_empty():
     )
 
     assert result["sources"][0]["title"] == "gost_21.pdf"
+
+
+def test_chat_rag_global_fallback_expands_window_if_personal_docs_dominate():
+    llm_router = SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text="Ответ [S1]")))
+    pipeline = ChatRagPipeline(rag_engine=_CrowdedGlobalRagEngine(), llm_router=llm_router)
+
+    result = asyncio.run(
+        pipeline.run(
+            message="Что такое СП?",
+            user_id="unknown-user",
+            role_system_prompt="role prompt",
+            top_k=6,
+        )
+    )
+
+    assert len(result["sources"]) == 6
+    assert all(item["title"].startswith("global-") for item in result["sources"])

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -36,9 +36,10 @@ def test_request_with_valid_api_key_returns_200(monkeypatch: pytest.MonkeyPatch)
     async def _run() -> None:
         old_keys = settings.api_keys
         settings.api_keys = ["valid-key"]
+        captured_user_id: dict[str, str] = {}
 
         async def _fake_process(message: str, session_id: str, role: str, user_id: str = "u"):
-            _ = user_id
+            captured_user_id["value"] = user_id
             return {
                 "reply": f"echo: {message}",
                 "session_id": session_id,
@@ -63,6 +64,8 @@ def test_request_with_valid_api_key_returns_200(monkeypatch: pytest.MonkeyPatch)
         data = response.json()
         assert data["reply"] == "echo: ping"
         assert data["agents_used"] == ["mock"]
+        assert captured_user_id["value"].startswith("api-key:")
+        assert captured_user_id["value"] != "anonymous"
 
     asyncio.run(_run())
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -37,7 +37,8 @@ def test_request_with_valid_api_key_returns_200(monkeypatch: pytest.MonkeyPatch)
         old_keys = settings.api_keys
         settings.api_keys = ["valid-key"]
 
-        async def _fake_process(message: str, session_id: str, role: str):
+        async def _fake_process(message: str, session_id: str, role: str, user_id: str = "u"):
+            _ = user_id
             return {
                 "reply": f"echo: {message}",
                 "session_id": session_id,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -85,3 +85,29 @@ def test_run_pipeline_generate_tk_fallback_without_bridge():
 
     assert result["reply"] == "ai-only"
     assert "tk_bridge_result" not in result
+
+
+def test_chat_intent_uses_chat_rag_pipeline():
+    orchestrator = Orchestrator()
+    orchestrator.session_memory.add = AsyncMock()
+    orchestrator.chat_rag.run = AsyncMock(
+        return_value={
+            "reply": "RAG answer",
+            "agents_used": ["retriever", "responder"],
+            "sources": [{"title": "sp_48.pdf", "page": 2, "score": 0.95}],
+        }
+    )
+
+    result = asyncio.run(
+        orchestrator.process(
+            message="что такое сп 48?",
+            session_id="s-chat",
+            role="pto_engineer",
+            intent="chat",
+            user_id="user-1",
+        )
+    )
+
+    assert result["reply"] == "RAG answer"
+    assert result["agents_used"] == ["retriever", "responder"]
+    assert result["sources"][0]["title"] == "sp_48.pdf"


### PR DESCRIPTION
### Motivation

- Improve chat UX by rendering Markdown (tables, lists, fenced code) inside assistant bubbles and showing retrieval citations under answers. 
- Replace the previous hardcoded “researcher” chat mode with a real RAG pipeline that retrieves from a user's personal KB (fallback to global) and returns cited fragments and source metadata. 
- Make SSE include `source` events so the UI can surface sources incrementally and avoid duplicate messages on fast double-submits. 

### Description

- UI: added `react-markdown`, `remark-gfm`, `rehype-highlight` and `rehype-sanitize` (dependencies in `desktop/package.json`) and switched `desktop/src/components/MessageBubble.tsx` to render assistant content with `ReactMarkdown` while keeping user messages plain text. 
- UI: introduced `desktop/src/components/MessageSources.tsx` to render top citations and wired `MessageBubble` to show `metadata.sources`. 
- Client SSE: added streaming client `sendChatMessageStream` in `desktop/src/api/coreClient.ts`, extended SSE types/parser (`desktop/src/api/sseEvents.ts`) to support `event: source`, and propagated `sources` / `message_id` through the client types. 
- Store/UX: made chat store idempotent by deduplicating `addMessage` and adding `upsertMessage` in `desktop/src/store/chatStore.ts`, and guarded duplicate submits in `ChatWindow` using a stable `message_id`. 
- Backend pipeline: implemented `core/pipelines/chat_rag.py` implementing personal-source first retrieval (by `username`) and fallback to global collection, context/prompt assembly with cited fragments, and returning `sources` and step list `['retriever','responder']`. 
- Integration: instantiated `ChatRagPipeline` in `core/orchestrator.py` and replaced the hardcoded `agents_used=[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bf36416c832fa67bec4536f2900c)