### PR TITLE
Finalize ResearcherAgent refactor with resilient parsing, fallbacks, and tests

### DIFF
--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -42,7 +42,8 @@ class RAGSearchTool:
 class ResearcherAgent(BaseAgent):
     """🔍 Researcher — универсальный поиск фактов с источниками и confidence."""
 
-    system_prompt = """Ты — Researcher агент.
+    system_prompt = """
+Ты — Researcher агент.
 Анализируй предоставленные источники (RAG + web) и извлекай из них факты.
 Возвращай СТРОГО валидный JSON без markdown-обёртки по схеме:
 {"facts":[{"text":"...","applicability":"...","confidence":0.0,
@@ -55,18 +56,19 @@ class ResearcherAgent(BaseAgent):
 - confidence от 0.0 до 1.0, чем надёжнее источник — тем выше.
 - Если релевантных данных нет — верни facts:[] и опиши пробел в gaps.
 - Для строительных тем указывай номер документа и пункт в поле text.
-"""
+""".strip()
 
     def __init__(
         self,
         llm_router: LLMRouter,
         rag_engine: RAGEngine | None = None,
         web_search_tool: WebSearchTool | None = None,
+        cache: RedisCache | None = None,
     ) -> None:
         super().__init__(agent_id="01", llm_router=llm_router)
         self.rag_engine = rag_engine
         self.web_search_tool = web_search_tool or WebSearchTool()
-        self.cache = RedisCache(settings.redis_url)
+        self.cache = cache
 
     async def _run(self, state: dict[str, Any]) -> dict[str, Any]:
         """Режим внутри pipeline — вызывается оркестратором."""
@@ -87,34 +89,33 @@ class ResearcherAgent(BaseAgent):
         )
         prompt = self._build_research_prompt(message, context, all_sources)
 
-        llm_timeout = self._timeout("research_llm_timeout_seconds", 25.0)
+        llm_timeout = self._timeout("research_llm_timeout_seconds", 45.0)
         response_text = ""
+        llm_diagnostics: list[str] = []
+
         try:
             response = await asyncio.wait_for(
                 self.llm_router.query(prompt=prompt, system_prompt=self.system_prompt),
                 timeout=llm_timeout,
             )
             response_text = str(getattr(response, "text", "") or "")
-            payload = self._parse_llm_json(message, response_text, all_sources)
         except TimeoutError:
             logger.warning("researcher.llm_timeout: timeout=%.2f", llm_timeout)
-            payload = self._build_fallback_response(
-                query=message,
-                sources=all_sources,
-                diagnostics=["Таймаут LLM при генерации структурированного ответа"],
-            )
+            llm_diagnostics.append("llm_timeout")
         except Exception as exc:  # noqa: BLE001
             logger.warning("researcher.llm_failed: %s", exc)
-            payload = self._build_fallback_response(
-                query=message,
-                sources=all_sources,
-                diagnostics=["Ошибка LLM при генерации структурированного ответа"],
+            llm_diagnostics.append(f"llm_failed:{type(exc).__name__}")
+
+        payload = self._parse_llm_json(message, response_text, all_sources)
+
+        merged_diagnostics = [*collection_diagnostics, *llm_diagnostics, *payload.diagnostics]
+        if merged_diagnostics:
+            payload = payload.model_copy(
+                update={"diagnostics": list(dict.fromkeys(merged_diagnostics))}
             )
 
-        if collection_diagnostics:
-            payload = payload.model_copy(
-                update={"diagnostics": [*payload.diagnostics, *collection_diagnostics]}
-            )
+        if payload.gaps:
+            payload = payload.model_copy(update={"gaps": list(dict.fromkeys(payload.gaps))})
 
         state["research_facts"] = response_text
         state["research_payload"] = payload.model_dump()
@@ -139,6 +140,15 @@ class ResearcherAgent(BaseAgent):
         result = await self.run(state)
         return ResearchResponse.model_validate(result["research_payload"])
 
+    def _get_cache(self) -> RedisCache | None:
+        if self.cache is None:
+            try:
+                self.cache = RedisCache(settings.redis_url)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("researcher.cache_init_failed: %s", exc)
+                self.cache = None
+        return self.cache
+
     async def _collect_sources(
         self,
         message: str,
@@ -157,12 +167,14 @@ class ResearcherAgent(BaseAgent):
         ).hexdigest()[:12]
         cache_key = f"research_sources:v2:{query_hash}_{scope_hash}"
 
-        try:
-            cached = await self.cache.get(cache_key)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("researcher.cache_get_failed: %s", exc)
-            diagnostics.append("Кэш источников недоступен (get)")
-            cached = None
+        cached = None
+        cache_client = self._get_cache()
+        if cache_client is not None:
+            try:
+                cached = await cache_client.get(cache_key)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("researcher.cache_get_failed: %s", exc)
+                diagnostics.append("cache_unavailable")
 
         if cached:
             try:
@@ -180,22 +192,23 @@ class ResearcherAgent(BaseAgent):
             )
         except TimeoutError:
             logger.warning("researcher.rag_timeout: timeout=%.2f", rag_timeout)
-            diagnostics.append("RAG поиск превысил таймаут")
+            diagnostics.append("rag_timeout")
             rag_chunks = []
         except Exception as exc:  # noqa: BLE001
             logger.warning("researcher.rag_failed: %s", exc)
-            diagnostics.append("Ошибка при RAG поиске")
+            diagnostics.append(f"rag_failed:{type(exc).__name__}")
             rag_chunks = []
 
         rag_sources = [
-            self._rag_chunk_to_source(idx, chunk)
-            for idx, chunk in enumerate(rag_chunks)
+            self._rag_chunk_to_source(idx, chunk) for idx, chunk in enumerate(rag_chunks)
         ]
         rag_sources = self._deduplicate_rag_sources(rag_sources)
 
-        if self._need_web_fallback(rag_sources):
+        needs_web = self._need_web_fallback(rag_sources)
+        if needs_web:
+            diagnostics.append("web_fallback_triggered")
             web_query = self._build_web_query(message, topic_scope)
-            web_timeout = self._timeout("research_web_timeout_seconds", 8.0)
+            web_timeout = self._timeout("research_web_timeout_seconds", 12.0)
             try:
                 web_items = await asyncio.wait_for(
                     self.web_search_tool.run(web_query, max_results=5),
@@ -203,11 +216,11 @@ class ResearcherAgent(BaseAgent):
                 )
             except TimeoutError:
                 logger.warning("researcher.web_timeout: timeout=%.2f", web_timeout)
-                diagnostics.append("Web-поиск превысил таймаут")
+                diagnostics.append("web_timeout")
                 web_items = []
             except Exception as exc:  # noqa: BLE001
                 logger.warning("researcher.web_failed: %s", exc)
-                diagnostics.append("Ошибка web-поиска")
+                diagnostics.append(f"web_failed:{type(exc).__name__}")
                 web_items = []
         else:
             web_items = []
@@ -217,16 +230,20 @@ class ResearcherAgent(BaseAgent):
             for idx, item in enumerate(web_items, start=len(rag_sources))
         ]
         sources = [*rag_sources, *web_sources]
-        if sources:
+
+        if sources and cache_client is not None:
             try:
-                await self.cache.set(
+                await cache_client.set(
                     cache_key,
                     json.dumps([source.model_dump() for source in sources], ensure_ascii=False),
                     ttl=3600,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.warning("researcher.cache_set_failed: %s", exc)
-                diagnostics.append("Кэш источников недоступен (set)")
+                diagnostics.append("cache_unavailable")
+
+        if diagnostics:
+            diagnostics = list(dict.fromkeys(diagnostics))
         return sources, diagnostics
 
     def _need_web_fallback(self, rag_sources: list[ResearchSource]) -> bool:
@@ -264,8 +281,7 @@ class ResearcherAgent(BaseAgent):
         if source.type == "rag":
             locator = source.locator or "без страницы"
             return (
-                f"- [{source.id} | {source.document or source.title}, "
-                f"{locator}] {wrapped_snippet}"
+                f"- [{source.id} | {source.document or source.title}, {locator}] {wrapped_snippet}"
             )
         return f"- [{source.id} | {source.title}] {wrapped_snippet or source.url or ''}"
 
@@ -287,9 +303,9 @@ class ResearcherAgent(BaseAgent):
                 gaps = [str(g) for g in data.get("gaps", [])]
             except (TypeError, ValueError) as exc:
                 logger.info("researcher.json_payload_invalid: %s", exc)
-                diagnostics.append("LLM вернул ответ не в JSON-формате")
+                diagnostics.append("llm_invalid_json")
         else:
-            diagnostics.append("LLM вернул ответ не в JSON-формате")
+            diagnostics.append("llm_invalid_json")
 
         facts, source_diagnostics = self._validate_fact_source_ids(facts, sources)
         diagnostics.extend(source_diagnostics)
@@ -297,62 +313,45 @@ class ResearcherAgent(BaseAgent):
         if not sources:
             gaps.append("Не найдено релевантных источников")
         if self._contains_prompt_injection(raw):
-            diagnostics.append("Обнаружены признаки prompt-injection в ответе модели")
+            diagnostics.append("prompt_injection_detected")
 
         return ResearchResponse(
             query=query,
             facts=facts,
             sources=sources,
-            gaps=gaps,
-            diagnostics=diagnostics,
+            gaps=list(dict.fromkeys(gaps)),
+            diagnostics=list(dict.fromkeys(diagnostics)),
             confidence_overall=self._compute_confidence_overall(facts, sources),
-        )
-
-    def _build_fallback_response(
-        self,
-        *,
-        query: str,
-        sources: list[ResearchSource],
-        diagnostics: list[str],
-    ) -> ResearchResponse:
-        gaps = ["Не удалось получить структурированный ответ от LLM"]
-        if not sources:
-            gaps.append("Не найдено релевантных источников")
-        return ResearchResponse(
-            query=query,
-            facts=[],
-            sources=sources,
-            gaps=gaps,
-            diagnostics=diagnostics,
-            confidence_overall=self._compute_confidence_overall([], sources),
         )
 
     @classmethod
     def _extract_json_payload(cls, raw: str) -> dict[str, Any] | list[Any] | None:
-        """Найти JSON в ответе LLM: fenced block -> first raw JSON object/array."""
-        fenced = cls._strip_markdown_fence(raw)
-        if fenced:
-            try:
-                parsed = json.loads(fenced)
-                if isinstance(parsed, (dict, list)):
-                    return parsed
-            except json.JSONDecodeError:
-                pass
+        """Найти JSON в ответе LLM: fenced block -> raw json -> first json."""
+        cleaned = raw.strip()
 
-        return cls._extract_first_json(raw)
-
-    @staticmethod
-    def _strip_markdown_fence(text: str) -> str:
-        """Убрать markdown-обёртку ```json ... ``` если LLM её добавил."""
-        cleaned = text.strip()
         fenced_match = re.search(
             r"```(?:json)?\s*(.*?)```",
             cleaned,
             flags=re.IGNORECASE | re.DOTALL,
         )
         if fenced_match:
-            return fenced_match.group(1).strip()
-        return cleaned
+            candidate = fenced_match.group(1).strip()
+            try:
+                parsed = json.loads(candidate)
+                if isinstance(parsed, (dict, list)):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+
+        if cleaned:
+            try:
+                parsed = json.loads(cleaned)
+                if isinstance(parsed, (dict, list)):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+
+        return cls._extract_first_json(raw)
 
     @staticmethod
     def _extract_first_json(text: str) -> dict[str, Any] | list[Any] | None:
@@ -406,13 +405,18 @@ class ResearcherAgent(BaseAgent):
     def _compute_confidence_overall(
         cls, facts: list[ResearchFact], sources: list[ResearchSource]
     ) -> float:
-        source_component = cls._avg_score(sources)
-        if not facts:
-            return round(source_component, 2)
+        avg_fact = sum(f.confidence for f in facts) / len(facts) if facts else 0.0
+        avg_src = cls._avg_score(sources) if sources else 0.0
 
-        fact_conf = sum(f.confidence for f in facts) / len(facts)
-        weighted = 0.6 * fact_conf + 0.4 * source_component
-        return round(min(1.0, max(0.0, weighted)), 2)
+        if facts and sources:
+            score = min(1.0, 0.6 * avg_fact + 0.4 * avg_src)
+        elif sources:
+            score = min(1.0, 0.4 * avg_src)
+        elif facts:
+            score = min(1.0, 0.6 * avg_fact)
+        else:
+            score = 0.0
+        return round(max(0.0, score), 2)
 
     @staticmethod
     def _safe_int(value: Any, default: int = 0) -> int:
@@ -528,9 +532,8 @@ class ResearcherAgent(BaseAgent):
 
             if source.score > existing.score:
                 deduped[key] = source
-            elif (
-                source.score == existing.score
-                and len(source.snippet or "") > len(existing.snippet or "")
+            elif source.score == existing.score and len(source.snippet or "") > len(
+                existing.snippet or ""
             ):
                 deduped[key] = source
         return list(deduped.values())

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -106,7 +106,21 @@ class ResearcherAgent(BaseAgent):
             logger.warning("researcher.llm_failed: %s", exc)
             llm_diagnostics.append(f"llm_failed:{type(exc).__name__}")
 
-        payload = self._parse_llm_json(message, response_text, all_sources)
+        if llm_diagnostics:
+            payload = ResearchResponse(
+                query=message,
+                facts=[],
+                sources=all_sources,
+                gaps=["Не удалось получить структурированный ответ от LLM"],
+                diagnostics=[],
+                confidence_overall=self._compute_confidence_overall([], all_sources),
+            )
+            if not all_sources:
+                payload = payload.model_copy(
+                    update={"gaps": [*payload.gaps, "Не найдено релевантных источников"]}
+                )
+        else:
+            payload = self._parse_llm_json(message, response_text, all_sources)
 
         merged_diagnostics = [*collection_diagnostics, *llm_diagnostics, *payload.diagnostics]
         if merged_diagnostics:

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -303,9 +303,9 @@ class ResearcherAgent(BaseAgent):
                 gaps = [str(g) for g in data.get("gaps", [])]
             except (TypeError, ValueError) as exc:
                 logger.info("researcher.json_payload_invalid: %s", exc)
-                diagnostics.append("llm_invalid_json")
+                diagnostics.extend(["llm_invalid_json", "LLM вернул ответ не в JSON-формате"])
         else:
-            diagnostics.append("llm_invalid_json")
+            diagnostics.extend(["llm_invalid_json", "LLM вернул ответ не в JSON-формате"])
 
         facts, source_diagnostics = self._validate_fact_source_ids(facts, sources)
         diagnostics.extend(source_diagnostics)

--- a/config/settings.py
+++ b/config/settings.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
 
     # ── Researcher ───────────────────────────────
     research_rag_timeout_seconds: float = 12.0
-    research_web_timeout_seconds: float = 8.0
-    research_llm_timeout_seconds: float = 25.0
+    research_web_timeout_seconds: float = 12.0
+    research_llm_timeout_seconds: float = 45.0
     research_web_min_rag_sources: int = 2
     research_web_min_avg_score: float = 0.35
     research_web_min_snippet_chars: int = 500

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -221,6 +221,7 @@ def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
     assert result["research_facts"] == ""
     payload = result["research_payload"]
     assert "llm_timeout" in payload["diagnostics"]
+    assert "llm_invalid_json" not in payload["diagnostics"]
     assert "research_facts" in result
     assert "research_payload" in result
 

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -203,8 +203,7 @@ def test_deduplicate_rag_sources() -> None:
     assert any(item.document == "СП 2" for item in deduped)
 
 
-@pytest.mark.anyio
-async def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
+def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
     async def rag_search(
         query: str, n_results: int = 5, filter_scope: str | None = None
     ) -> list[dict[str, Any]]:
@@ -217,7 +216,7 @@ async def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
         cache=_FakeCache(),
     )
 
-    result = await agent.run({"message": "q", "history": []})
+    result = asyncio.run(agent.run({"message": "q", "history": []}))
 
     assert result["research_facts"] == ""
     payload = result["research_payload"]
@@ -226,8 +225,7 @@ async def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
     assert "research_payload" in result
 
 
-@pytest.mark.anyio
-async def test_rag_timeout_falls_back_to_web_and_keeps_running(
+def test_rag_timeout_falls_back_to_web_and_keeps_running(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def slow_search(
@@ -250,19 +248,20 @@ async def test_rag_timeout_falls_back_to_web_and_keeps_running(
     )
     monkeypatch.setattr(settings, "research_rag_timeout_seconds", 0.001)
 
-    sources, diagnostics = await agent._collect_sources(
-        "q",
-        topic_scope=None,
-        access_scope=None,
-        context="",
+    sources, diagnostics = asyncio.run(
+        agent._collect_sources(
+            "q",
+            topic_scope=None,
+            access_scope=None,
+            context="",
+        )
     )
 
     assert any(source.type == "web" for source in sources)
     assert "rag_timeout" in diagnostics or "rag_failed:TimeoutError" in diagnostics
 
 
-@pytest.mark.anyio
-async def test_cache_failure_does_not_break_agent() -> None:
+def test_cache_failure_does_not_break_agent() -> None:
     async def rag_search(
         query: str, n_results: int = 5, filter_scope: str | None = None
     ) -> list[dict[str, Any]]:
@@ -275,7 +274,7 @@ async def test_cache_failure_does_not_break_agent() -> None:
         cache=_FakeCache(get_side_effect=ConnectionError("redis down")),
     )
 
-    result = await agent.run({"message": "q", "history": []})
+    result = asyncio.run(agent.run({"message": "q", "history": []}))
     diagnostics = result["research_payload"]["diagnostics"]
 
     assert "cache_unavailable" in diagnostics
@@ -297,14 +296,13 @@ def test_compute_confidence_overall_edge_cases() -> None:
     assert empty == pytest.approx(0.0)
 
 
-@pytest.mark.anyio
-async def test_collection_diagnostics_are_merged_and_deduplicated() -> None:
+def test_collection_diagnostics_are_merged_and_deduplicated() -> None:
     agent = _mk_agent(llm_reply='{"facts":[],"gaps":["g1","g1"]}')
     agent._collect_sources = AsyncMock(
         return_value=([], ["cache_unavailable", "cache_unavailable"])
     )  # type: ignore[method-assign]
 
-    result = await agent.run({"message": "q", "history": []})
+    result = asyncio.run(agent.run({"message": "q", "history": []}))
     payload = result["research_payload"]
 
     assert payload["diagnostics"][0] == "cache_unavailable"

--- a/tests/test_researcher_agent.py
+++ b/tests/test_researcher_agent.py
@@ -1,7 +1,8 @@
-"""Unit-тесты чистых функций ResearcherAgent."""
+"""Unit-тесты ResearcherAgent."""
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -9,15 +10,64 @@ from unittest.mock import AsyncMock
 import pytest
 
 from agents.researcher import ResearcherAgent
+from config.settings import settings
 from schemas.research import ResearchFact, ResearchSource
 
 
-def _mock_llm_router(reply: str = "{}") -> SimpleNamespace:
-    return SimpleNamespace(query=AsyncMock(return_value=SimpleNamespace(text=reply)))
+class _FakeCache:
+    def __init__(self, get_side_effect: Exception | None = None) -> None:
+        self.get_side_effect = get_side_effect
+        self.set_calls = 0
+
+    async def get(self, key: str) -> str | None:
+        if self.get_side_effect:
+            raise self.get_side_effect
+        return None
+
+    async def set(self, key: str, value: str, ttl: int = 3600) -> None:
+        self.set_calls += 1
 
 
-def _mk_agent() -> ResearcherAgent:
-    return ResearcherAgent(cast(Any, _mock_llm_router()))
+class _FakeRAGEngine:
+    def __init__(self, search_impl: Any) -> None:
+        self.search = search_impl
+
+
+def _mock_llm_router(reply: str = "{}", side_effect: Exception | None = None) -> SimpleNamespace:
+    query = AsyncMock()
+    if side_effect is not None:
+        query.side_effect = side_effect
+    else:
+        query.return_value = SimpleNamespace(text=reply)
+    return SimpleNamespace(query=query)
+
+
+def _mk_agent(
+    *,
+    llm_reply: str = "{}",
+    llm_side_effect: Exception | None = None,
+    rag_engine: Any | None = None,
+    web_search_tool: Any | None = None,
+    cache: Any | None = None,
+) -> ResearcherAgent:
+    return ResearcherAgent(
+        cast(Any, _mock_llm_router(llm_reply, llm_side_effect)),
+        rag_engine=cast(Any, rag_engine),
+        web_search_tool=cast(Any, web_search_tool),
+        cache=cast(Any, cache),
+    )
+
+
+def _source_rag_0(score: float = 0.7, snippet: str = "snippet") -> ResearchSource:
+    return ResearchSource(
+        id="rag-0",
+        type="rag",
+        title="СП",
+        document="СП",
+        page=1,
+        score=score,
+        snippet=snippet,
+    )
 
 
 @pytest.mark.parametrize(
@@ -38,16 +88,23 @@ def _mk_agent() -> ResearcherAgent:
             False,
         ),
         (
-            "before text\n"
+            "preamble {not json}\n"
             '{"facts":[{"text":"f","applicability":"high",'
             '"confidence":0.8,"source_ids":["rag-0"]}],"gaps":[]}\n'
-            "after text",
+            "epilogue",
             1,
             False,
         ),
         (
             '{"facts":[{"text":"f","applicability":"high",'
-            '"confidence":0.8,"source_ids":["rag-0"]}],"gaps":[]} trailing',
+            '"confidence":0.8,"source_ids":["rag-0"]}],"gaps":["g1"]} trailing text',
+            1,
+            False,
+        ),
+        (
+            '{"facts":[{"text":"f","applicability":"high","confidence":0.8,'
+            '"source_ids":["rag-0"]}],"gaps":["outer"],'
+            '"nested":{"inner":[{"x":1}]}}',
             1,
             False,
         ),
@@ -56,25 +113,13 @@ def _mk_agent() -> ResearcherAgent:
 )
 def test_parse_llm_json_variants(raw: str, expected_facts_len: int, expect_diag: bool) -> None:
     agent = _mk_agent()
-    sources = [
-        ResearchSource(
-            id="rag-0",
-            type="rag",
-            title="СП",
-            document="СП",
-            page=1,
-            score=0.7,
-            snippet="snippet",
-        )
-    ]
-
-    payload = agent._parse_llm_json("query", raw, sources)
+    payload = agent._parse_llm_json("query", raw, [_source_rag_0()])
 
     assert len(payload.facts) == expected_facts_len
     if expect_diag:
-        assert "LLM вернул ответ не в JSON-формате" in payload.diagnostics
+        assert "llm_invalid_json" in payload.diagnostics
     else:
-        assert "LLM вернул ответ не в JSON-формате" not in payload.diagnostics
+        assert "llm_invalid_json" not in payload.diagnostics
 
 
 def test_validate_fact_source_ids() -> None:
@@ -82,7 +127,7 @@ def test_validate_fact_source_ids() -> None:
         ResearchFact(text="ok", applicability="", confidence=0.7, source_ids=["rag-0", "missing"]),
         ResearchFact(text="drop", applicability="", confidence=0.6, source_ids=["missing"]),
     ]
-    sources = [ResearchSource(id="rag-0", type="rag", title="S", score=0.8)]
+    sources = [_source_rag_0()]
 
     valid_facts, diagnostics = ResearcherAgent._validate_fact_source_ids(facts, sources)
 
@@ -92,56 +137,62 @@ def test_validate_fact_source_ids() -> None:
     assert any("отброшен" in d for d in diagnostics)
 
 
-def test_need_web_fallback_thresholds() -> None:
+def test_need_web_fallback_thresholds_and_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
     agent = _mk_agent()
-    low = [ResearchSource(id="rag-0", type="rag", title="S", score=0.2, snippet="x" * 800)]
-    assert agent._need_web_fallback(low)
+    monkeypatch.setattr(settings, "research_web_min_rag_sources", 2)
+    monkeypatch.setattr(settings, "research_web_min_avg_score", 0.5)
+    monkeypatch.setattr(settings, "research_web_min_snippet_chars", 10)
 
-    enough = [
-        ResearchSource(id="rag-0", type="rag", title="A", score=0.8, snippet="x" * 300),
-        ResearchSource(id="rag-1", type="rag", title="B", score=0.7, snippet="x" * 300),
+    assert agent._need_web_fallback([_source_rag_0(score=0.9, snippet="x" * 20)])
+
+    low_avg = [
+        _source_rag_0(score=0.4, snippet="x" * 6),
+        ResearchSource(
+            id="rag-1", type="rag", title="СП2", document="СП2", page=2, score=0.4, snippet="x" * 6
+        ),
     ]
-    assert not agent._need_web_fallback(enough)
+    assert agent._need_web_fallback(low_avg)
+
+    low_snippet = [
+        _source_rag_0(score=0.8, snippet="x" * 4),
+        ResearchSource(
+            id="rag-1", type="rag", title="СП2", document="СП2", page=2, score=0.8, snippet="x" * 4
+        ),
+    ]
+    assert agent._need_web_fallback(low_snippet)
+
+    boundary_ok = [
+        _source_rag_0(score=0.5, snippet="x" * 5),
+        ResearchSource(
+            id="rag-1", type="rag", title="СП2", document="СП2", page=2, score=0.5, snippet="x" * 5
+        ),
+    ]
+    assert not agent._need_web_fallback(boundary_ok)
 
 
-def test_normalize_rag_score_similarity_and_distance() -> None:
-    similarity_chunk = {"score": 0.75, "score_type": "similarity"}
-    distance_chunk_unit = {"score": 0.2, "score_type": "distance"}
-    distance_chunk_large = {"score": 4.0, "score_type": "distance"}
+def test_normalize_rag_score_similarity_and_distance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "rag_score_mode", "similarity")
 
-    assert ResearcherAgent._normalize_rag_score(similarity_chunk) == pytest.approx(0.75)
-    assert ResearcherAgent._normalize_rag_score(distance_chunk_unit) == pytest.approx(0.8)
-    assert ResearcherAgent._normalize_rag_score(distance_chunk_large) == pytest.approx(0.2)
+    assert ResearcherAgent._normalize_rag_score({"score": 75}) == pytest.approx(0.75)
+    assert ResearcherAgent._normalize_rag_score({"score": -10}) == pytest.approx(0.0)
+    assert ResearcherAgent._normalize_rag_score(
+        {"score": 0.2, "score_type": "distance"}
+    ) == pytest.approx(0.8)
+    assert ResearcherAgent._normalize_rag_score(
+        {"score": 4.0, "score_type": "distance"}
+    ) == pytest.approx(0.2)
 
 
 def test_deduplicate_rag_sources() -> None:
     sources = [
         ResearchSource(
-            id="rag-0",
-            type="rag",
-            title="СП 1",
-            document="СП 1",
-            page=5,
-            score=0.6,
-            snippet="a",
+            id="rag-0", type="rag", title="СП 1", document="СП 1", page=5, score=0.6, snippet="a"
         ),
         ResearchSource(
-            id="rag-1",
-            type="rag",
-            title="СП 1",
-            document="СП 1",
-            page=5,
-            score=0.9,
-            snippet="bb",
+            id="rag-1", type="rag", title="СП 1", document="СП 1", page=5, score=0.9, snippet="bb"
         ),
         ResearchSource(
-            id="rag-2",
-            type="rag",
-            title="СП 2",
-            document="СП 2",
-            page=1,
-            score=0.5,
-            snippet="c",
+            id="rag-2", type="rag", title="СП 2", document="СП 2", page=1, score=0.5, snippet="c"
         ),
     ]
 
@@ -150,3 +201,112 @@ def test_deduplicate_rag_sources() -> None:
     assert len(deduped) == 2
     assert any(item.document == "СП 1" and item.score == pytest.approx(0.9) for item in deduped)
     assert any(item.document == "СП 2" for item in deduped)
+
+
+@pytest.mark.anyio
+async def test_llm_timeout_sets_diagnostics_and_state_keys() -> None:
+    async def rag_search(
+        query: str, n_results: int = 5, filter_scope: str | None = None
+    ) -> list[dict[str, Any]]:
+        return [{"source": "СП", "page": 1, "text": "t", "score": 0.8}]
+
+    agent = _mk_agent(
+        llm_side_effect=TimeoutError(),
+        rag_engine=_FakeRAGEngine(rag_search),
+        web_search_tool=SimpleNamespace(run=AsyncMock(return_value=[])),
+        cache=_FakeCache(),
+    )
+
+    result = await agent.run({"message": "q", "history": []})
+
+    assert result["research_facts"] == ""
+    payload = result["research_payload"]
+    assert "llm_timeout" in payload["diagnostics"]
+    assert "research_facts" in result
+    assert "research_payload" in result
+
+
+@pytest.mark.anyio
+async def test_rag_timeout_falls_back_to_web_and_keeps_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_search(
+        query: str, n_results: int = 5, filter_scope: str | None = None
+    ) -> list[dict[str, Any]]:
+        await asyncio.sleep(0.02)
+        return [{"source": "СП", "page": 1, "text": "t", "score": 0.8}]
+
+    web_tool = SimpleNamespace(
+        run=AsyncMock(
+            return_value=[{"title": "w", "url": "https://x", "snippet": "abc", "score": 0.5}]
+        )
+    )
+
+    agent = _mk_agent(
+        llm_reply='{"facts":[],"gaps":[]}',
+        rag_engine=_FakeRAGEngine(slow_search),
+        web_search_tool=web_tool,
+        cache=_FakeCache(),
+    )
+    monkeypatch.setattr(settings, "research_rag_timeout_seconds", 0.001)
+
+    sources, diagnostics = await agent._collect_sources(
+        "q",
+        topic_scope=None,
+        access_scope=None,
+        context="",
+    )
+
+    assert any(source.type == "web" for source in sources)
+    assert "rag_timeout" in diagnostics or "rag_failed:TimeoutError" in diagnostics
+
+
+@pytest.mark.anyio
+async def test_cache_failure_does_not_break_agent() -> None:
+    async def rag_search(
+        query: str, n_results: int = 5, filter_scope: str | None = None
+    ) -> list[dict[str, Any]]:
+        return [{"source": "СП", "page": 1, "text": "t", "score": 0.8}]
+
+    agent = _mk_agent(
+        llm_reply='{"facts":[],"gaps":[]}',
+        rag_engine=_FakeRAGEngine(rag_search),
+        web_search_tool=SimpleNamespace(run=AsyncMock(return_value=[])),
+        cache=_FakeCache(get_side_effect=ConnectionError("redis down")),
+    )
+
+    result = await agent.run({"message": "q", "history": []})
+    diagnostics = result["research_payload"]["diagnostics"]
+
+    assert "cache_unavailable" in diagnostics
+    assert "research_payload" in result
+
+
+def test_compute_confidence_overall_edge_cases() -> None:
+    fact = ResearchFact(text="f", applicability="", confidence=0.9, source_ids=["rag-0"])
+    source = _source_rag_0(score=0.8)
+
+    both = ResearcherAgent._compute_confidence_overall([fact], [source])
+    only_sources = ResearcherAgent._compute_confidence_overall([], [source])
+    only_facts = ResearcherAgent._compute_confidence_overall([fact], [])
+    empty = ResearcherAgent._compute_confidence_overall([], [])
+
+    assert both == pytest.approx(0.86)
+    assert only_sources == pytest.approx(0.32)
+    assert only_facts == pytest.approx(0.54)
+    assert empty == pytest.approx(0.0)
+
+
+@pytest.mark.anyio
+async def test_collection_diagnostics_are_merged_and_deduplicated() -> None:
+    agent = _mk_agent(llm_reply='{"facts":[],"gaps":["g1","g1"]}')
+    agent._collect_sources = AsyncMock(
+        return_value=([], ["cache_unavailable", "cache_unavailable"])
+    )  # type: ignore[method-assign]
+
+    result = await agent.run({"message": "q", "history": []})
+    payload = result["research_payload"]
+
+    assert payload["diagnostics"][0] == "cache_unavailable"
+    assert payload["diagnostics"].count("cache_unavailable") == 1
+    assert payload["gaps"].count("g1") == 1


### PR DESCRIPTION
### Motivation
- Завершить рефакторинг ResearcherAgent, сделав парсинг LLM-ответов и работу с источниками надёжной в продакшене без изменения публичного API (`_run`, `run_standalone`) и всегда заполнять ключи `research_facts`/`research_payload`. 
- Обеспечить устойчивость к таймаутам/ошибкам LLM/RAG/Web и сделать поведение предсказуемым для downstream (детерминированные diagnostics и fallback-пayload). 

### Description
- ResearcherAgent: переведён `system_prompt` на настоящий многострочник, добавлен `cache` DI (`cache: RedisCache | None = None`) с lazy init и fail-safe `get/set` (диагностика `cache_unavailable`) и сохранением прежней семантики при отсутствии кэша.  
- Реализована устойчивая стратегия извлечения JSON из LLM: fenced block -> direct `json.loads(cleaned)` -> сканирование `raw_decode` с проверки каждой позиции `{`/`[`, и детерминированные diagnostics (`llm_timeout`, `llm_failed:<Exc>`, `llm_invalid_json`, `prompt_injection_detected`).  
- Улучшены мердж и дедупликация diagnostics и gaps (сохранение порядка), добавлена явная марка `web_fallback_triggered`, а также более предсказуемые сообщения об ошибках RAG/Web (`rag_timeout`, `web_timeout`, `rag_failed:<Exc>`, `web_failed:<Exc>`).  
- Поведение score/timeout: дефолты таймаутов обновлены в `settings` (RAG=12s, Web=12s, LLM=45s), поддержка `rag_score_mode`/`score_type` для нормализации RAG-оценок сохранена, и `confidence_overall` переработан в устойчивую формулу (facts+sources / only facts / only sources / none) с downweight. 

### Testing
- Импорт модуля прошёл: `python -c "import agents.researcher"` успешно завершился.  
- Unit tests: `pytest tests/test_researcher_agent.py -v` прошёл успешно (15 passed) covering JSON parsing variants, `validate_fact_source_ids`, web-fallback thresholds, rag score normalization, deduplication, LLM/RAG timeouts, cache failure resilience, confidence edge-cases, and state keys.  
- Static checks: `ruff check agents/researcher.py tests/test_researcher_agent.py` и `ruff format` применялись и не выявили оставшихся ошибок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea502539dc832fbe95d5967c8fb6f0)