### PR TITLE
Enhance ResearcherAgent: source collection, JSON parsing, web fallback, and standalone run

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -1,7 +1,9 @@
-"""Агент Researcher — поиск информации по нормативам и базе знаний."""
+"""Агент Researcher — поиск информации по нормативам, вебу и базе знаний."""
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any
 
 from agents.base import BaseAgent
@@ -10,135 +12,229 @@ from core.rag_engine import RAGEngine
 from core.tools.web_search import WebSearchTool
 from schemas.research import ResearchFact, ResearchResponse, ResearchSource
 
+logger = logging.getLogger(__name__)
+
 
 class RAGSearchTool:
     """Лёгкий tool-адаптер поверх RAGEngine."""
 
-    def __init__(self, rag_engine: RAGEngine):
+    def __init__(self, rag_engine: RAGEngine) -> None:
         self.rag_engine = rag_engine
 
     async def run(
         self,
         query: str,
         *,
-        role: str | None = None,
+        scope: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        chunks = await self.rag_engine.search(query, n_results=limit, filter_scope=role)
-        if role and not chunks:
+        chunks = await self.rag_engine.search(query, n_results=limit, filter_scope=scope)
+        if scope and not chunks:
             chunks = await self.rag_engine.search(query, n_results=limit)
-        return chunks
+        return chunks or []
 
 
 class ResearcherAgent(BaseAgent):
-    """🔍 Researcher — поиск по нормативам и возврат структурированных фактов."""
+    """🔍 Researcher — универсальный поиск фактов с источниками и confidence."""
 
     system_prompt = (
-        "Ты — Researcher агент. Ищи факты по СП/СНиП/ГОСТ и стройнормам. "
-        "Возвращай структурированно: 1) факт, 2) источник (номер документа, пункт), "
-        "3) применимость. Если данных нет — явно укажи это."
+        "Ты — Researcher агент. Анализируй предоставленные источники (RAG + web) "
+        "и извлекай из них факты. Возвращай СТРОГО валидный JSON без markdown-обёртки "
+        "по схеме:\n"
+        '{"facts":[{"text":"...","applicability":"...",'
+        '"confidence":0.0,"source_ids":["rag-0","web-1"]}],'
+        '"gaps":["что не удалось найти"]}\n'
+        "Правила:\n"
+        "- Каждый факт должен ссылаться хотя бы на один source_id из списка источников.\n"
+        "- confidence от 0.0 до 1.0, чем надёжнее источник — тем выше.\n"
+        "- Если релевантных данных нет — верни facts:[] и опиши пробел в gaps.\n"
+        "- Для строительных тем указывай номер документа и пункт в поле text."
     )
 
-    def __init__(self, llm_router: LLMRouter) -> None:
+    def __init__(
+        self,
+        llm_router: LLMRouter,
+        rag_engine: RAGEngine | None = None,
+        web_search_tool: WebSearchTool | None = None,
+    ) -> None:
         super().__init__(agent_id="01", llm_router=llm_router)
-        self.rag_engine: RAGEngine | None = None
-        self.web_search_tool = WebSearchTool()
+        self.rag_engine = rag_engine
+        self.web_search_tool = web_search_tool or WebSearchTool()
 
     async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Режим внутри pipeline — вызывается оркестратором."""
         if self.rag_engine is None:
             self.rag_engine = RAGEngine()
 
         message = str(state.get("message", "")).strip()
-        role = str(state.get("role", "")).strip() or None
+        scope = str(state.get("scope") or state.get("role") or "").strip() or None
+        context = str(state.get("context", "")).strip()
 
-        rag_tool = RAGSearchTool(self.rag_engine)
-        rag_chunks = await rag_tool.run(message, role=role)
-        rag_sources = [
-            self._rag_chunk_to_source(index, chunk) for index, chunk in enumerate(rag_chunks)
-        ]
-
-        should_use_web = len(rag_sources) < 2 or self._avg_score(rag_sources) < 0.35
-        web_items: list[dict[str, Any]] = []
-        if should_use_web:
-            web_items = await self.web_search_tool.run(message, max_results=5)
-        web_sources = [
-            self._web_item_to_source(index, item)
-            for index, item in enumerate(web_items, start=len(rag_sources))
-        ]
-
-        all_sources = [*rag_sources, *web_sources]
-        chunks_text = "\n".join(self._source_brief(source) for source in all_sources)
-        if not chunks_text:
-            chunks_text = "(релевантные источники не найдены)"
-
-        rag_prompt = f"Источники:\n{chunks_text}\n\nЗапрос пользователя: {message}"
-        context = str(state.get("context", ""))
-        prompt = f"Контекст:\n{context}\n\n{rag_prompt}" if context else rag_prompt
+        all_sources = await self._collect_sources(message, scope)
+        prompt = self._build_prompt(message, context, all_sources)
 
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
-        payload = self._build_research_payload(message, response.text, all_sources)
+        payload = self._parse_llm_json(message, response.text, all_sources)
 
         state["research_facts"] = response.text
         state["research_payload"] = payload.model_dump()
         return self._update_state(state, response.text)
 
-    def _build_research_payload(
+    async def run_standalone(
+        self,
+        message: str,
+        *,
+        scope: str | None = None,
+        context: str = "",
+        user_id: str | None = None,
+    ) -> ResearchResponse:
+        """Соло-вызов без pipeline — для REST API и Telegram-бота."""
+        state: dict[str, Any] = {
+            "message": message,
+            "scope": scope,
+            "context": context,
+            "user_id": user_id,
+            "history": [],
+        }
+        result = await self.run(state)
+        return ResearchResponse.model_validate(result["research_payload"])
+
+    async def _collect_sources(self, message: str, scope: str | None) -> list[ResearchSource]:
+        """Собрать источники из RAG и (если надо) из веба."""
+        rag_tool = RAGSearchTool(self.rag_engine)  # type: ignore[arg-type]
+        try:
+            rag_chunks = await rag_tool.run(message, scope=scope)
+        except Exception as exc:
+            logger.warning("researcher.rag_failed: %s", exc)
+            rag_chunks = []
+
+        rag_sources = [self._rag_chunk_to_source(idx, chunk) for idx, chunk in enumerate(rag_chunks)]
+
+        if self._need_web_fallback(rag_sources):
+            try:
+                web_items = await self.web_search_tool.run(message, max_results=5)
+            except Exception as exc:
+                logger.warning("researcher.web_failed: %s", exc)
+                web_items = []
+        else:
+            web_items = []
+
+        web_sources = [
+            self._web_item_to_source(idx, item)
+            for idx, item in enumerate(web_items, start=len(rag_sources))
+        ]
+        return [*rag_sources, *web_sources]
+
+    def _need_web_fallback(self, rag_sources: list[ResearchSource]) -> bool:
+        """Нужно ли подключать web search: мало источников или слабый avg score."""
+        if len(rag_sources) < 2:
+            return True
+        return self._avg_score(rag_sources) < 0.35
+
+    def _build_prompt(self, message: str, context: str, sources: list[ResearchSource]) -> str:
+        chunks_text = "\n".join(self._source_brief(s) for s in sources) or "(релевантные источники не найдены)"
+        prompt = f"Источники:\n{chunks_text}\n\nЗапрос пользователя: {message}"
+        if context:
+            prompt = f"Контекст:\n{context}\n\n{prompt}"
+        return prompt
+
+    def _source_brief(self, source: ResearchSource) -> str:
+        if source.type == "rag":
+            locator = source.locator or "без страницы"
+            return f"- [{source.id} | {source.document or source.title}, {locator}] {source.snippet or ''}"
+        return f"- [{source.id} | {source.title}] {source.snippet or source.url or ''}"
+
+    def _parse_llm_json(
         self,
         query: str,
-        answer_text: str,
+        raw: str,
         sources: list[ResearchSource],
     ) -> ResearchResponse:
-        source_ids = [source.id for source in sources][:3]
-        fact = ResearchFact(
-            text=answer_text.strip(),
-            applicability="Уточняется по контексту запроса",
-            confidence=round(self._avg_score(sources), 2),
-            source_ids=source_ids,
-        )
-        gaps = [] if sources else ["Не найдено релевантных источников"]
+        """Извлечь JSON из ответа LLM с graceful fallback."""
+        facts: list[ResearchFact] = []
+        gaps: list[str] = []
+
+        try:
+            data = json.loads(self._strip_markdown_fence(raw))
+            facts = [ResearchFact(**f) for f in data.get("facts", [])]
+            gaps = [str(g) for g in data.get("gaps", [])]
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.info("researcher.json_parse_failed: %s", exc)
+            facts = [
+                ResearchFact(
+                    text=raw.strip(),
+                    applicability="Не удалось распарсить JSON — вернён сырой ответ",
+                    confidence=self._avg_score(sources),
+                    source_ids=[s.id for s in sources[:3]],
+                )
+            ]
+            gaps = ["LLM вернул ответ не в JSON-формате"]
+
+        if not sources:
+            gaps.append("Не найдено релевантных источников")
+
         return ResearchResponse(
             query=query,
-            facts=[fact],
+            facts=facts,
             sources=sources,
             gaps=gaps,
             confidence_overall=round(self._avg_score(sources), 2),
         )
 
-    def _avg_score(self, sources: list[ResearchSource]) -> float:
-        if not sources:
-            return 0.0
-        total = sum(source.score for source in sources)
-        return min(1.0, max(0.0, total / len(sources)))
+    @staticmethod
+    def _strip_markdown_fence(text: str) -> str:
+        """Убрать markdown-обёртку ```json ... ``` если LLM её добавил."""
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.split("\n", 1)[-1]
+        if cleaned.endswith("```"):
+            cleaned = cleaned.rsplit("```", 1)[0]
+        return cleaned.strip()
 
     def _rag_chunk_to_source(self, idx: int, chunk: dict[str, Any]) -> ResearchSource:
-        source = str(chunk.get("source", "unknown"))
-        page = int(chunk.get("page", 0))
+        source_name = str(chunk.get("source", "unknown"))
+        page = self._safe_int(chunk.get("page"))
         return ResearchSource(
             id=f"rag-{idx}",
             type="rag",
-            title=source,
-            document=source,
+            title=source_name,
+            document=source_name,
             page=page if page > 0 else None,
             locator=f"стр. {page}" if page > 0 else None,
             snippet=str(chunk.get("text", ""))[:400],
-            score=float(chunk.get("score", 0.0)),
+            score=self._safe_float(chunk.get("score")),
         )
 
     def _web_item_to_source(self, idx: int, item: dict[str, Any]) -> ResearchSource:
+        url = item.get("url")
+        published = item.get("published_at")
         return ResearchSource(
             id=f"web-{idx}",
             type="web",
             title=str(item.get("title", "Web source")),
-            url=str(item.get("url")) if item.get("url") else None,
+            url=str(url) if url else None,
             snippet=str(item.get("snippet", ""))[:400],
-            score=float(item.get("score", 0.0)),
-            published_at=str(item.get("published_at")) if item.get("published_at") else None,
+            score=self._safe_float(item.get("score")),
+            published_at=str(published) if published else None,
         )
 
-    def _source_brief(self, source: ResearchSource) -> str:
-        if source.type == "rag":
-            return (
-                f"- [rag:{source.document or source.title}, {source.locator or 'без страницы'}] "
-                f"{source.snippet or ''}"
-            )
-        return f"- [web:{source.title}] {source.snippet or source.url or ''}"
+    @staticmethod
+    def _avg_score(sources: list[ResearchSource]) -> float:
+        if not sources:
+            return 0.0
+        total = sum(s.score for s in sources)
+        return min(1.0, max(0.0, total / len(sources)))
+
+    @staticmethod
+    def _safe_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value) if value is not None else default
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _safe_float(value: Any, default: float = 0.0) -> float:
+        try:
+            return float(value) if value is not None else default
+        except (TypeError, ValueError):
+            return default

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -156,6 +156,8 @@ class ResearcherAgent(BaseAgent):
 
         try:
             data = json.loads(self._strip_markdown_fence(raw))
+            if not isinstance(data, dict):
+                raise TypeError("LLM JSON payload must be an object")
             facts = [ResearchFact(**f) for f in data.get("facts", [])]
             gaps = [str(g) for g in data.get("gaps", [])]
         except (json.JSONDecodeError, TypeError, ValueError) as exc:

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -71,7 +71,7 @@ class ResearcherAgent(BaseAgent):
         context = str(state.get("context", "")).strip()
 
         all_sources = await self._collect_sources(message, scope)
-        prompt = self._build_prompt(message, context, all_sources)
+        prompt = self._build_research_prompt(message, context, all_sources)
 
         response = await self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt)
         payload = self._parse_llm_json(message, response.text, all_sources)
@@ -131,7 +131,7 @@ class ResearcherAgent(BaseAgent):
             return True
         return self._avg_score(rag_sources) < 0.35
 
-    def _build_prompt(self, message: str, context: str, sources: list[ResearchSource]) -> str:
+    def _build_research_prompt(self, message: str, context: str, sources: list[ResearchSource]) -> str:
         chunks_text = "\n".join(self._source_brief(s) for s in sources) or "(релевантные источники не найдены)"
         prompt = f"Источники:\n{chunks_text}\n\nЗапрос пользователя: {message}"
         if context:

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -84,3 +84,22 @@ def test_researcher_returns_valid_json_payload():
     assert isinstance(payload["facts"], list)
     assert isinstance(payload["sources"], list)
     assert 0 <= payload["confidence_overall"] <= 1
+
+
+def test_researcher_falls_back_when_llm_returns_non_object_json():
+    agent = ResearcherAgent(cast(Any, _mock_llm_router("[]")))
+
+    class _Rag:
+        async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
+            _ = (query, n_results, filter_scope)
+            return [{"source": "СП 48", "page": 1, "text": "Факт", "score": 0.6}]
+
+    agent.rag_engine = cast(Any, _Rag())
+    agent.web_search_tool = cast(Any, SimpleNamespace(run=AsyncMock(return_value=[])))
+
+    state = asyncio.run(agent.run({"message": "что по СП 48", "history": []}))
+    payload = state["research_payload"]
+
+    assert payload["facts"]
+    assert payload["facts"][0]["text"] == "[]"
+    assert "LLM вернул ответ не в JSON-формате" in payload["gaps"]


### PR DESCRIPTION
### Motivation
- Improve robustness of the Researcher agent by separating source collection, prompt building and LLM JSON parsing to produce structured research payloads. 
- Provide graceful fallbacks for RAG/web failures and for non-JSON LLM outputs so the service remains usable in degraded conditions.

### Description
- Reworked `agents/researcher.py` to add a `RAGSearchTool` with a `scope` parameter and `chunks or []` return to avoid None errors.
- Implemented `_collect_sources`, `_need_web_fallback`, `_build_prompt` and `_source_brief` to assemble RAG and web sources and to build a clearer prompt for the LLM.
- Added `_parse_llm_json` with markdown-fence cleanup (`_strip_markdown_fence`), strict JSON parsing and a fallback `ResearchFact` when parsing fails, plus logging for RAG/web errors.
- Added constructor DI for optional `RAGEngine` and `WebSearchTool`, `run_standalone(...)` for non-pipeline use, and safe numeric helpers `_safe_int`/`_safe_float` and normalized `_avg_score`.

### Testing
- Ran `pytest -q tests/test_researcher.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea04ea6dc8832f9d738c1fde80bab7)