### PR TITLE
Add Alembic configuration and CI schema drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,40 @@ jobs:
       - run: uv run --no-project ruff format --check .
       - run: uv run --no-project mypy core/ agents/ api/ --ignore-missing-imports
 
+  alembic:
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 15
+    env:
+      DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:5432/construction_ai_ci
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: construction_ai_ci
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d construction_ai_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync --extra dev --no-install-project
+      - name: Apply all migrations
+        run: uv run --no-project alembic upgrade head
+      - name: Verify migration drift
+        run: |
+          if uv run --no-project alembic --help | grep -q "check"; then
+            uv run --no-project alembic check
+          else
+            uv run --no-project python scripts/alembic_schema_check.py
+          fi
+
   test:
     runs-on: ubuntu-latest
     needs: lint

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+# This value is overridden in migrations/env.py from DATABASE_URL.
+sqlalchemy.url = sqlite:///./data/construction_ai.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,89 @@
+"""Alembic environment for Construction AI Core migrations."""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+import os
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from core.projects import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Track SQLAlchemy models from the project.
+target_metadata = Base.metadata
+
+
+def _get_database_url() -> str:
+    return os.getenv("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
+
+
+def _include_object(object_, name, type_, reflected, compare_to):
+    """Compare only tables represented in SQLAlchemy metadata.
+
+    The project still has legacy/raw-SQL tables not tracked by ORM models; those
+    should not trigger Alembic drift failures.
+    """
+    if type_ == "table":
+        return name in target_metadata.tables
+
+    if type_ in {"column", "index", "unique_constraint", "foreign_key_constraint"}:
+        table_name = None
+        if getattr(object_, "table", None) is not None:
+            table_name = object_.table.name
+        elif getattr(compare_to, "table", None) is not None:
+            table_name = compare_to.table.name
+        return table_name in target_metadata.tables
+
+    return True
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    context.configure(
+        url=_get_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
+        include_object=_include_object,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    section = config.get_section(config.config_ini_section, {})
+    section["sqlalchemy.url"] = _get_database_url()
+
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+            include_object=_include_object,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: str | Sequence[str] | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dev = [
     "pytest-timeout>=2.3.1",
     "ruff>=0.6.0",
     "mypy>=1.11.0",
+    "alembic>=1.13.0",
+    "psycopg[binary]>=3.2.0",
 ]
 
 [build-system]

--- a/scripts/alembic_schema_check.py
+++ b/scripts/alembic_schema_check.py
@@ -1,0 +1,37 @@
+"""Fail if SQLAlchemy models diverge from Alembic-managed schema."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import create_engine
+
+from core.projects import Base
+
+
+def main() -> int:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL is required for Alembic schema check.", file=sys.stderr)
+        return 2
+
+    engine = create_engine(database_url)
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        diffs = compare_metadata(context, Base.metadata)
+
+    if diffs:
+        print("Detected schema drift between models and migrations:", file=sys.stderr)
+        for diff in diffs:
+            print(f" - {diff!r}", file=sys.stderr)
+        return 1
+
+    print("No schema drift detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Restore project Alembic configuration so migrations can be managed and checked in CI.
- Ensure `target_metadata` references the project's SQLAlchemy models so Alembic autogenerate can compare ORM state to migrations.
- Add a CI gate that fails PRs when models diverge from Alembic-managed schema, making schema drift a blocking check.
- Skills: none used.

### Description
- Add `alembic.ini` with `script_location = migrations` and a default SQLAlchemy URL fallback for local runs.
- Add `migrations/env.py` wired to `core.projects.Base.metadata` and implement `include_object` to limit autogenerate comparisons to ORM-managed tables, plus add `migrations/script.py.mako` template for generated revisions.
- Add `scripts/alembic_schema_check.py` which uses `alembic.autogenerate.compare_metadata` as a fallback drift check, and add dev dependencies `alembic` and `psycopg[binary]` to `pyproject.toml`.
- Update `.github/workflows/ci.yml` with a new `alembic` job that spins up a PostgreSQL service, runs `alembic upgrade head`, then runs `alembic check` if available or the fallback script, causing CI to fail on detected drift.

### Testing
- Successfully compiled `migrations/env.py` and `scripts/alembic_schema_check.py` with `python -m compileall` which completed without errors.
- Attempted to run `uv sync --extra dev --no-install-project` to validate dependency installation but it failed due to network/tunnel errors when downloading packages from PyPI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e3d36688832fadad15d0167e8d73)