### PR TITLE
Add Redis caching to Researcher and tighten web-fallback heuristics

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
+import hashlib
 from typing import Any
 
 from agents.base import BaseAgent
+from config.settings import settings
+from core.cache import RedisCache
 from core.llm_router import LLMRouter
 from core.rag_engine import RAGEngine
 from core.tools.web_search import WebSearchTool
@@ -46,6 +49,7 @@ class ResearcherAgent(BaseAgent):
         '"gaps":["что не удалось найти"]}\n'
         "Правила:\n"
         "- Каждый факт должен ссылаться хотя бы на один source_id из списка источников.\n"
+        "- applicability: 'высокая/средняя/низкая' по релевантности стройке.\n"
         "- confidence от 0.0 до 1.0, чем надёжнее источник — тем выше.\n"
         "- Если релевантных данных нет — верни facts:[] и опиши пробел в gaps.\n"
         "- Для строительных тем указывай номер документа и пункт в поле text."
@@ -60,6 +64,7 @@ class ResearcherAgent(BaseAgent):
         super().__init__(agent_id="01", llm_router=llm_router)
         self.rag_engine = rag_engine
         self.web_search_tool = web_search_tool or WebSearchTool()
+        self.cache = RedisCache(settings.redis_url)
 
     async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         """Режим внутри pipeline — вызывается оркестратором."""
@@ -101,6 +106,16 @@ class ResearcherAgent(BaseAgent):
 
     async def _collect_sources(self, message: str, scope: str | None) -> list[ResearchSource]:
         """Собрать источники из RAG и (если надо) из веба."""
+        message_hash = hashlib.sha256(message.encode("utf-8")).hexdigest()[:16]
+        cache_key = f"research_sources:{message_hash}_{scope or 'all'}"
+        cached = await self.cache.get(cache_key)
+        if cached:
+            try:
+                payload = json.loads(cached)
+                return [ResearchSource.model_validate(item) for item in payload]
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                logger.info("researcher.cache_parse_failed: %s", exc)
+
         rag_tool = RAGSearchTool(self.rag_engine)  # type: ignore[arg-type]
         try:
             rag_chunks = await rag_tool.run(message, scope=scope)
@@ -123,13 +138,21 @@ class ResearcherAgent(BaseAgent):
             self._web_item_to_source(idx, item)
             for idx, item in enumerate(web_items, start=len(rag_sources))
         ]
-        return [*rag_sources, *web_sources]
+        sources = [*rag_sources, *web_sources]
+        await self.cache.set(
+            cache_key,
+            json.dumps([source.model_dump() for source in sources], ensure_ascii=False),
+            ttl=3600,
+        )
+        return sources
 
     def _need_web_fallback(self, rag_sources: list[ResearchSource]) -> bool:
         """Нужно ли подключать web search: мало источников или слабый avg score."""
         if len(rag_sources) < 2:
             return True
-        return self._avg_score(rag_sources) < 0.35
+        if self._avg_score(rag_sources) < 0.35:
+            return True
+        return sum(len(source.snippet or "") for source in rag_sources) < 500
 
     def _build_research_prompt(self, message: str, context: str, sources: list[ResearchSource]) -> str:
         chunks_text = "\n".join(self._source_brief(s) for s in sources) or "(релевантные источники не найдены)"

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -139,11 +139,12 @@ class ResearcherAgent(BaseAgent):
             for idx, item in enumerate(web_items, start=len(rag_sources))
         ]
         sources = [*rag_sources, *web_sources]
-        await self.cache.set(
-            cache_key,
-            json.dumps([source.model_dump() for source in sources], ensure_ascii=False),
-            ttl=3600,
-        )
+        if sources:
+            await self.cache.set(
+                cache_key,
+                json.dumps([source.model_dump() for source in sources], ensure_ascii=False),
+                ttl=3600,
+            )
         return sources
 
     def _need_web_fallback(self, rag_sources: list[ResearchSource]) -> bool:

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -103,3 +103,26 @@ def test_researcher_falls_back_when_llm_returns_non_object_json():
     assert payload["facts"]
     assert payload["facts"][0]["text"] == "[]"
     assert "LLM вернул ответ не в JSON-формате" in payload["gaps"]
+
+
+def test_researcher_does_not_cache_empty_sources():
+    agent = ResearcherAgent(cast(Any, _mock_llm_router("Ответ")))
+
+    class _Rag:
+        async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
+            _ = (query, n_results, filter_scope)
+            return []
+
+    agent.rag_engine = cast(Any, _Rag())
+    agent.web_search_tool = cast(Any, SimpleNamespace(run=AsyncMock(return_value=[])))
+    agent.cache = cast(
+        Any,
+        SimpleNamespace(
+            get=AsyncMock(return_value=None),
+            set=AsyncMock(),
+        ),
+    )
+
+    asyncio.run(agent.run({"message": "пустой поиск", "history": []}))
+
+    assert agent.cache.set.await_count == 0

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -19,8 +19,8 @@ def test_researcher_uses_rag_first():
         async def search(self, query: str, n_results: int = 5, filter_scope: str | None = None):
             _ = (query, n_results, filter_scope)
             return [
-                {"source": "СП 70.13330", "page": 18, "text": "Про бетон", "score": 0.9},
-                {"source": "ГОСТ 7473", "page": 5, "text": "Смесь", "score": 0.8},
+                {"source": "СП 70.13330", "page": 18, "text": "Про бетон " * 40, "score": 0.9},
+                {"source": "ГОСТ 7473", "page": 5, "text": "Смесь " * 40, "score": 0.8},
             ]
 
     agent.rag_engine = cast(Any, _Rag())


### PR DESCRIPTION
### Motivation
- Reduce repeated RAG/web calls and speed up `ResearcherAgent` by caching collected sources for short-term reuse. 
- Improve decision when to call web search by adding a snippet-length check so weak/very short RAG results trigger a web fallback, and make `applicability` output explicit for building-related relevance.

### Description
- Instantiate a `RedisCache` in `ResearcherAgent.__init__` using `settings.redis_url` and use it in `_collect_sources` to read/write cached sources. 
- Implement a cache key `research_sources:{sha16(message)}_{scope}` and serialize sources with `source.model_dump()` for storage and restore them with `ResearchSource.model_validate` on cache hit, with `ttl=3600` seconds. 
- Update `_need_web_fallback` to also return `True` when `sum(len(source.snippet or "") for source in rag_sources) < 500` in addition to existing checks. 
- Clarify the `system_prompt` to require `applicability` be one of `'высокая/средняя/низкая'` and adjust tests to account for the new snippet-length heuristic.

### Testing
- Ran `pytest -q tests/test_researcher.py`; an initial run showed 1 failure due to Redis connection warnings triggering unexpected web calls, then after adjustments reran `pytest -q tests/test_researcher.py` which completed successfully with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea144f8600832f8513365c4fff36a6)