### PR TITLE
Enhance ResearcherAgent: pipeline artifacts, RAG-first retrieval, web fallback and structured payload

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -34,7 +34,7 @@ class BaseAgent(ABC):
         """Внутренняя реализация выполнения конкретного агента."""
 
     def _build_prompt(self, state: dict[str, Any]) -> str:
-        """Собрать финальный prompt из message и context."""
+        """Собрать финальный prompt из message, context и истории пайплайна."""
         message = str(state.get("message", ""))
         context = str(state.get("context", ""))
         prompt = message
@@ -42,21 +42,45 @@ class BaseAgent(ABC):
             prompt = f"Контекст:\n{context}\n\nЗапрос:\n{message}"
 
         conversation_history = state.get("conversation_history", [])
-        if not conversation_history:
-            return prompt
-
-        lines: list[str] = []
+        conversation_lines: list[str] = []
         for item in conversation_history:
             if not isinstance(item, dict):
                 continue
             role = str(item.get("role", "unknown"))
             content = str(item.get("content", ""))
             timestamp = str(item.get("timestamp", ""))
-            lines.append(f"- [{timestamp}] {role}: {content}")
+            conversation_lines.append(f"- [{timestamp}] {role}: {content}")
 
-        if not lines:
-            return prompt
-        return f"{prompt}\n\nИстория диалога:\n" + "\n".join(lines)
+        pipeline_lines = self._build_pipeline_history(state)
+
+        sections = [prompt]
+        if conversation_lines:
+            sections.append("История диалога:\n" + "\n".join(conversation_lines))
+        if pipeline_lines:
+            sections.append("Pipeline artifacts:\n" + "\n".join(pipeline_lines))
+        return "\n\n".join(sections)
+
+    def _build_pipeline_history(self, state: dict[str, Any], *, limit: int = 3) -> list[str]:
+        """Краткая выжимка последних результатов агентов и ключевых артефактов."""
+        history = state.get("history", [])
+        lines: list[str] = []
+
+        if isinstance(history, list):
+            for item in history[-limit:]:
+                if not isinstance(item, dict):
+                    continue
+                agent = str(item.get("agent_name") or item.get("agent") or "unknown")
+                output = str(item.get("output", "")).strip().replace("\n", " ")
+                lines.append(f"- {agent}: {output[:300]}")
+
+        artifact_keys = ["research_facts", "risk_report", "draft", "verification"]
+        for key in artifact_keys:
+            value = state.get(key)
+            if value is None:
+                continue
+            text = str(value).strip().replace("\n", " ")
+            lines.append(f"- {key}: {text[:240]}")
+        return lines
 
     def _update_state(self, state: dict[str, Any], reply: str) -> dict[str, Any]:
         """Добавить результат агента в историю."""

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -54,8 +54,7 @@ class ResearcherAgent(BaseAgent):
         rag_tool = RAGSearchTool(self.rag_engine)
         rag_chunks = await rag_tool.run(message, role=role)
         rag_sources = [
-            self._rag_chunk_to_source(index, chunk)
-            for index, chunk in enumerate(rag_chunks)
+            self._rag_chunk_to_source(index, chunk) for index, chunk in enumerate(rag_chunks)
         ]
 
         should_use_web = len(rag_sources) < 2 or self._avg_score(rag_sources) < 0.35

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -7,6 +7,27 @@ from typing import Any
 from agents.base import BaseAgent
 from core.llm_router import LLMRouter
 from core.rag_engine import RAGEngine
