### PR TITLE
Unify profile API contract around canonical GET /api/me

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from fastapi import Header, HTTPException, Request
 
-from api.routes.auth import decode_jwt_token
+from api.security import JWTError, decode_jwt
 from config.settings import settings
 
 
@@ -46,6 +46,20 @@ def _lookup_api_key_user(api_key: str) -> str | None:
     return str(row[0])
 
 
+def _decode_jwt_token(token: str) -> dict[str, str]:
+    try:
+        payload = decode_jwt(token, settings.jwt_secret, algorithms=["HS256"])
+    except JWTError as exc:
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+    username = payload.get("sub")
+    role = payload.get("role")
+    org_id = payload.get("org_id")
+    if not username or not role:
+        raise HTTPException(status_code=401, detail="Invalid token payload")
+    return {"username": str(username), "role": str(role), "org_id": str(org_id or "default")}
+
+
 async def current_user(
     request: Request,
     authorization: str | None = Header(default=None),
@@ -53,12 +67,21 @@ async def current_user(
 ) -> CurrentUser:
     """Resolve authenticated user from JWT first, then API key mapping."""
     if authorization and authorization.startswith("Bearer "):
-        payload = decode_jwt_token(authorization.removeprefix("Bearer ").strip())
+        payload = _decode_jwt_token(authorization.removeprefix("Bearer ").strip())
         return CurrentUser(
             username=payload["username"],
             role=payload["role"],
             org_id=payload.get("org_id", "default"),
         )
+
+    if x_api_key:
+        if x_api_key not in settings.api_keys:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        username = _lookup_api_key_user(x_api_key)
+        role = "admin" if x_api_key in settings.admin_api_keys else "pto_engineer"
+        if username:
+            return CurrentUser(username=username, role=role, org_id="default")
+        return CurrentUser(username=f"api_key:{x_api_key[-6:]}", role=role, org_id="default")
 
     state_username = getattr(request.state, "username", None)
     state_role = getattr(request.state, "user_role", None)
@@ -69,12 +92,4 @@ async def current_user(
             org_id=str(getattr(request.state, "org_id", "default") or "default"),
         )
 
-    if not x_api_key or x_api_key not in settings.api_keys:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
-    username = _lookup_api_key_user(x_api_key)
-    if not username:
-        raise HTTPException(status_code=401, detail="Authentication required")
-
-    role = "admin" if x_api_key in settings.admin_api_keys else "pto_engineer"
-    return CurrentUser(username=username, role=role, org_id="default")
+    raise HTTPException(status_code=401, detail="Authentication required")

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -11,7 +11,7 @@ from hashlib import sha256
 from typing import Any, cast
 
 import structlog
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 from fastapi.routing import APIRoute
 from slowapi import Limiter
@@ -74,7 +74,10 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header.removeprefix("Bearer ").strip()
-            payload = decode_jwt_token(token)
+            try:
+                payload = decode_jwt_token(token)
+            except HTTPException as exc:
+                return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
             request.state.username = payload["username"]
             request.state.user_role = payload["role"]
             request.state.org_id = payload.get("org_id", "default")

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -6,8 +6,9 @@ import datetime as dt
 import sqlite3
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 
+from api.deps import CurrentUser, current_user
 from api.models import TokenResponse, UserCreate, UserLogin
 from api.security import JWTError, decode_jwt, encode_jwt, hash_password, verify_password
 from config.settings import settings
@@ -129,41 +130,37 @@ async def api_login_user(payload: UserLogin) -> TokenResponse:
     return await _login_impl(payload)
 
 
-def _build_me_response(request: Request) -> dict[str, str | bool]:
-    """Return current user profile based on middleware-populated JWT context."""
-    username = getattr(request.state, "username", None)
-    user_role = getattr(request.state, "user_role", None)
-    if username is None or user_role is None:
-        raise HTTPException(status_code=401, detail="Authentication required")
+def _build_me_response(user: CurrentUser) -> dict[str, str | bool]:
+    """Return current user profile in stable API contract format."""
+    username = str(user.username)
+    role = str(user.role)
+    org_id = str(user.org_id or "default")
 
-    user = _get_user(username)
-    if user is None:
-        role = str(user_role)
-        return {
-            "username": username,
-            "role": role,
-            "org_id": "default",
-            "is_admin": role == "admin",
-        }
+    user_row = _get_user(username)
+    if user_row is not None:
+        _username, _password_hash, db_role, db_org_id, _created_at = user_row
+        role = db_role
+        org_id = db_org_id or "default"
 
-    _username, _password_hash, role, org_id, _created_at = user
     return {"username": username, "role": role, "org_id": org_id, "is_admin": role == "admin"}
 
 
-@router.get("/me")
-async def me(request: Request) -> dict[str, str | bool]:
-    return _build_me_response(request)
+@legacy_router.get("/api/me")
+async def api_me(user: CurrentUser = Depends(current_user)) -> dict[str, str | bool]:
+    """Canonical profile endpoint with JWT + X-API-Key authentication support."""
+    return _build_me_response(user)
+
+
+@router.get("/me", include_in_schema=False)
+async def me_alias_auth(user: CurrentUser = Depends(current_user)) -> dict[str, str | bool]:
+    """Backward-compatible alias for GET /auth/me."""
+    return _build_me_response(user)
 
 
 @api_router.get("/me", include_in_schema=False)
-async def api_auth_me(request: Request) -> dict[str, str | bool]:
-    return _build_me_response(request)
-
-
-@legacy_router.get("/api/me", include_in_schema=False)
-async def api_me_legacy(request: Request) -> dict[str, str | bool]:
-    """Backward-compatible alias for desktop clients using GET /api/me."""
-    return _build_me_response(request)
+async def me_alias_api_auth(user: CurrentUser = Depends(current_user)) -> dict[str, str | bool]:
+    """Backward-compatible alias for GET /api/auth/me."""
+    return _build_me_response(user)
 
 
 def decode_jwt_token(token: str) -> dict[str, str]:

--- a/desktop/src/api/coreClient.ts
+++ b/desktop/src/api/coreClient.ts
@@ -184,6 +184,7 @@ export interface RagSourceItem {
 export interface MeResponse {
   username: string;
   role: string;
+  org_id: string;
   is_admin: boolean;
 }
 

--- a/telegram/handlers/__init__.py
+++ b/telegram/handlers/__init__.py
@@ -60,6 +60,7 @@ ROLE_NAMES = {
 
 _PERIOD_RE = re.compile(r"^\d{2}\.\d{2}\.\d{4}\s*-\s*\d{2}\.\d{2}\.\d{4}$")
 _API_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]{16,64}$")
+PROFILE_ENDPOINT = "/api/me"
 
 
 def _get_api_key() -> str:
@@ -244,7 +245,7 @@ async def link_handler(message: Message) -> None:
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
             response = await client.get(
-                f"{settings.core_api_url.rstrip('/')}/api/me",
+                f"{settings.core_api_url.rstrip('/')}{PROFILE_ENDPOINT}",
                 headers={"X-API-Key": api_key},
             )
     except httpx.HTTPError:
@@ -279,7 +280,7 @@ async def whoami_handler(message: Message) -> None:
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
             response = await client.get(
-                f"{settings.core_api_url.rstrip('/')}/api/me",
+                f"{settings.core_api_url.rstrip('/')}{PROFILE_ENDPOINT}",
                 headers={"X-API-Key": api_key},
             )
             response.raise_for_status()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
-"""Tests for JWT auth routes."""
+"""Tests for auth routes and canonical profile endpoint contract."""
 
 import asyncio
+import sqlite3
 from pathlib import Path
 
 from httpx import ASGITransport, AsyncClient
@@ -9,28 +10,56 @@ from api.main import app
 from config.settings import settings
 
 
+def _register_user(client: AsyncClient, username: str, invite_code: str, password: str):
+    return client.post(
+        "/auth/register",
+        json={
+            "username": username,
+            "password": password,
+            "invite_code": invite_code,
+        },
+    )
+
+
+def _configure_auth_test_state(tmp_path: Path) -> dict[str, object]:
+    return {
+        "users_db_path": settings.users_db_path,
+        "invite_codes": settings.invite_codes,
+        "jwt_secret": settings.jwt_secret,
+        "api_keys": settings.api_keys,
+        "admin_api_keys": settings.admin_api_keys,
+        "new_users_db_path": str(tmp_path / "users.db"),
+    }
+
+
+def _apply_auth_test_state(state: dict[str, object]) -> None:
+    settings.users_db_path = str(state["new_users_db_path"])
+    settings.invite_codes = {"PTO-XXX": "pto_engineer", "ADMIN-XXX": "admin"}
+    settings.jwt_secret = "test-secret"
+    settings.api_keys = ["test-api-key-123456"]
+    settings.admin_api_keys = ["test-api-key-123456"]
+
+
+def _restore_auth_test_state(state: dict[str, object]) -> None:
+    settings.users_db_path = str(state["users_db_path"])
+    settings.invite_codes = state["invite_codes"]  # type: ignore[assignment]
+    settings.jwt_secret = str(state["jwt_secret"])
+    settings.api_keys = state["api_keys"]  # type: ignore[assignment]
+    settings.admin_api_keys = state["admin_api_keys"]  # type: ignore[assignment]
+
+
 def test_register_with_valid_invite_code(tmp_path: Path):
     """Register endpoint should create user with mapped role."""
 
     async def _run() -> None:
-        old_users_db_path = settings.users_db_path
-        old_invite_codes = settings.invite_codes
-        settings.users_db_path = str(tmp_path / "users.db")
-        settings.invite_codes = {"PTO-XXX": "pto_engineer"}
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
         try:
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                response = await client.post(
-                    "/auth/register",
-                    json={
-                        "username": "ivan",
-                        "password": "pass123",
-                        "invite_code": "PTO-XXX",
-                    },
-                )
+                response = await _register_user(client, "ivan", "PTO-XXX", "pass123")
         finally:
-            settings.users_db_path = old_users_db_path
-            settings.invite_codes = old_invite_codes
+            _restore_auth_test_state(state)
 
         assert response.status_code == 200
         assert response.json() == {
@@ -46,32 +75,19 @@ def test_login_returns_jwt(tmp_path: Path):
     """Login should return bearer token and role."""
 
     async def _run() -> None:
-        old_users_db_path = settings.users_db_path
-        old_invite_codes = settings.invite_codes
-        old_jwt_secret = settings.jwt_secret
-        settings.users_db_path = str(tmp_path / "users.db")
-        settings.invite_codes = {"ADMIN-XXX": "admin"}
-        settings.jwt_secret = "test-secret"
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
         try:
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                register_response = await client.post(
-                    "/auth/register",
-                    json={
-                        "username": "admin",
-                        "password": "pass123",
-                        "invite_code": "ADMIN-XXX",
-                    },
-                )
+                register_response = await _register_user(client, "admin", "ADMIN-XXX", "pass123")
                 assert register_response.status_code == 200
                 login_response = await client.post(
                     "/auth/login",
                     json={"username": "admin", "password": "pass123"},
                 )
         finally:
-            settings.users_db_path = old_users_db_path
-            settings.invite_codes = old_invite_codes
-            settings.jwt_secret = old_jwt_secret
+            _restore_auth_test_state(state)
 
         assert login_response.status_code == 200
         payload = login_response.json()
@@ -83,60 +99,110 @@ def test_login_returns_jwt(tmp_path: Path):
     asyncio.run(_run())
 
 
-def test_me_requires_auth():
-    """Me endpoint should require auth token."""
+def test_canonical_me_requires_token(tmp_path: Path):
+    """GET /api/me should return 401 without any auth credentials."""
 
     async def _run() -> None:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            response = await client.get("/auth/me")
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/me")
+        finally:
+            _restore_auth_test_state(state)
         assert response.status_code == 401
-        assert response.json() == {"detail": "Invalid API key"}
 
     asyncio.run(_run())
 
 
-def test_api_me_returns_profile(tmp_path: Path):
-    """GET /api/me should return username, role and is_admin."""
+def test_canonical_me_rejects_invalid_jwt(tmp_path: Path):
+    """GET /api/me should return 401 for invalid JWT in Authorization header."""
 
     async def _run() -> None:
-        old_users_db_path = settings.users_db_path
-        old_invite_codes = settings.invite_codes
-        old_jwt_secret = settings.jwt_secret
-        settings.users_db_path = str(tmp_path / "users.db")
-        settings.invite_codes = {"PTO-XXX": "pto_engineer"}
-        settings.jwt_secret = "test-secret"
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
         try:
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                register_response = await client.post(
-                    "/auth/register",
-                    json={
-                        "username": "ivan",
-                        "password": "pass123",
-                        "invite_code": "PTO-XXX",
-                    },
-                )
+                response = await client.get("/api/me", headers={"Authorization": "Bearer invalid.jwt"})
+        finally:
+            _restore_auth_test_state(state)
+        assert response.status_code == 401
+        assert response.json() == {"detail": "Invalid token"}
+
+    asyncio.run(_run())
+
+
+def test_canonical_me_returns_profile_for_valid_jwt(tmp_path: Path):
+    """GET /api/me should return stable profile contract for valid JWT."""
+
+    async def _run() -> None:
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                register_response = await _register_user(client, "ivan", "PTO-XXX", "pass123")
                 assert register_response.status_code == 200
                 login_response = await client.post(
                     "/auth/login",
                     json={"username": "ivan", "password": "pass123"},
                 )
                 token = login_response.json()["access_token"]
-                me_response = await client.get(
-                    "/api/me", headers={"Authorization": f"Bearer {token}"}
-                )
+                response = await client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
         finally:
-            settings.users_db_path = old_users_db_path
-            settings.invite_codes = old_invite_codes
-            settings.jwt_secret = old_jwt_secret
+            _restore_auth_test_state(state)
 
-        assert me_response.status_code == 200
-        assert me_response.json() == {
+        assert response.status_code == 200
+        assert response.json() == {
             "username": "ivan",
             "role": "pto_engineer",
             "org_id": "default",
             "is_admin": False,
+        }
+
+    asyncio.run(_run())
+
+
+def test_canonical_me_returns_profile_for_valid_api_key(tmp_path: Path):
+    """GET /api/me should return stable profile contract for valid X-API-Key."""
+
+    async def _run() -> None:
+        state = _configure_auth_test_state(tmp_path)
+        _apply_auth_test_state(state)
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                register_response = await _register_user(client, "operator", "ADMIN-XXX", "pass123")
+                assert register_response.status_code == 200
+                with sqlite3.connect(settings.users_db_path) as connection:
+                    connection.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS api_keys (
+                            api_key TEXT PRIMARY KEY,
+                            user_id TEXT NOT NULL
+                        )
+                        """
+                    )
+                    connection.execute(
+                        "INSERT INTO api_keys (api_key, user_id) VALUES (?, ?)",
+                        ("test-api-key-123456", "operator"),
+                    )
+                    connection.commit()
+                response = await client.get(
+                    "/api/me",
+                    headers={"X-API-Key": "test-api-key-123456"},
+                )
+        finally:
+            _restore_auth_test_state(state)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "username": "operator",
+            "role": "admin",
+            "org_id": "default",
+            "is_admin": True,
         }
 
     asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Eliminate inconsistent use of profile endpoints and make the user profile API contract explicit and stable for desktop, telegram and backend code. 
- Support both authentication modes (`Authorization: Bearer <jwt>` and `X-API-Key`) deliberately and compatibly rather than relying on implicit, scattered behavior. 
- Provide a single, well-documented contract for clients and tests: `{ username, role, org_id, is_admin }`.

### Description
- Introduced a canonical profile endpoint `GET /api/me` (implemented in `api/routes/auth.py`) and added explicit backward-compatible aliases for `GET /auth/me` and `GET /api/auth/me` that depend on the same auth path. (api/routes/auth.py)
- Centralized authentication resolution in dependency `current_user` and added robust JWT decoding there while preserving API-key support and a safe fallback for API-key-only requests. (api/deps.py)
- Hardened middleware JWT handling so invalid JWTs return a JSON `401` response instead of surfacing uncaught middleware exceptions; middleware still populates `request.state` for other flows. (api/middleware.py)
- Updated desktop client typing for the Me contract to include `org_id` so UI code and the API contract are consistent. (desktop/src/api/coreClient.ts)
- Centralized the profile endpoint string in telegram handlers and switched `/link` and `/whoami` to use the canonical `PROFILE_ENDPOINT` to avoid string divergence. (telegram/handlers/__init__.py)
- Reworked and extended `tests/test_auth.py` to exercise canonical `/api/me` for negative and positive cases: no credentials, invalid JWT, valid JWT, and valid `X-API-Key`, and to assert the stable response shape. (tests/test_auth.py)

Modified files: `api/routes/auth.py`, `api/deps.py`, `api/middleware.py`, `desktop/src/api/coreClient.ts`, `telegram/handlers/__init__.py`, `tests/test_auth.py`.

### Testing
- Ran unit tests in `tests/test_auth.py` with `pytest` and all tests passed (`6 passed`).
- The updated tests cover registration/login flows and canonical `/api/me` negative and positive authentication scenarios and validate the stable response shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f649d33c832f9b61e602b11033ef)