### PR TITLE
fix(tauri): use core:path:default permission identifier

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -10,7 +10,7 @@
     "store:default",
     "shell:allow-open",
     "fs:allow-read-dir",
-    "path:default",
+    "core:path:default",
     "dialog:allow-message",
     "dialog:allow-ask",
     "allow-get-api-url",


### PR DESCRIPTION
## Проблема

После merge #119 desktop-build падает на всех платформах (macOS/Ubuntu/Windows) во время cargo build:

```
Permission path:default not found, expected one of
  allow-copy-last-log-lines, ..., core:default, core:path:default, ...
```

В Tauri 2 встроенный permission для path-плагина называется `core:path:default`, а не `path:default`. Это ошибка в исходном промте (#109), Codex скопировал дословно.

## Фикс

Одна строка в `desktop/src-tauri/capabilities/default.json`:

```diff
-    "path:default",
+    "core:path:default",
```

## Проверка

После merge проверим, что джобы `build (macos-latest)`, `build (ubuntu-latest)`, `build (windows-latest)` в `desktop-build.yml` стали зелёными.

Closes #109