+from core.tools.web_search import WebSearchTool
+from schemas.research import ResearchFact, ResearchResponse, ResearchSource
+
+
+class RAGSearchTool:
+    """Лёгкий tool-адаптер поверх RAGEngine."""
+
+    def __init__(self, rag_engine: RAGEngine):
+        self.rag_engine = rag_engine
+
+    async def run(
+        self,
+        query: str,
+        *,
+        role: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        chunks = await self.rag_engine.search(query, n_results=limit, filter_scope=role)
+        if role and not chunks:
+            chunks = await self.rag_engine.search(query, n_results=limit)
+        return chunks
 
 
 class ResearcherAgent(BaseAgent):
@@ -21,29 +42,104 @@ class ResearcherAgent(BaseAgent):
     def __init__(self, llm_router: LLMRouter) -> None:
         super().__init__(agent_id="01", llm_router=llm_router)
         self.rag_engine: RAGEngine | None = None
+        self.web_search_tool = WebSearchTool()
 
     async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         if self.rag_engine is None:
             self.rag_engine = RAGEngine()
-        message = str(state.get("message", ""))
-        role = str(state.get("role", "")) or None
-        chunks = await self.rag_engine.search(message, filter_scope=role)
-        if role and not chunks:
-            chunks = await self.rag_engine.search(message)
-        chunks_text = (
-            "\n".join(
-                f"- [{chunk['source']}, стр. {chunk['page']}] {chunk['text']}" for chunk in chunks
-            )
-            or "(релевантные нормативы не найдены)"
-        )
 
-        rag_prompt = f"Релевантные нормативы:\n{chunks_text}\n\nЗапрос пользователя: {message}"
+        message = str(state.get("message", "")).strip()
+        role = str(state.get("role", "")).strip() or None
 
-        prompt = rag_prompt
+        rag_tool = RAGSearchTool(self.rag_engine)
+        rag_chunks = await rag_tool.run(message, role=role)
+        rag_sources = [
+            self._rag_chunk_to_source(index, chunk)
+            for index, chunk in enumerate(rag_chunks)
+        ]
+
+        should_use_web = len(rag_sources) < 2 or self._avg_score(rag_sources) < 0.35
+        web_items: list[dict[str, Any]] = []
+        if should_use_web:
+            web_items = await self.web_search_tool.run(message, max_results=5)
+        web_sources = [
+            self._web_item_to_source(index, item)
+            for index, item in enumerate(web_items, start=len(rag_sources))
+        ]
+
+        all_sources = [*rag_sources, *web_sources]
+        chunks_text = "\n".join(self._source_brief(source) for source in all_sources)
+        if not chunks_text:
+            chunks_text = "(релевантные источники не найдены)"
+
+        rag_prompt = f"Источники:\n{chunks_text}\n\nЗапрос пользователя: {message}"
         context = str(state.get("context", ""))
-        if context:
-            prompt = f"Контекст:\n{context}\n\n{rag_prompt}"
+        prompt = f"Контекст:\n{context}\n\n{rag_prompt}" if context else rag_prompt
 
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
+        payload = self._build_research_payload(message, response.text, all_sources)
+
         state["research_facts"] = response.text
+        state["research_payload"] = payload.model_dump()
         return self._update_state(state, response.text)
+
+    def _build_research_payload(
+        self,
+        query: str,
+        answer_text: str,
+        sources: list[ResearchSource],
+    ) -> ResearchResponse:
+        source_ids = [source.id for source in sources][:3]
+        fact = ResearchFact(
+            text=answer_text.strip(),
+            applicability="Уточняется по контексту запроса",
+            confidence=round(self._avg_score(sources), 2),
+            source_ids=source_ids,
+        )
+        gaps = [] if sources else ["Не найдено релевантных источников"]
+        return ResearchResponse(
+            query=query,
+            facts=[fact],
+            sources=sources,
+            gaps=gaps,
+            confidence_overall=round(self._avg_score(sources), 2),
+        )
+
+    def _avg_score(self, sources: list[ResearchSource]) -> float:
+        if not sources:
+            return 0.0
+        total = sum(source.score for source in sources)
+        return min(1.0, max(0.0, total / len(sources)))
+
+    def _rag_chunk_to_source(self, idx: int, chunk: dict[str, Any]) -> ResearchSource:
+        source = str(chunk.get("source", "unknown"))
+        page = int(chunk.get("page", 0))
+        return ResearchSource(
+            id=f"rag-{idx}",
+            type="rag",
+            title=source,
+            document=source,
+            page=page if page > 0 else None,
+            locator=f"стр. {page}" if page > 0 else None,
+            snippet=str(chunk.get("text", ""))[:400],
+            score=float(chunk.get("score", 0.0)),
+        )
+
+    def _web_item_to_source(self, idx: int, item: dict[str, Any]) -> ResearchSource:
+        return ResearchSource(
+            id=f"web-{idx}",
+            type="web",
+            title=str(item.get("title", "Web source")),
+            url=str(item.get("url")) if item.get("url") else None,
+            snippet=str(item.get("snippet", ""))[:400],
+            score=float(item.get("score", 0.0)),
+            published_at=str(item.get("published_at")) if item.get("published_at") else None,
+        )
+
+    def _source_brief(self, source: ResearchSource) -> str:
+        if source.type == "rag":
+            return (
+                f"- [rag:{source.document or source.title}, {source.locator or 'без страницы'}] "
+                f"{source.snippet or ''}"
+            )
+        return f"- [web:{source.title}] {source.snippet or source.url or ''}"

--- a/api/main.py
+++ b/api/main.py
@@ -36,6 +36,7 @@ from api.routes import (
     linking,
     projects,
     rag,
+    research,
     sign,
     web,
     web_push,
@@ -122,6 +123,7 @@ app.include_router(auth.legacy_router, tags=["auth"])
 app.include_router(billing.router, prefix="/api", tags=["billing"])
 app.include_router(branding.router, prefix="/api", tags=["branding"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
+app.include_router(research.router, prefix="/api", tags=["research"])
 # generate.router содержит /api/generate/* включая /api/generate/exec-album
 app.include_router(generate.router, prefix="/api", tags=["generate"])
 app.include_router(sign.router, prefix="/api", tags=["sign"])

--- a/api/routes/research.py
+++ b/api/routes/research.py
@@ -1,0 +1,45 @@
+"""Standalone endpoint для ResearcherAgent."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from agents.researcher import ResearcherAgent
+from core.llm_router import LLMRouter
+
+router = APIRouter()
+researcher_agent = ResearcherAgent(LLMRouter())
+
+
+class ResearchRequest(BaseModel):
+    query: str
+    role: str = "pto_engineer"
+    context: str = ""
+    session_id: str | None = None
+
+
+class ResearchApiResponse(BaseModel):
+    session_id: str
+    research_facts: str
+    research_payload: dict
+
+
+@router.post("/research", response_model=ResearchApiResponse)
+async def research(payload: ResearchRequest) -> ResearchApiResponse:
+    session_id = payload.session_id or str(uuid.uuid4())
+    state = {
+        "message": payload.query,
+        "role": payload.role,
+        "context": payload.context,
+        "session_id": session_id,
+        "history": [],
+    }
+    result = await researcher_agent.run(state)
+    return ResearchApiResponse(
+        session_id=session_id,
+        research_facts=str(result.get("research_facts", "")),
+        research_payload=dict(result.get("research_payload", {})),
+    )

--- a/core/llm_router.py
+++ b/core/llm_router.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import hashlib
+import json
 from dataclasses import dataclass
 from enum import Enum
 
@@ -235,6 +236,21 @@ class LLMRouter:
             model=used_model,
             usage=usage,
         )
+
+
+
+    def parse_json_response(self, response_text: str) -> dict | None:
+        """Безопасно распарсить JSON из текстового ответа LLM."""
+        text = response_text.strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+            return None
+        except json.JSONDecodeError:
+            return None
 
     def _intent_cache_key(self, system_prompt: str | None, prompt: str) -> str | None:
         if system_prompt and "Определи intent запроса" in system_prompt:

--- a/core/llm_router.py
+++ b/core/llm_router.py
@@ -237,8 +237,6 @@ class LLMRouter:
             usage=usage,
         )
 
-
-
     def parse_json_response(self, response_text: str) -> dict | None:
         """Безопасно распарсить JSON из текстового ответа LLM."""
         text = response_text.strip()

--- a/core/tools/base.py
+++ b/core/tools/base.py
@@ -1,0 +1,14 @@
+"""Базовые контракты для инструментов retrieval."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseTool(ABC):
+    """Абстрактный базовый класс для tool-интерфейсов."""
+
+    @abstractmethod
+    async def run(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        """Выполнить инструмент и вернуть список нормализованных результатов."""

--- a/core/tools/web_search.py
+++ b/core/tools/web_search.py
@@ -13,9 +13,29 @@ from core.tools.base import BaseTool
 class WebSearchTool(BaseTool):
     """Выполняет веб-поиск через Perplexity Sonar, если настроен API ключ."""
 
-    def __init__(self, *, timeout_seconds: float = 30.0) -> None:
+    _shared_client: httpx.AsyncClient | None = None
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
         self.timeout_seconds = timeout_seconds
-        self._client = httpx.AsyncClient(timeout=timeout_seconds)
+        if client is not None:
+            self._client = client
+        else:
+            if WebSearchTool._shared_client is None:
+                WebSearchTool._shared_client = httpx.AsyncClient(timeout=timeout_seconds)
+            self._client = WebSearchTool._shared_client
+
+    @classmethod
+    async def aclose_shared_client(cls) -> None:
+        """Явно закрыть разделяемый клиент (например, в shutdown)."""
+        if cls._shared_client is None:
+            return
+        await cls._shared_client.aclose()
+        cls._shared_client = None
 
     async def run(
         self,
@@ -58,10 +78,10 @@ class WebSearchTool(BaseTool):
                 },
             )
             response.raise_for_status()
+            payload = response.json()
         except Exception:
             return []
 
-        payload = response.json()
         items: list[dict[str, Any]] = []
         for idx, citation in enumerate(payload.get("citations", []), start=1):
             if isinstance(citation, str):

--- a/core/tools/web_search.py
+++ b/core/tools/web_search.py
@@ -1,0 +1,99 @@
+"""Инструмент web_search с fallback на Perplexity API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from config.settings import settings
+from core.tools.base import BaseTool
+
+
+class WebSearchTool(BaseTool):
+    """Выполняет веб-поиск через Perplexity Sonar, если настроен API ключ."""
+
+    def __init__(self, *, timeout_seconds: float = 30.0) -> None:
+        self.timeout_seconds = timeout_seconds
+        self._client = httpx.AsyncClient(timeout=timeout_seconds)
+
+    async def run(
+        self,
+        query: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Вернуть структурированные web-источники или пустой список без исключений."""
+        if not settings.perplexity_api_key.strip() or not query.strip():
+            return []
+
+        max_results = int(kwargs.get("max_results", 5))
+        allowed_domains = kwargs.get("allowed_domains")
+        domain_text = ""
+        if isinstance(allowed_domains, list) and allowed_domains:
+            domain_text = f" Разрешённые домены: {', '.join(map(str, allowed_domains))}."
+
+        try:
+            response = await self._client.post(
+                "https://api.perplexity.ai/chat/completions",
+                headers={"Authorization": f"Bearer {settings.perplexity_api_key}"},
+                json={
+                    "model": "sonar",
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": (
+                                "Ты веб-поисковый инструмент. Верни JSON-массив объектов "
+                                "с полями title,url,snippet,published_at,score."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": (
+                                f"Запрос: {query}. Верни до {max_results} результатов.{domain_text}"
+                            ),
+                        },
+                    ],
+                    "temperature": 0,
+                    "max_tokens": 800,
+                },
+            )
+            response.raise_for_status()
+        except Exception:
+            return []
+
+        payload = response.json()
+        items: list[dict[str, Any]] = []
+        for idx, citation in enumerate(payload.get("citations", []), start=1):
+            if isinstance(citation, str):
+                items.append(
+                    {
+                        "type": "web",
+                        "title": citation,
+                        "url": citation,
+                        "snippet": "",
+                        "published_at": None,
+                        "score": max(0.0, 1.0 - (idx - 1) * 0.1),
+                    }
+                )
+
+        if items:
+            return items[:max_results]
+
+        message = ""
+        choices = payload.get("choices") or []
+        if choices and isinstance(choices[0], dict):
+            message = str((choices[0].get("message") or {}).get("content", ""))
+
+        if message:
+            return [
+                {
+                    "type": "web",
+                    "title": "Perplexity summary",
+                    "url": None,
+                    "snippet": message[:500],
+                    "published_at": None,
+                    "score": 0.4,
+                }
+            ]
+
+        return []

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Схемы API и внутренних payload-структур."""
+
+from schemas.research import ResearchFact, ResearchResponse, ResearchSource
+
+__all__ = ["ResearchFact", "ResearchResponse", "ResearchSource"]

--- a/schemas/research.py
+++ b/schemas/research.py
@@ -1,0 +1,39 @@
+"""Pydantic-схемы для структурированного ответа Researcher."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ResearchFact(BaseModel):
+    """Найденный факт и оценка его применимости."""
+
+    text: str
+    applicability: str = ""
+    confidence: float = Field(ge=0.0, le=1.0)
+    source_ids: list[str] = Field(default_factory=list)
+
+
+class ResearchSource(BaseModel):
+    """Нормализованный источник (RAG / web / memory)."""
+
+    id: str
+    type: str
+    title: str
+    document: str | None = None
+    page: int | None = None
+    url: str | None = None
+    locator: str | None = None
+    snippet: str | None = None
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    published_at: str | None = None
+
+
+class ResearchResponse(BaseModel):
+    """Структурированный payload ответа Researcher."""
+
+    query: str
+    facts: list[ResearchFact] = Field(default_factory=list)
+    sources: list[ResearchSource] = Field(default_factory=list)
+    gaps: list[str] = Field(default_factory=list)
+    confidence_overall: float = Field(default=0.0, ge=0.0, le=1.0)

--- a/tests/test_agent_prompt_pipeline.py
+++ b/tests/test_agent_prompt_pipeline.py
@@ -1,0 +1,32 @@
+"""Проверка попадания результатов предыдущих агентов в prompt следующего."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from agents.base import BaseAgent
+
+
+class _DummyAgent(BaseAgent):
+    async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
+        return state
+
+
+def test_build_prompt_includes_pipeline_history_and_artifacts() -> None:
+    agent = _DummyAgent(agent_id="99", llm_router=SimpleNamespace())
+    state = {
+        "message": "Сделай вывод",
+        "context": "Контекст",
+        "conversation_history": [{"role": "user", "content": "Ранее", "timestamp": "t1"}],
+        "history": [
+            {"agent_name": "Researcher", "output": "Нашел ГОСТ"},
+            {"agent_name": "Analyst", "output": "Риск высокий"},
+        ],
+        "research_facts": "ГОСТ 123",
+    }
+
+    prompt = agent._build_prompt(state)
+
+    assert "История диалога" in prompt
+    assert "Pipeline artifacts" in prompt
+    assert "Researcher" in prompt
+    assert "research_facts" in prompt

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -1,0 +1,86 @@
+"""Тесты ResearcherAgent: RAG-first, web fallback и payload schema."""
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+from agents.researcher import ResearcherAgent
+
+
+def _mock_llm_router(reply: str = "Факт") -> SimpleNamespace:
+    return SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text=reply)))
+
+
+def test_researcher_uses_rag_first():
+    agent = ResearcherAgent(cast(Any, _mock_llm_router("RAG answer")))
+
+    class _Rag:
+        async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
+            _ = (query, n_results, filter_scope)
+            return [
+                {"source": "СП 70.13330", "page": 18, "text": "Про бетон", "score": 0.9},
+                {"source": "ГОСТ 7473", "page": 5, "text": "Смесь", "score": 0.8},
+            ]
+
+    agent.rag_engine = cast(Any, _Rag())
+    agent.web_search_tool = cast(Any, SimpleNamespace(run=AsyncMock(return_value=[])))
+
+    state = asyncio.run(agent.run({"message": "бетон", "history": []}))
+
+    assert "research_payload" in state
+    assert len(state["research_payload"]["sources"]) == 2
+    assert all(source["type"] == "rag" for source in state["research_payload"]["sources"])
+    assert agent.web_search_tool.run.await_count == 0
+
+
+def test_researcher_falls_back_to_web_when_rag_empty():
+    agent = ResearcherAgent(cast(Any, _mock_llm_router("Web answer")))
+
+    class _Rag:
+        async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
+            _ = (query, n_results, filter_scope)
+            return []
+
+    agent.rag_engine = cast(Any, _Rag())
+    agent.web_search_tool = cast(
+        Any,
+        SimpleNamespace(
+            run=AsyncMock(
+                return_value=[
+                    {
+                        "type": "web",
+                        "title": "Минстрой",
+                        "url": "https://example.org",
+                        "snippet": "Обновление",
+                        "score": 0.7,
+                    }
+                ]
+            )
+        ),
+    )
+
+    state = asyncio.run(agent.run({"message": "новости", "history": []}))
+
+    assert any(source["type"] == "web" for source in state["research_payload"]["sources"])
+    assert agent.web_search_tool.run.await_count == 1
+
+
+def test_researcher_returns_valid_json_payload():
+    agent = ResearcherAgent(cast(Any, _mock_llm_router("Ответ")))
+
+    class _Rag:
+        async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
+            _ = (query, n_results, filter_scope)
+            return [{"source": "СП 48", "page": 1, "text": "Факт", "score": 0.6}]
+
+    agent.rag_engine = cast(Any, _Rag())
+    agent.web_search_tool = cast(Any, SimpleNamespace(run=AsyncMock(return_value=[])))
+
+    state = asyncio.run(agent.run({"message": "что по СП 48", "history": []}))
+    payload = state["research_payload"]
+
+    assert payload["query"] == "что по СП 48"
+    assert isinstance(payload["facts"], list)
+    assert isinstance(payload["sources"], list)
+    assert 0 <= payload["confidence_overall"] <= 1

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -1,0 +1,38 @@
+"""Тесты WebSearchTool: graceful fallback и reuse shared client."""
+
+import asyncio
+
+from config.settings import settings
+from core.tools.web_search import WebSearchTool
+
+
+class _BrokenJsonResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        raise ValueError("invalid json")
+
+
+class _ClientWithBrokenJson:
+    async def post(self, *args, **kwargs):
+        _ = (args, kwargs)
+        return _BrokenJsonResponse()
+
+
+def test_web_search_returns_empty_on_invalid_json(monkeypatch):
+    monkeypatch.setattr(settings, "perplexity_api_key", "test-key")
+    tool = WebSearchTool(client=_ClientWithBrokenJson())
+
+    result = asyncio.run(tool.run("test query"))
+
+    assert result == []
+
+
+def test_web_search_uses_shared_async_client():
+    tool_a = WebSearchTool()
+    tool_b = WebSearchTool()
+
+    assert tool_a._client is tool_b._client
+
+    asyncio.run(WebSearchTool.aclose_shared_client())


### PR DESCRIPTION
### Motivation
- Ensure outputs from earlier pipeline agents are visible to downstream agents by including recent agent outputs and key artifacts in prompts.
- Make `ResearcherAgent` more robust and testable by introducing a tool-style retrieval stack with explicit web search fallback. 
- Provide a machine-readable structured response for Researcher results to support memory, API consumers and further processing.

### Description
- Update prompt building in `BaseAgent._build_prompt()` to include conversation history plus a compact `Pipeline artifacts` block built by a new `_build_pipeline_history()` helper, exposing recent agent outputs and keys like `research_facts`. 
- Refactor `ResearcherAgent` to use a small tool-layer: added `RAGSearchTool` adapter and integrated a `WebSearchTool` to perform RAG-first retrieval with a Perplexity-backed web fallback; `ResearcherAgent` now writes `state["research_payload"]` (Pydantic) in addition to `state["research_facts"]`.
- Add Pydantic schemas `ResearchFact`, `ResearchSource`, `ResearchResponse` in `schemas/research.py` and export them via `schemas/__init__.py`.
- Add `core/tools/base.py` and `core/tools/web_search.py` implementing an async web-search tool that safely returns an empty list if Perplexity is not configured or an error occurs.
- Add a safe JSON parsing helper `parse_json_response()` in `core/llm_router.py` to support future structured-response workflows without changing `query()` semantics.
- Expose a standalone endpoint `POST /api/research` in `api/routes/research.py` and register it in `api/main.py` for direct Researcher usage.
- Add tests `tests/test_researcher.py` (RAG-first, web fallback, payload validity) and `tests/test_agent_prompt_pipeline.py` (prompt includes pipeline artifacts).

### Testing
- Ran linter: `ruff check agents/base.py agents/researcher.py core/llm_router.py core/tools/base.py core/tools/web_search.py schemas/research.py api/routes/research.py tests/test_researcher.py tests/test_agent_prompt_pipeline.py api/main.py`, which passed.
- Ran unit tests: `pytest -q tests/test_researcher.py tests/test_agent_prompt_pipeline.py`, which succeeded with `4 passed` (tests covering RAG-first behavior, web fallback, payload schema validity, and prompt pipeline inclusion).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf1d3670832fa8fda438aa3641d3)