### PR TITLE
researcher: remove dead domain helpers and simplify fact validation flow

### DIFF
--- a/agents/researcher/domain.py
+++ b/agents/researcher/domain.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
-
 from schemas.research import Diagnostic, ResearchSource
 
 _NORM_HINTS = ("сп", "гост", "снип", "санпин", "фз", "приказ")
 _LAW_HINTS = ("федеральный закон", "кодекс", "постановление")
 _PROJECT_HINTS = ("проект", "рабочая документация", "рд", "пд")
-
-
-@dataclass(frozen=True)
-class VersionConflict:
-    source_a: str
-    source_b: str
 
 
 def classify_source_type(source: ResearchSource) -> str:
@@ -45,16 +36,6 @@ def is_active_source(source: ResearchSource) -> bool:
     if source.is_active is None:
         return True
     return bool(source.is_active)
-
-
-def compare_versions(source_a: ResearchSource, source_b: ResearchSource) -> int:
-    va = _version_tuple(source_a.document_version)
-    vb = _version_tuple(source_b.document_version)
-    if va > vb:
-        return 1
-    if va < vb:
-        return -1
-    return 0
 
 
 def detect_version_conflict(sources: list[ResearchSource]) -> list[Diagnostic]:
@@ -128,10 +109,3 @@ def diagnostics_for_sources(sources: list[ResearchSource]) -> list[Diagnostic]:
                 )
             )
     return diagnostics
-
-
-def _version_tuple(value: str | None) -> tuple[int, ...]:
-    if not value:
-        return ()
-    nums = [int(x) for x in re.findall(r"\d+", value)]
-    return tuple(nums)

--- a/agents/researcher/fact_validator.py
+++ b/agents/researcher/fact_validator.py
@@ -17,7 +17,7 @@ class FactValidator:
         facts: list[ResearchFact],
         sources: list[ResearchSource],
     ) -> tuple[list[ResearchFact], list[Diagnostic]]:
-        return self._validate_impl(facts, sources, self._min_similarity)
+        return self._validate_impl(facts, sources)
 
     @staticmethod
     def validate(
@@ -25,15 +25,14 @@ class FactValidator:
         sources: list[ResearchSource],
         config: ResearcherConfig,
     ) -> tuple[list[ResearchFact], list[Diagnostic]]:
-        return FactValidator._validate_impl(facts, sources, config.fact_citation_min_similarity)
+        _ = config.fact_citation_min_similarity
+        return FactValidator._validate_impl(facts, sources)
 
     @staticmethod
     def _validate_impl(
         facts: list[ResearchFact],
         sources: list[ResearchSource],
-        threshold: float,
     ) -> tuple[list[ResearchFact], list[Diagnostic]]:
-        _ = threshold
         by_id = {source.id: source for source in sources}
         validated: list[ResearchFact] = []
         diagnostics: list[Diagnostic] = []


### PR DESCRIPTION
### Motivation
- Reduce dead/legacy code in the researcher domain and simplify the validator internals to keep the agent lean and easier to reason about.
- Preserve the strict, fail-closed behavior and existing validation/diagnostics while removing unused helpers.

### Description
- Deleted unused domain helpers in `agents/researcher/domain.py`: removed `VersionConflict` dataclass, `compare_versions` and `_version_tuple` and related unused imports, leaving source classification, prioritization and diagnostics intact.
- Simplified `agents/researcher/fact_validator.py` by removing an unused internal `threshold` parameter from `_validate_impl` and aligning both public entry points (`validate_facts` and `validate`) to call the same strict exact-quote validation path.
- Changed only internal plumbing; no behavioral relaxations to quote/entailment checks, access controls, prompt building, LLM schema handling, or redaction logic.

### Testing
- Ran researcher tests with `python -m pytest tests/agents/test_researcher -q` which passed: `100 passed`.
- Ran full test suite with `python -m pytest -q` which passed: `248 passed`.
- Verified no new skips/xfails were added and existing diagnostics/tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb40003c38832fa251100055c06d81)